### PR TITLE
chore: v0.2.0 リリース（CHANGELOG 更新）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+---
+
+## [0.2.0] - 2026-04-04
+
 ### Added
 - **Studio Ph-5: 引数なしデフォルト起動 + DB なしモード** (Issue #85)
   - `NullTransferStateDb` 新設（`CloudMigrator.Core.State`）: Null Object パターンで `ITransferStateDb` を実装。DB なし起動時に全読み込みメソッドは空/ゼロ値を返し、書き込みは無視する
@@ -520,5 +524,6 @@
 - `task.md` - フェーズ別タスク管理
 - `README.md` - プロジェクト概要・構成・開発手順
 
-[Unreleased]: https://github.com/scottlz0310/cloud-migrator/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/scottlz0310/cloud-migrator/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/scottlz0310/cloud-migrator/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/scottlz0310/cloud-migrator/releases/tag/v0.1.0


### PR DESCRIPTION
## v0.2.0 リリース準備

CHANGELOG.md の `[Unreleased]` セクションを `[0.2.0] - 2026-04-04` に昇格します。

### 主な変更内容（v0.1.0 → v0.2.0）

#### CloudMigrator Studio（Issue #80〜#85）
- **Ph-1**: `GET/PUT /api/config` + 設定タブ UI
- **Ph-2**: 転送開始/停止 UI（`POST /api/transfer/start`）
- **Ph-3**: ログストリーミング SSE + ログビューア UI
- **Ph-4**: 接続テスト UI（`POST /api/setup/doctor`）
- **Ph-5**: 引数なしデフォルト起動 + DB なしモード

#### SharePoint 版 4フェーズパイプライン
- SQLite 状態管理（`ITransferStateDb`）による中断再開対応
- Phase A/B/C/D 構造（リカバリ・クロール・フォルダ先行作成・転送）
- `AdaptiveConcurrencyController` による動的並列度制御
- E2E 検証 TC-01〜TC-07 完了 + バグ2件修正（PR #91）

#### その他
- 失敗時の再試行確認プロンプト・`--auto-retry` オプション
- `permanent_failed` 永久放置バグ修正
- `throughput_files_per_min` / `throughput_bytes_per_sec` メトリクス

### テスト
381 tests PASSED（0 FAIL）

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>