### PR TITLE
perf: フォルダ作成並列度を MaxParallelFolderCreations に分離

### DIFF
--- a/src/CloudMigrator.Core/Configuration/MigratorOptions.cs
+++ b/src/CloudMigrator.Core/Configuration/MigratorOptions.cs
@@ -17,6 +17,9 @@ public sealed class MigratorOptions
     /// <summary>最大並列転送数。デフォルト 4（FR-14）</summary>
     public int MaxParallelTransfers { get; set; } = 4;
 
+    /// <summary>フォルダ先行作成フェーズの最大並列度。デフォルト 4（Graph API クォータ対策）</summary>
+    public int MaxParallelFolderCreations { get; set; } = 4;
+
     /// <summary>リトライ回数。デフォルト 3（FR-15）</summary>
     public int RetryCount { get; set; } = 3;
 

--- a/src/CloudMigrator.Core/Transfer/TransferEngine.cs
+++ b/src/CloudMigrator.Core/Transfer/TransferEngine.cs
@@ -112,7 +112,7 @@ public sealed class TransferEngine
                 depthGroup,
                 new ParallelOptions
                 {
-                    MaxDegreeOfParallelism = _options.MaxParallelTransfers,
+                    MaxDegreeOfParallelism = _options.MaxParallelFolderCreations,
                     CancellationToken = cancellationToken,
                 },
                 async (destFolderPath, ct) =>


### PR DESCRIPTION
## 概要

フォルダ先行作成フェーズが \MaxParallelTransfers\（config: 32）を継承していたため、3000+ フォルダのロードテストで Graph API クォータを即枯渇させてクラッシュする問題を修正。

## 変更内容

### \MigratorOptions.cs\
- \MaxParallelFolderCreations\ プロパティを追加（デフォルト: 4）

### \TransferEngine.cs\
- フォルダ先行作成ループの \MaxDegreeOfParallelism\ を \MaxParallelFolderCreations\ に変更
- ファイル転送ループは引き続き \MaxParallelTransfers\ を使用（変更なし）

## ロードテスト結果（3,445 フォルダ / 24,481 ファイル）

| | 修正前 | 修正後 |
|---|---|---|
| 結果 | クラッシュ (TooManyRequests) | 完了 |
| 所要時間 | 428 秒で強制終了 | 57 分 07 秒 |
| 転送成功 | 0 | **24,471 ファイル** |
| 転送失敗 | — | 10 件（throttle、再実行で回収可） |
| 平均レート | — | 8.0 file/sec（最大 16.0） |

10 件の失敗はすべて HTTP 429 Throttle によるもの。スキップリスト活用で再実行時に転送済みファイルをスキップして残りのみ転送可能。

## テスト
- ユニットテスト 188 件全件パス