### PR TITLE
docs: CHANGELOG / task.md を PR #38 マージ後に更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,6 @@
 - **`MigratorOptions`: `MaxParallelFolderCreations` プロパティ追加（デフォルト 4）（PR #38）**
   - フォルダ先行作成フェーズとファイル転送フェーズの並列度を独立して制御可能に
   - `configs/config.json` の `maxParallelFolderCreations` に任意の値を設定可能
-
-### Fixed
-- **フォルダ先行作成フェーズの Graph API クォータ枯渇クラッシュ（PR #38）**
-  - フォルダ作成ループが `MaxParallelTransfers`（デフォルト 4、config: 32）を流用していたため
-    大量フォルダ構成で HTTP 429 TooManyRequests を即時枯渇させてクラッシュする問題を修正
-  - `TransferEngine` のフォルダ作成ループを `MaxParallelFolderCreations` に切り替え
-
-### Added
 - **フォルダ先行作成の並列化・GET優先・スキップキャッシュ（PR #36）**
   - `TransferEngine.RunAsync`: フォルダパスを深さ別グループで並列作成（FR-06 強化）
     - `folderPathSet.GroupBy(深さ).OrderBy(深さ)` でグループ化し `Parallel.ForEachAsync` で並列処理
@@ -26,6 +18,12 @@
   - `GraphStorageProvider.EnsureFolderSegmentAsync`: GET-first + 409 競合フォールバック実装
     - `catch(ApiException) { if (status != 409) throw; ... }` パターンで Ubuntu/macOS CI 安定化
   - テスト: `FakeStorageProvider` による呼び出し順序のプラットフォーム非依存な検証（3件追加）
+
+### Fixed
+- **フォルダ先行作成フェーズの Graph API クォータ枯渇クラッシュ（PR #38）**
+  - フォルダ作成ループが `MaxParallelTransfers`（デフォルト 4、config: 32）を流用していたため
+    大量フォルダ構成で HTTP 429 TooManyRequests を即時枯渇させてクラッシュする問題を修正
+  - `TransferEngine` のフォルダ作成ループを `MaxParallelFolderCreations` に切り替え
 
 ---
   - `UploadUrl` のみで `UploadSession` を構築すると `NextExpectedRanges` が `null` になり、

--- a/task.md
+++ b/task.md
@@ -157,4 +157,4 @@
 - [x] `TransferEngine.RunAsync`: フォルダ作成ループを `MaxParallelFolderCreations` に切り替え
   - 修正前: `MaxParallelTransfers`（config: 32）を流用 → 3000+ フォルダで即クォータ枯渇・クラッシュ
   - 修正後: `MaxParallelFolderCreations`（config: 8）で制御 → 24,471 ファイル完走（57:07）
-- [x] ユニットテスト 188 件全通過確認、PR #38 作成済み
+- [x] ユニットテスト 188 件全通過確認、PR #38 マージ済み


### PR DESCRIPTION
PR #38 マージに伴うドキュメント更新のみ。コード変更なし。