### PR TITLE
feat: WiX MSI インストーラー + GitHub Actions Release ワークフロー (ISSUE #100)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
       - name: .NET セットアップ
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0'
+          dotnet-version: '10.0.201'
 
       - name: WiX Toolset v4 インストール
         run: dotnet tool install wix --version 4.0.5 --global
@@ -142,11 +142,17 @@ jobs:
           name: publish-win-x64
           path: published/win-x64
 
-      - name: バージョン文字列を抽出（v プレフィックス除去）
+      - name: MSI 用バージョン文字列を抽出
         id: version
         shell: pwsh
         run: |
-          $version = "${{ github.ref_name }}".TrimStart('v')
+          $tag = "${{ github.ref_name }}"
+
+          if ($tag -notmatch '^v(?<version>\d+\.\d+\.\d+(?:\.\d+)?)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$') {
+            throw "無効なリリースタグ形式です。SemVer 形式のタグ（例: v1.2.3, v1.2.3.4, v1.2.3-rc.1, v1.2.3+build.1）を使用してください: $tag"
+          }
+
+          $version = $Matches['version']
           "version=$version" >> $env:GITHUB_OUTPUT
 
       - name: MSI ビルド

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,3 +109,56 @@ jobs:
         run: gh release upload ${{ github.ref_name }} "${{ env.ASSET_NAME }}" --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Published バイナリをアーティファクトに保存（MSI ビルド用 / win-x64 のみ）
+        if: matrix.rid == 'win-x64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-win-x64
+          path: publish/win-x64/
+          retention-days: 1
+
+  msi:
+    name: MSI インストーラービルド
+    runs-on: windows-latest
+    needs: publish
+    env:
+      HUSKY: 0
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: .NET セットアップ
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0'
+
+      - name: WiX Toolset v4 インストール
+        run: dotnet tool install wix --version 4.0.5 --global
+
+      - name: win-x64 バイナリをダウンロード
+        uses: actions/download-artifact@v4
+        with:
+          name: publish-win-x64
+          path: published/win-x64
+
+      - name: バージョン文字列を抽出（v プレフィックス除去）
+        id: version
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart('v')
+          "version=$version" >> $env:GITHUB_OUTPUT
+
+      - name: MSI ビルド
+        shell: pwsh
+        run: |
+          wix build installer/wix/Product.wxs `
+            -arch x64 `
+            -d Version=${{ steps.version.outputs.version }} `
+            -d "BinDir=${{ github.workspace }}/published/win-x64" `
+            -o cloud-migrator-setup.msi
+
+      - name: MSI をリリースにアップロード
+        run: gh release upload ${{ github.ref_name }} cloud-migrator-setup.msi --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.201",
+    "rollForward": "latestPatch"
+  }
+}

--- a/installer/wix/Product.wxs
+++ b/installer/wix/Product.wxs
@@ -24,6 +24,12 @@
     <!-- 旧バージョンを自動アンインストールしてから新バージョンをインストール -->
     <MajorUpgrade DowngradeErrorMessage="より新しいバージョンの Cloud Migrator がインストール済みです。" />
 
+    <!--
+      ADDTOPATH: PATH への追加を制御するプロパティ（既定: 1 = 有効）
+      無効にする場合: msiexec /i cloud-migrator-setup.msi ADDTOPATH=0
+    -->
+    <Property Id="ADDTOPATH" Value="1" />
+
     <MediaTemplate EmbedCab="yes" />
 
     <!-- インストール先: %LOCALAPPDATA%\Programs\CloudMigrator\ -->
@@ -38,9 +44,9 @@
       <Directory Id="AppMenuFolder" Name="Cloud Migrator" />
     </StandardDirectory>
 
-    <!-- メイン実行ファイル -->
+    <!-- メイン実行ファイル（Guid 固定: アップグレード/修復時のコンポーネント追跡を安定させる） -->
     <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
-      <Component Id="MainExecutable" Guid="*">
+      <Component Id="MainExecutable" Guid="EA5F2D8B-1C3A-4E7F-9B0D-6A2C4E8F1B3D">
         <File Id="cloud_migrator_exe"
               Source="$(var.BinDir)\cloud-migrator.exe"
               KeyPath="yes" />
@@ -67,9 +73,11 @@
       </Component>
     </ComponentGroup>
 
-    <!-- PATH へ追加（ユーザー環境変数 / アンインストール時に自動削除） -->
+    <!-- PATH へ追加（ユーザー環境変数 / アンインストール時に自動削除）
+         Guid 固定: アップグレード時の PATH エントリ追跡を安定させる
+         ADDTOPATH=0 を渡すとインストールをスキップ（既定: 1 = 有効） -->
     <ComponentGroup Id="PathComponents" Directory="INSTALLFOLDER">
-      <Component Id="PathEntry" Guid="*">
+      <Component Id="PathEntry" Guid="3F7A9C1E-5B2D-4F8A-0C6E-8B1D3F5A7C9E" Condition="ADDTOPATH">
         <Environment Id="UserPath"
                      Name="PATH"
                      Value="[INSTALLFOLDER]"

--- a/installer/wix/Product.wxs
+++ b/installer/wix/Product.wxs
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Product.wxs - Cloud Migrator MSI インストーラー定義 (WiX Toolset v4)
+
+  インストール先 : %LOCALAPPDATA%\Programs\CloudMigrator\
+  スコープ       : perUser（UAC 昇格不要）
+  UpgradeCode    : 全バージョン共通で固定（変更禁止）
+  ProductCode    : MajorUpgrade により自動管理（Guid="*"）
+
+  ビルド例（CI / ローカル共通）:
+    wix build Product.wxs -arch x64 \
+      -d Version=1.2.3 \
+      -d BinDir=path\to\publish\win-x64 \
+      -o cloud-migrator-setup.msi
+-->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+
+  <Package Name="Cloud Migrator"
+           Manufacturer="scottlz0310"
+           Version="$(var.Version)"
+           UpgradeCode="C8A5F3B2-7E1D-4A9C-B6F0-2D8E3C1A5047"
+           Scope="perUser">
+
+    <!-- 旧バージョンを自動アンインストールしてから新バージョンをインストール -->
+    <MajorUpgrade DowngradeErrorMessage="より新しいバージョンの Cloud Migrator がインストール済みです。" />
+
+    <MediaTemplate EmbedCab="yes" />
+
+    <!-- インストール先: %LOCALAPPDATA%\Programs\CloudMigrator\ -->
+    <StandardDirectory Id="LocalAppDataFolder">
+      <Directory Id="ProgramsFolder" Name="Programs">
+        <Directory Id="INSTALLFOLDER" Name="CloudMigrator" />
+      </Directory>
+    </StandardDirectory>
+
+    <!-- スタートメニュー -->
+    <StandardDirectory Id="ProgramMenuFolder">
+      <Directory Id="AppMenuFolder" Name="Cloud Migrator" />
+    </StandardDirectory>
+
+    <!-- メイン実行ファイル -->
+    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+      <Component Id="MainExecutable" Guid="*">
+        <File Id="cloud_migrator_exe"
+              Source="$(var.BinDir)\cloud-migrator.exe"
+              KeyPath="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <!-- スタートメニューショートカット -->
+    <ComponentGroup Id="ShortcutComponents" Directory="AppMenuFolder">
+      <Component Id="ApplicationShortcut" Guid="*">
+        <Shortcut Id="StartMenuShortcut"
+                  Name="Cloud Migrator"
+                  Target="[INSTALLFOLDER]cloud-migrator.exe"
+                  WorkingDirectory="INSTALLFOLDER"
+                  Description="Cloud storage migration tool" />
+        <RemoveFolder Id="RemoveAppMenuFolder"
+                      Directory="AppMenuFolder"
+                      On="uninstall" />
+        <!-- ショートカットの KeyPath: レジストリで存在チェック -->
+        <RegistryValue Root="HKCU"
+                       Key="Software\CloudMigrator\Shortcuts"
+                       Type="integer"
+                       Value="1"
+                       KeyPath="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <!-- PATH へ追加（ユーザー環境変数 / アンインストール時に自動削除） -->
+    <ComponentGroup Id="PathComponents" Directory="INSTALLFOLDER">
+      <Component Id="PathEntry" Guid="*">
+        <Environment Id="UserPath"
+                     Name="PATH"
+                     Value="[INSTALLFOLDER]"
+                     Permanent="no"
+                     Part="last"
+                     Action="set"
+                     System="no" />
+        <RegistryValue Root="HKCU"
+                       Key="Software\CloudMigrator\Path"
+                       Type="integer"
+                       Value="1"
+                       KeyPath="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <Feature Id="ProductFeature" Title="Cloud Migrator" Level="1">
+      <ComponentGroupRef Id="ProductComponents" />
+      <ComponentGroupRef Id="ShortcutComponents" />
+      <ComponentGroupRef Id="PathComponents" />
+    </Feature>
+
+  </Package>
+</Wix>


### PR DESCRIPTION
## Summary

- `global.json` を追加し .NET SDK `10.0.201` を `latestPatch` ロールフォワードで固定
- `installer/wix/Product.wxs` を新設（WiX Toolset v4 / MSI 定義）
- `.github/workflows/release.yml` に `msi` ジョブを追加し、`v*` タグ push 時に `cloud-migrator-setup.msi` をリリースへ自動添付

## 変更詳細

### `global.json`
- SDK バージョン `10.0.201` + `rollForward: latestPatch` で CI のビルド再現性を保証

### `installer/wix/Product.wxs`
- インストール先: `%LOCALAPPDATA%\Programs\CloudMigrator\`
- `Scope="perUser"` — UAC 昇格不要
- `UpgradeCode` 固定（全バージョン共通: `C8A5F3B2-7E1D-4A9C-B6F0-2D8E3C1A5047`）
- `MajorUpgrade` — 旧バージョンを自動アンインストール後にインストール
- スタートメニューショートカット（アンインストール時に自動削除）
- ユーザー環境変数 PATH へ追加（アンインストール時に自動削除）

### `.github/workflows/release.yml`
- `publish` ジョブ（win-x64）に `actions/upload-artifact@v4` ステップを追加（`retention-days: 1`）
- `msi` ジョブを新設（`needs: publish`）:
  1. `dotnet tool install wix --version 4.0.5 --global`
  2. win-x64 バイナリをダウンロード
  3. タグ名から `v` プレフィックスを除去してバージョン抽出
  4. `wix build installer/wix/Product.wxs` で MSI 生成
  5. `gh release upload` で GitHub Release に添付

## リリース成果物（`v*` タグ push 時）

| ファイル | 内容 |
|---|---|
| `cloud-migrator-vX.Y.Z-win-x64.zip` | Windows 単一バイナリ |
| `cloud-migrator-vX.Y.Z-linux-x64.tar.gz` | Linux 単一バイナリ |
| `cloud-migrator-vX.Y.Z-osx-x64.tar.gz` | macOS (Intel) 単一バイナリ |
| `cloud-migrator-vX.Y.Z-osx-arm64.tar.gz` | macOS (Apple Silicon) 単一バイナリ |
| `cloud-migrator-setup.msi` | Windows MSI インストーラー |

## Test plan

- [ ] `wix build installer/wix/Product.wxs -arch x64 -d Version=0.1.0 -d BinDir=<publish/win-x64> -o test.msi` でローカルビルドが通る
- [ ] MSI インストールで `%LOCALAPPDATA%\Programs\CloudMigrator\cloud-migrator.exe` が配置される
- [ ] スタートメニューに "Cloud Migrator" ショートカットが作成される
- [ ] `cloud-migrator` が PATH から実行できる
- [ ] MSI アンインストールでショートカット・PATH エントリが削除される
- [ ] `v*` タグ push 時に GitHub Actions が `msi` ジョブを実行し MSI がリリースに添付される
- [ ] バージョンアップグレード時に旧バージョンが自動アンインストールされる

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)