### PR TITLE
docs: CHANGELOG.md / task.md を PR #36 マージ内容で更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@
 
 ## [Unreleased]
 
-### Fixed
-- **`GraphStorageProvider.LargeUploadAsync`: セッション URL 復元時の `NullReferenceException` 修正**
+### Added
+- **フォルダ先行作成の並列化・GET優先・スキップキャッシュ（PR #36）**
+  - `TransferEngine.RunAsync`: フォルダパスを深さ別グループで並列作成（FR-06 強化）
+    - `folderPathSet.GroupBy(深さ).OrderBy(深さ)` でグループ化し `Parallel.ForEachAsync` で並列処理
+    - `destRootNormalized` を `folderPathSet` に追加して深さ順ループで先行処理を保証
+  - `GraphStorageProvider.EnsureFolderSegmentAsync`: GET-first + 409 競合フォールバック実装
+    - `catch(ApiException) { if (status != 409) throw; ... }` パターンで Ubuntu/macOS CI 安定化
+  - テスト: `FakeStorageProvider` による呼び出し順序のプラットフォーム非依存な検証（3件追加）
+
+---
   - `UploadUrl` のみで `UploadSession` を構築すると `NextExpectedRanges` が `null` になり、
     `LargeFileUploadTask<DriveItem>` コンストラクター内の `GetRangesRemaining()` が NPE を投げる問題を修正（cv2.pyd 等の大容量ファイルで実測発生）
   - 復元時に `NextExpectedRanges = new List<string> { "0-" }` を初期値として設定し、セッション再開時の NPE を解消

--- a/task.md
+++ b/task.md
@@ -135,3 +135,16 @@
 - [x] `CliServices`: レート状態の永続化（`logs/rate_state.json`）を実装
   - 起動時: `rate_state.json` が存在すれば前回終了レートを `initialRate` として復元（コールドスタート排除）
   - 終了時: `Dispose()` 内で現在レートを JSON 保存（UTC 日時付き）
+
+## パフォーマンス改善: フォルダ先行作成並列化・GET優先・スキップキャッシュ（PR #36）
+
+- [x] `TransferEngine.RunAsync`: フォルダパスを深さ別グループで並列作成
+  - `folderPathSet.GroupBy(深さ).OrderBy(深さ)` でグループ化、`Parallel.ForEachAsync` で並列処理
+  - `destRootNormalized` を `folderPathSet` に追加し深さ順ループで先行処理を保証（CI 安定化を含む）
+- [x] `GraphStorageProvider.EnsureFolderAsync`: `_folderIdCache` によるキャッシュ済みセグメントのスキップ（再確認）
+- [x] `GraphStorageProvider.EnsureFolderSegmentAsync`: GET-first パターン + 409 競合フォールバック実装
+  - `catch (ApiException ex) { if (ex.ResponseStatusCode != 409) throw; ... }` パターンに変更（Ubuntu CI 安定化）
+- [x] `GraphStorageProvider.ListItemsAsync`: ストリーミング取得（`PageIterator` 相当）+ スキップリスト早期除外
+- [x] `TransferEngine`: `AdaptiveConcurrencyController` の `GetFirst` 最適化（`GetAsync` 優先呼び出し）
+- [x] テスト: `FakeStorageProvider` を使ったプラットフォーム非依存順序テスト（TransferEngine 3件）
+- [x] CI 全ジョブ（ubuntu / macOS / windows）PASS、PR #36 マージ済み


### PR DESCRIPTION
PR #36 マージ後のドキュメント更新。

## 変更内容
- `CHANGELOG.md`: PR #36（フォルダ先行作成並列化・GET優先・スキップキャッシュ）の変更内容を `[Unreleased]` セクションに追記
- `task.md`: PR #36 完了タスクを記録（FakeStorageProvider テスト追加・CI 安定化を含む）