### PR TITLE
feat(dashboard): ダッシュボードに詳細メトリクスを追加

### DIFF
--- a/src/CloudMigrator.Core/Migration/DropboxMigrationPipeline.cs
+++ b/src/CloudMigrator.Core/Migration/DropboxMigrationPipeline.cs
@@ -66,6 +66,11 @@ public sealed class DropboxMigrationPipeline : IMigrationPipeline
         var sw = Stopwatch.StartNew();
         _pipelineStartTime = DateTimeOffset.UtcNow;
 
+        // パイプライン開始時刻を初回のみ保存（リカバリ再起動時は上書きしない）
+        var existingStartedAt = await _stateDb.GetCheckpointAsync("pipeline_started_at", ct).ConfigureAwait(false);
+        if (existingStartedAt is null)
+            await _stateDb.SaveCheckpointAsync("pipeline_started_at", _pipelineStartTime.ToString("O"), ct).ConfigureAwait(false);
+
         var channel = Channel.CreateBounded<TransferJob>(new BoundedChannelOptions(ChannelCapacity)
         {
             FullMode = BoundedChannelFullMode.Wait,

--- a/src/CloudMigrator.Core/State/SqliteTransferStateDb.cs
+++ b/src/CloudMigrator.Core/State/SqliteTransferStateDb.cs
@@ -229,7 +229,7 @@ public sealed class SqliteTransferStateDb : ITransferStateDb
 
         int pending = 0, processing = 0, done = 0, failed = 0, permanentFailed = 0;
         long doneSizeBytes = 0;
-        int totalRetries = 0;
+        long totalRetries = 0;
         DateTimeOffset? firstUpdatedAt = null, lastUpdatedAt = null;
 
         await using (var reader = await countCmd.ExecuteReaderAsync(ct).ConfigureAwait(false))
@@ -244,7 +244,7 @@ public sealed class SqliteTransferStateDb : ITransferStateDb
                 doneSizeBytes = reader.IsDBNull(5) ? 0L : reader.GetInt64(5);
                 firstUpdatedAt = reader.IsDBNull(6) ? null : DateTimeOffset.Parse(reader.GetString(6));
                 lastUpdatedAt = reader.IsDBNull(7) ? null : DateTimeOffset.Parse(reader.GetString(7));
-                totalRetries = reader.IsDBNull(8) ? 0 : (int)reader.GetInt64(8);
+                totalRetries = reader.IsDBNull(8) ? 0L : reader.GetInt64(8);
             }
         }
 
@@ -274,12 +274,13 @@ public sealed class SqliteTransferStateDb : ITransferStateDb
         await using var crawlCmd = conn.CreateCommand();
         crawlCmd.CommandText = """
             SELECT key, value FROM checkpoints
-            WHERE key IN ('crawl_complete', 'crawl_total')
+            WHERE key IN ('crawl_complete', 'crawl_total', 'pipeline_started_at')
             """;
         // 備考: 旧バージョンで作成された DB や空 DB では crawl_complete チェックポイントが存在しない。
         // その場合でもダッシュボードが常に「クロール中」とならないよう、未記録時の既定値を true とする。
         var crawlComplete = true;
         int? crawlTotal = null;
+        DateTimeOffset? pipelineStartedAt = null;
         await using (var reader = await crawlCmd.ExecuteReaderAsync(ct).ConfigureAwait(false))
         {
             while (await reader.ReadAsync(ct).ConfigureAwait(false))
@@ -288,6 +289,7 @@ public sealed class SqliteTransferStateDb : ITransferStateDb
                 var v = reader.GetString(1);
                 if (k == "crawl_complete") crawlComplete = v == "true";
                 if (k == "crawl_total" && int.TryParse(v, out var n)) crawlTotal = n;
+                if (k == "pipeline_started_at" && DateTimeOffset.TryParse(v, out var started)) pipelineStartedAt = started;
             }
         }
 
@@ -302,6 +304,7 @@ public sealed class SqliteTransferStateDb : ITransferStateDb
             TotalRetries = totalRetries,
             FirstUpdatedAt = firstUpdatedAt,
             LastUpdatedAt = lastUpdatedAt,
+            PipelineStartedAt = pipelineStartedAt,
             RecentFailed = recentFailed,
             CrawlComplete = crawlComplete,
             CrawlTotal = crawlTotal,

--- a/src/CloudMigrator.Core/State/TransferSummary.cs
+++ b/src/CloudMigrator.Core/State/TransferSummary.cs
@@ -24,7 +24,13 @@ public sealed record TransferDbSummary
     public long TotalDoneSizeBytes { get; init; }
 
     /// <summary>全レコードの retry_count 合計</summary>
-    public int TotalRetries { get; init; }
+    public long TotalRetries { get; init; }
+
+    /// <summary>
+    /// パイプライン初回起動時刻（checkpoints の pipeline_started_at から取得）。
+    /// 経過時間の安定した起点として使用する。null の場合は <see cref="FirstUpdatedAt"/> を代用する。
+    /// </summary>
+    public DateTimeOffset? PipelineStartedAt { get; init; }
 
     /// <summary>DB 内の最も古い updated_at</summary>
     public DateTimeOffset? FirstUpdatedAt { get; init; }

--- a/src/CloudMigrator.Dashboard/DashboardServer.cs
+++ b/src/CloudMigrator.Dashboard/DashboardServer.cs
@@ -372,9 +372,10 @@ public static class DashboardServer
               document.getElementById('c-avgsize').textContent =
                 s.done > 0 ? fmtBytes(Math.round(s.totalDoneSizeBytes / s.done)) : '—';
 
-              // 経過時間
-              if (s.firstUpdatedAt) {
-                const elapsedSec = (Date.now() - new Date(s.firstUpdatedAt).getTime()) / 1000;
+              // 経過時間（pipeline_started_at checkpoint 優先、なければ firstUpdatedAt を代用）
+              const startedAt = s.pipelineStartedAt ?? s.firstUpdatedAt;
+              if (startedAt) {
+                const elapsedSec = (Date.now() - new Date(startedAt).getTime()) / 1000;
                 document.getElementById('c-elapsed').textContent = fmtDuration(elapsedSec);
               }
 

--- a/tests/unit/SqliteTransferStateDbTests.cs
+++ b/tests/unit/SqliteTransferStateDbTests.cs
@@ -344,6 +344,29 @@ public class SqliteTransferStateDbTests : IAsyncDisposable
         summary.RecentFailed.All(f => f.Error != null).Should().BeTrue();
     }
 
+    [Fact]
+    public async Task GetSummaryAsync_TotalRetries_SumsRetryCount()
+    {
+        // 検証対象: GetSummaryAsync  目的: 全レコードの retry_count が TotalRetries に合算される
+        await _db.InitializeAsync(CancellationToken.None);
+
+        // a.txt: 1 回失敗 → retry_count = 1
+        await _db.UpsertPendingAsync(MakeItem("p", "a.txt", "id1"), CancellationToken.None);
+        await _db.MarkFailedAsync("p", "a.txt", "err", CancellationToken.None);
+
+        // b.txt: 2 回失敗 → retry_count = 2
+        await _db.UpsertPendingAsync(MakeItem("p", "b.txt", "id2"), CancellationToken.None);
+        await _db.MarkFailedAsync("p", "b.txt", "err", CancellationToken.None);
+        await _db.MarkFailedAsync("p", "b.txt", "err", CancellationToken.None);
+
+        // c.txt: リトライなし → retry_count = 0
+        await _db.UpsertPendingAsync(MakeItem("p", "c.txt", "id3"), CancellationToken.None);
+
+        var summary = await _db.GetSummaryAsync(CancellationToken.None);
+
+        summary.TotalRetries.Should().Be(3L); // a.txt(1) + b.txt(2) + c.txt(0)
+    }
+
     // ── RecordMetricAsync / GetMetricsAsync ──────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **現在の並列数** KPI カードを追加（`current_parallelism` メトリクス最新値 / オレンジ）
- **並列数推移グラフ**（60分時系列）を追加 — 並列度の変動が一目でわかる
- **経過時間・推定残り時間（ETA）** カードを追加 — スループットから自動計算
- **平均ファイルサイズ** カードを追加（`totalDoneSizeBytes / done`）
- **リトライ総数** カードを追加（アンバー）
- **エラー率** カードを追加（0%=緑 / >0%=赤で動的着色）

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `TransferSummary.cs` | `TotalRetries` プロパティを追加 |
| `SqliteTransferStateDb.cs` | `GetSummaryAsync` に `SUM(retry_count)` クエリを追加 |
| `DropboxMigrationPipeline.cs` | 100件ごとのメトリクス記録に `current_parallelism` を追加 |
| `DashboardServer.cs` | 新 KPI カード行・グラフ・JS 更新（CSS/HTML/JS） |

## Test plan

- [x] `dotnet build` 成功（警告 0、エラー 0）
- [x] `dotnet test` 全 257 テスト通過
- [x] 実際の転送テストでダッシュボード表示を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)