### PR TITLE
feat: 移行完了時に完了サマリーパネルをダッシュボードに表示

### DIFF
--- a/src/CloudMigrator.Dashboard/AssemblyInfo.cs
+++ b/src/CloudMigrator.Dashboard/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CloudMigrator.Tests.Unit")]

--- a/src/CloudMigrator.Dashboard/DashboardServer.cs
+++ b/src/CloudMigrator.Dashboard/DashboardServer.cs
@@ -1,6 +1,7 @@
 using CloudMigrator.Core.Migration;
 using CloudMigrator.Core.State;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -20,19 +21,37 @@ public static class DashboardServer
     /// </summary>
     public static async Task RunAsync(string dbPath, int port, CancellationToken ct)
     {
+        // SqliteTransferStateDb は DI に渡すが、インスタンスを外部から渡す場合は
+        // DI コンテナが DisposeAsync を呼ばないため finally で明示的に解放する。
+        var db = new SqliteTransferStateDb(dbPath);
+        await db.InitializeAsync(ct).ConfigureAwait(false);
+        var app = BuildApp(db);
+        app.Urls.Add($"http://localhost:{port}");
+        try
+        {
+            await app.RunAsync(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            await db.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// 全エンドポイントをマップした <see cref="WebApplication"/> を生成する。
+    /// <paramref name="configureWebHost"/> に <c>wb =&gt; wb.UseTestServer()</c> を渡すと
+    /// インプロセスの TestServer として使用できる（単体テスト向け）。
+    /// </summary>
+    internal static WebApplication BuildApp(
+        ITransferStateDb db,
+        Action<IWebHostBuilder>? configureWebHost = null)
+    {
         var builder = WebApplication.CreateBuilder();
         builder.Logging.SetMinimumLevel(LogLevel.Warning); // ダッシュボード固有のノイズを抑制
-
-        // ITransferStateDb を DI コンテナに登録する。
-        // テストや将来の DB 差し替えはここを変更するだけで対応できる。
-        builder.Services.AddSingleton<ITransferStateDb>(_ => new SqliteTransferStateDb(dbPath));
+        builder.Services.AddSingleton(db);
+        configureWebHost?.Invoke(builder.WebHost);
 
         var app = builder.Build();
-        app.Urls.Add($"http://localhost:{port}");
-
-        // 起動時に 1 回だけスキーマ初期化（IDisposable はホスト停止時に解放される）
-        var db = app.Services.GetRequiredService<ITransferStateDb>();
-        await db.InitializeAsync(ct).ConfigureAwait(false);
 
         // ── API エンドポイント ────────────────────────────────────────────────
 
@@ -97,7 +116,7 @@ public static class DashboardServer
         // GET /  → ダッシュボード HTML
         app.MapGet("/", () => Results.Content(IndexHtml, "text/html; charset=utf-8"));
 
-        await app.RunAsync(ct).ConfigureAwait(false);
+        return app;
     }
 
     // ── インライン HTML（Chart.js CDN 使用） ──────────────────────────────────
@@ -255,11 +274,12 @@ public static class DashboardServer
             const POLL_INTERVAL = 5000; // ms
             const MAX_HISTORY = 60;     // 直近 5 分分（5s × 60）
 
-            let latestFilesPerMin = 0;  // 最新スループット（ETA 計算用）
-            let completedAt   = null;   // 完了検出時刻（一度だけセット）
-            let lastPhaseData = null;   // 最新フェーズデータ（サマリー用）
-            let peakFilesPerMin = 0;    // ピーク スループット（files/min）
-            let peakBytesPerSec = 0;    // ピーク スループット（bytes/sec）
+            let latestFilesPerMin = 0;   // 最新スループット（ETA 計算用）
+            let completedAt    = null;   // 完了検出時刻（一度だけセット）
+            let lastPhaseData  = null;   // 最新フェーズデータ（サマリー用）
+            let peakFilesPerMin = 0;     // ピーク スループット（files/min）
+            let peakBytesPerSec = 0;     // ピーク スループット（bytes/sec）
+            let pipelineStartedAt = null; // パイプライン開始時刻（全期間カバーのメトリクス取得用）
 
             function fmtDuration(sec) {
               sec = Math.round(sec);
@@ -511,6 +531,7 @@ public static class DashboardServer
 
               // 経過時間（pipeline_started_at checkpoint 優先、なければ firstUpdatedAt を代用）
               const startedAt = s.pipelineStartedAt ?? s.firstUpdatedAt;
+              if (startedAt && !pipelineStartedAt) pipelineStartedAt = startedAt;
               if (startedAt) {
                 const elapsedSec = (Date.now() - new Date(startedAt).getTime()) / 1000;
                 document.getElementById('c-elapsed').textContent = fmtDuration(elapsedSec);
@@ -526,7 +547,10 @@ public static class DashboardServer
 
               // 完了検出：pending/processing がゼロかつ 1 件以上完了
               const allDone = s.pending === 0 && s.processing === 0 && s.done > 0;
-              if (allDone && !completedAt) completedAt = new Date();
+              if (allDone && !completedAt) {
+                // 完了確定時刻はサーバー由来の lastUpdatedAt を優先し、なければクライアント時刻を使用
+                completedAt = s.lastUpdatedAt ? new Date(s.lastUpdatedAt) : new Date();
+              }
               if (completedAt) {
                 showCompletionSummary(s);
                 // フェーズバッジを「移行完了」に固定
@@ -538,11 +562,16 @@ public static class DashboardServer
             }
 
             async function refreshMetrics() {
+              // パイプライン開始から全期間をカバーする分数（最低 60 分）
+              // 60 分を超える移行でピーク値が欠落するのを防ぐための動的計算
+              const minsElapsed = pipelineStartedAt
+                ? Math.ceil((Date.now() - new Date(pipelineStartedAt).getTime()) / 60000) + 10 : 60;
+              const metricsMinutes = Math.max(60, minsElapsed);
               const [rlRes, filesRes, bytesRes, parallelRes] = await Promise.all([
-                fetch('/api/metrics?name=rate_limit_pct&minutes=60'),
-                fetch('/api/metrics?name=throughput_files_per_min&minutes=60'),
-                fetch('/api/metrics?name=throughput_bytes_per_sec&minutes=60'),
-                fetch('/api/metrics?name=current_parallelism&minutes=60'),
+                fetch(`/api/metrics?name=rate_limit_pct&minutes=${metricsMinutes}`),
+                fetch(`/api/metrics?name=throughput_files_per_min&minutes=${metricsMinutes}`),
+                fetch(`/api/metrics?name=throughput_bytes_per_sec&minutes=${metricsMinutes}`),
+                fetch(`/api/metrics?name=current_parallelism&minutes=${metricsMinutes}`),
               ]);
               if (rlRes.ok) {
                 const data = await rlRes.json();

--- a/tests/unit/CloudMigrator.Tests.Unit.csproj
+++ b/tests/unit/CloudMigrator.Tests.Unit.csproj
@@ -8,11 +8,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="8.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/tests/unit/DashboardServerTests.cs
+++ b/tests/unit/DashboardServerTests.cs
@@ -1,0 +1,188 @@
+using System.Net;
+using System.Net.Http.Json;
+using CloudMigrator.Core.Migration;
+using CloudMigrator.Core.State;
+using CloudMigrator.Dashboard;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Moq;
+
+namespace CloudMigrator.Tests.Unit;
+
+/// <summary>
+/// 検証対象: DashboardServer API エンドポイント
+/// 目的: 各エンドポイントが ITransferStateDb を正しく呼び出し、
+///       適切な HTTP レスポンスを返すことを確認する
+/// </summary>
+public sealed class DashboardServerTests : IAsyncDisposable
+{
+    private readonly Mock<ITransferStateDb> _mockDb = new(MockBehavior.Loose);
+    private WebApplication? _app;
+
+    private async Task<HttpClient> CreateClientAsync()
+    {
+        _app = DashboardServer.BuildApp(_mockDb.Object, wb => wb.UseTestServer());
+        await _app.StartAsync();
+        return _app.GetTestClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_app is not null)
+        {
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+    }
+
+    // ── /api/status ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetStatus_ReturnsOkWithSummary()
+    {
+        // 検証対象: GET /api/status  目的: GetSummaryAsync を呼び出し 200 OK とサマリーを返す
+        var summary = new TransferDbSummary { Done = 42, Pending = 3 };
+        _mockDb.Setup(d => d.GetSummaryAsync(It.IsAny<CancellationToken>()))
+               .ReturnsAsync(summary);
+        var client = await CreateClientAsync();
+
+        var response = await client.GetAsync("/api/status");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<TransferDbSummary>();
+        body!.Done.Should().Be(42);
+        body.Pending.Should().Be(3);
+    }
+
+    // ── /api/metrics ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetMetrics_DefaultsToRateLimitPct()
+    {
+        // 検証対象: GET /api/metrics (name省略)  目的: デフォルト name=rate_limit_pct・minutes=60 で取得する
+        _mockDb.Setup(d => d.GetMetricsAsync("rate_limit_pct", 60, It.IsAny<CancellationToken>()))
+               .ReturnsAsync((IReadOnlyList<MetricPoint>)new List<MetricPoint>());
+        var client = await CreateClientAsync();
+
+        var response = await client.GetAsync("/api/metrics");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        _mockDb.Verify(d => d.GetMetricsAsync("rate_limit_pct", 60, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetMetrics_CustomNameAndMinutes_ForwardsToDb()
+    {
+        // 検証対象: GET /api/metrics?name=throughput_files_per_min&minutes=30
+        // 目的: 指定パラメータを GetMetricsAsync にそのまま渡す
+        _mockDb.Setup(d => d.GetMetricsAsync("throughput_files_per_min", 30, It.IsAny<CancellationToken>()))
+               .ReturnsAsync((IReadOnlyList<MetricPoint>)new List<MetricPoint>());
+        var client = await CreateClientAsync();
+
+        var response = await client.GetAsync("/api/metrics?name=throughput_files_per_min&minutes=30");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        _mockDb.Verify(d => d.GetMetricsAsync("throughput_files_per_min", 30, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ── /api/phase ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetPhase_ReturnsCrawling_WhenNoCrawlCompleteCheckpoint()
+    {
+        // 検証対象: GET /api/phase  目的: crawl_complete チェックポイントなし → phase="crawling"
+        _mockDb.Setup(d => d.GetCheckpointAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync((string?)null);
+        _mockDb.Setup(d => d.GetMetricsAsync("sp_folder_done", 120, It.IsAny<CancellationToken>()))
+               .ReturnsAsync((IReadOnlyList<MetricPoint>)new List<MetricPoint>());
+        var client = await CreateClientAsync();
+
+        var response = await client.GetAsync("/api/phase");
+        var json = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        json.Should().Contain("\"phase\":\"crawling\"");
+    }
+
+    [Fact]
+    public async Task GetPhase_ReturnsFolderCreation_WhenCrawlCompleteButNotFolderCreation()
+    {
+        // 検証対象: GET /api/phase
+        // 目的: crawl_complete=true かつ folder_creation_complete=null → phase="folder_creation"
+        _mockDb.Setup(d => d.GetCheckpointAsync(SharePointMigrationPipeline.CrawlCompleteKey, It.IsAny<CancellationToken>()))
+               .ReturnsAsync("true");
+        _mockDb.Setup(d => d.GetCheckpointAsync(SharePointMigrationPipeline.FolderCreationCompleteKey, It.IsAny<CancellationToken>()))
+               .ReturnsAsync((string?)null);
+        _mockDb.Setup(d => d.GetCheckpointAsync(SharePointMigrationPipeline.FolderTotalKey, It.IsAny<CancellationToken>()))
+               .ReturnsAsync((string?)null);
+        _mockDb.Setup(d => d.GetMetricsAsync("sp_folder_done", 120, It.IsAny<CancellationToken>()))
+               .ReturnsAsync((IReadOnlyList<MetricPoint>)new List<MetricPoint>());
+        var client = await CreateClientAsync();
+
+        var response = await client.GetAsync("/api/phase");
+        var json = await response.Content.ReadAsStringAsync();
+
+        json.Should().Contain("\"phase\":\"folder_creation\"");
+    }
+
+    [Fact]
+    public async Task GetPhase_ReturnsTransferring_WhenBothCheckpointsTrue()
+    {
+        // 検証対象: GET /api/phase
+        // 目的: crawl_complete=true かつ folder_creation_complete=true → phase="transferring"、folderTotal を含む
+        _mockDb.Setup(d => d.GetCheckpointAsync(SharePointMigrationPipeline.CrawlCompleteKey, It.IsAny<CancellationToken>()))
+               .ReturnsAsync("true");
+        _mockDb.Setup(d => d.GetCheckpointAsync(SharePointMigrationPipeline.FolderCreationCompleteKey, It.IsAny<CancellationToken>()))
+               .ReturnsAsync("true");
+        _mockDb.Setup(d => d.GetCheckpointAsync(SharePointMigrationPipeline.FolderTotalKey, It.IsAny<CancellationToken>()))
+               .ReturnsAsync("100");
+        _mockDb.Setup(d => d.GetMetricsAsync("sp_folder_done", 120, It.IsAny<CancellationToken>()))
+               .ReturnsAsync((IReadOnlyList<MetricPoint>)new List<MetricPoint>());
+        var client = await CreateClientAsync();
+
+        var response = await client.GetAsync("/api/phase");
+        var json = await response.Content.ReadAsStringAsync();
+
+        json.Should().Contain("\"phase\":\"transferring\"");
+        json.Should().Contain("\"folderTotal\":100");
+    }
+
+    // ── /api/errors ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetErrors_ReturnsRecentFailedItems()
+    {
+        // 検証対象: GET /api/errors  目的: TransferDbSummary.RecentFailed をそのまま返す
+        var summary = new TransferDbSummary
+        {
+            RecentFailed = [new FailedItem("docs/sub", "report.xlsx", "Timeout")]
+        };
+        _mockDb.Setup(d => d.GetSummaryAsync(It.IsAny<CancellationToken>()))
+               .ReturnsAsync(summary);
+        var client = await CreateClientAsync();
+
+        var response = await client.GetAsync("/api/errors");
+        var json = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        json.Should().Contain("report.xlsx");
+        json.Should().Contain("Timeout");
+    }
+
+    // ── / ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetIndex_ReturnsHtmlDashboard()
+    {
+        // 検証対象: GET /  目的: ContentType=text/html, CloudMigrator ダッシュボード HTML を返す
+        var client = await CreateClientAsync();
+
+        var response = await client.GetAsync("/");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("text/html");
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("CloudMigrator");
+    }
+}


### PR DESCRIPTION
## 概要

移行パイプラインが完了した際（`pending + processing === 0` かつ `done > 0`）に、ダッシュボードへ**完了サマリーパネル**を自動表示します。

## 変更内容

### `DashboardServer.cs`

**CSS**
- `.completion-summary` パネルスタイル（グラデーション背景・緑ボーダー）
- `.cs-item` / `.cs-value` カードスタイル（success / warn / danger 色分け）
- `.phase-badge.completed` (teal) を追加

**HTML**
- `#completionSummary` セクション（12 指標カード）をフォルダ進捗バーの直後に追加（初期 `display:none`）

**JavaScript**
- `completedAt` / `lastPhaseData` / `peakFilesPerMin` / `peakBytesPerSec` 変数を追加
- `showCompletionSummary(s)` 関数: 完了サマリーパネルの全指標を描画
- `refreshStatus()`: `pending + processing === 0` を検出したら `completedAt` をセットし `showCompletionSummary()` を呼び出す。フェーズバッジを「移行完了」(teal) に固定
- `refreshMetrics()`: files/min・bytes/sec 系列のピーク値を追跡
- `refreshPhase()`: `lastPhaseData` にキャッシュ；完了後はバッジ上書きをスキップ

## 表示される 12 指標

| 指標 | 計算元 |
|------|--------|
| 完了ファイル数 | `status.done` |
| 失敗ファイル数 | `failed + permanentFailed`（0件→緑 / >0→赤） |
| 転送データ量 | `totalDoneSizeBytes` |
| 作成フォルダ数 | `/api/phase` の `folderDone` |
| 総所要時間 | `pipelineStartedAt` → 完了検出時刻 |
| 平均スループット | `done ÷ 経過分` |
| 平均転送速度 | `totalBytes ÷ 経過秒` |
| ピーク スループット | metrics 系列の最大 files/min |
| ピーク 転送速度 | metrics 系列の最大 bytes/sec |
| リトライ総数 | `totalRetries` |
| エラー率 | `failed / total`（5%超→赤 / >0→黄 / 0→緑） |
| 平均ファイルサイズ | `totalBytes ÷ done` |

## テスト確認

- `dotnet build` → 0 errors, 0 warnings ✅
