### PR TITLE
docs: usage.md に dashboard コマンドの使い方を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@
   - `CloudMigrator.slnx` に `CloudMigrator.Dashboard` 追加
   - 全テスト 240 件 PASS（既存テストへの影響なし）
 
+### Docs
+- `usage.md` に `dashboard` コマンドのセクションを追加（コマンド例・表示項目・REST API エンドポイント一覧）
+  - 更新間隔を実装値（5秒）に修正、エラー件数上限を実装値（最大5件）に修正
+  - `--db` 省略時は設定値を参照する旨を明記
+
 - **`status` コマンド（Dropbox 転送ダッシュボード）**
   - `TransferDbSummary` レコード追加（`src/CloudMigrator.Core/State/TransferSummary.cs`）: ステータス別件数・完了率・完了バイト数・最近の失敗5件
   - `ITransferStateDb.GetSummaryAsync` 追加（サマリー情報を取得、DB 空時はゼロサマリー返却）

--- a/usage.md
+++ b/usage.md
@@ -88,7 +88,7 @@ dotnet run --project src/CloudMigrator.Cli -- file-crawler explore --source shar
 転送状況をブラウザでリアルタイム監視します。転送実行中または実行後に使用します。
 
 ```bash
-# デフォルト（DB: logs/dropbox_transfer_state.db、ポート: 5050）
+# --db / --port 省略時は設定値を使用（DB: 設定値のパス［既定: logs/dropbox_transfer_state.db］、ポート: 設定値のポート［既定: 5050］）
 dotnet run --project src/CloudMigrator.Cli -- dashboard
 
 # DB パスとポートを指定
@@ -106,7 +106,7 @@ dotnet run --project src/CloudMigrator.Cli -- dashboard --no-browser
 | **レート制限ヒット率（%）** | 100 件ごとに計測された Graph API レート制限ヒット率の推移 |
 | **スループット（ファイル/分）** | 100 件ごとに計測された転送速度（ファイル数/分）の推移 |
 | **スループット（バイト/秒）** | 100 件ごとに計測された転送速度（バイト/秒）の推移 |
-| **直近エラーログ** | 転送失敗の直近 50 件 |
+| **直近エラーログ** | 転送失敗の最大 5 件 |
 
 **API エンドポイント（直接取得したい場合）**
 
@@ -115,10 +115,10 @@ GET /api/status                                          # 転送サマリ JSON
 GET /api/metrics?name=rate_limit_pct&minutes=60         # レート制限ヒット率
 GET /api/metrics?name=throughput_files_per_min&minutes=60  # スループット（ファイル/分）
 GET /api/metrics?name=throughput_bytes_per_sec&minutes=60  # スループット（バイト/秒）
-GET /api/errors?limit=50                                 # 直近エラーログ
+GET /api/errors                                          # 直近エラーログ（最大 5 件）
 ```
 
-> **グラフ更新間隔**: 10 秒ごとに自動更新されます。  
+> **グラフ更新間隔**: 5 秒ごとに自動更新されます。  
 > **注意**: `dashboard` コマンドはスループット計測に転送 DB（SQLite）を使用するため、`transfer` コマンドで生成された DB ファイルが必要です。
 
 ### quality-metrics


### PR DESCRIPTION
## 概要

`usage.md` の「3. 主要サブコマンド」セクションに `dashboard` コマンドの説明を追加しました。

## 追加内容

- 基本コマンド例（`--db` / `--port` / `--no-browser` オプション）
- 表示内容の一覧（転送サマリ・レート制限ヒット率・スループット 2 グラフ・エラーログ）
- REST API エンドポイント一覧（`/api/status` / `/api/metrics` / `/api/errors`）
- 補足注意事項（更新間隔・DB ファイル必須）