### PR TITLE
docs: task.md / CHANGELOG.md を PR #40 マージ後に更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@
 ## [Unreleased]
 
 ### Added
+- **OneDrive → Dropbox 転送先対応（PR #40）**
+  - `IStorageProvider` に `DownloadToTempAsync` / `UploadFromLocalAsync` を追加しクロスプロバイダー転送を実現
+  - `GraphStorageProvider`: `DownloadToTempAsync`（Graph API 経由でローカル一時ファイルへ）/ `UploadFromLocalAsync` 実装
+  - `DropboxStorageProvider`: `UploadFromLocalAsync`（ローカルファイルから Dropbox へアップロード）実装
+  - `TransferEngine`: `_sourceProvider` フィールドを追加。`UploadItemAsync` でソース DL → デスト UL → 一時ファイル削除フローを実装
+  - `MigratorOptions`: `DestinationProvider` フィールド追加（デフォルト: `"sharepoint"`）
+  - `CliServices` / `TransferCommand`: Dropbox 転送先ルーティング + `RebuildSkipListFromDropboxAsync` 追加
+  - `DoctorCommand`: `DestinationProvider=dropbox` 時に SP フィールドを `[WRN]` に格下げ（`SpCheck` ローカル関数）
+  - `BootstrapCommand`: `--destination dropbox` オプション追加。Dropbox AccessToken / RootPath プロンプト、SP 解決スキップ、`.env` への Dropbox token 書き込み対応
+  - `InitCommand`: `ApplyDropboxValuesToConfigTemplate` メソッド追加
+  - `docs/manual-test-runbook.md`: セクション 10「OneDrive→Dropbox 転送テストシナリオ」を追記（TC-Dropbox-01〜07 + 実施記録テンプレート）
+  - テスト: 193 件全パス（+5 件追加: DoctorCommand 2件 / InitCommand 3件）
+
 - **`MigratorOptions`: `MaxParallelFolderCreations` プロパティ追加（デフォルト 4）（PR #38）**
   - フォルダ先行作成フェーズとファイル転送フェーズの並列度を独立して制御可能に
   - `configs/config.json` の `maxParallelFolderCreations` に任意の値を設定可能

--- a/task.md
+++ b/task.md
@@ -158,3 +158,19 @@
   - 修正前: `MaxParallelTransfers`（config: 32）を流用 → 3000+ フォルダで即クォータ枯渇・クラッシュ
   - 修正後: `MaxParallelFolderCreations`（config: 8）で制御 → 24,471 ファイル完走（57:07）
 - [x] ユニットテスト 188 件全通過確認、PR #38 マージ済み
+
+## Phase 10: OneDrive → Dropbox 転送先対応（PR #40）
+
+- [x] `IStorageProvider` に `DownloadToTempAsync` / `UploadFromLocalAsync` 追加
+- [x] `GraphStorageProvider`: `DownloadToTempAsync`（Graph API → 一時ファイル）/ `UploadFromLocalAsync` 実装
+- [x] `DropboxStorageProvider`: `UploadFromLocalAsync`（Dropbox SDK 経由）実装
+- [x] `TransferEngine`: `_sourceProvider` 追加、クロスプロバイダー転送フロー（DL→一時→UL→削除）
+- [x] `MigratorOptions`: `DestinationProvider` フィールド追加（デフォルト: `"sharepoint"`）
+- [x] `CliServices` / `TransferCommand`: Dropbox 転送先ルーティング + `RebuildSkipListFromDropboxAsync`
+- [x] `DoctorCommand`: `isDropboxDest` 時に SP フィールドを `[WRN]` に格下げ（`SpCheck` ローカル関数）
+- [x] `BootstrapCommand`: `--destination dropbox` オプション、Dropbox プロンプトフロー、SP スキップ
+- [x] `InitCommand`: `ApplyDropboxValuesToConfigTemplate` メソッド追加
+- [x] `configs/config.json`: `"destinationProvider": "sharepoint"` 追加
+- [x] テスト: `SetupDoctorCommandTests` 2件・`SetupInitCommandTests` 3件追加（193件全パス）
+- [x] `docs/manual-test-runbook.md`: セクション10「OneDrive→Dropbox テストシナリオ」追記（TC-Dropbox-01〜07）
+- [x] PR #40 マージ済み


### PR DESCRIPTION
PR #40（OneDrive→Dropbox 転送先対応）のマージ後ドキュメント更新。

- `task.md`: Phase 10 完了チェックボックスを追加
- `CHANGELOG.md`: `[Unreleased]` セクションに Phase 10 の変更内容を追記