### PR TITLE
refactor: #117 Dashboard サービス層を Core/Observability へ移動（テスト容易性向上）

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,9 @@ coverage:
         threshold: 5%
 
 ignore:
-  - "src/CloudMigrator.Dashboard/**"
+  - "src/CloudMigrator.Dashboard/Components/**"
+  - "src/CloudMigrator.Dashboard/MainWindow.xaml.cs"
+  - "src/CloudMigrator.Dashboard/App.xaml.cs"
+  - "src/CloudMigrator.Dashboard/WpfDialogService.cs"
   - "src/CloudMigrator.Cli/Commands/DashboardCommand.cs"
   - "src/CloudMigrator.Cli/Program.cs"

--- a/src/CloudMigrator.Core/CloudMigrator.Core.csproj
+++ b/src/CloudMigrator.Core/CloudMigrator.Core.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.5" />
   </ItemGroup>

--- a/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
@@ -1,9 +1,8 @@
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using CloudMigrator.Core.Configuration;
 
-namespace CloudMigrator.Dashboard;
+namespace CloudMigrator.Core.Configuration;
 
 /// <summary>
 /// GET /api/config で返す設定 DTO（シークレット除外済み）。

--- a/src/CloudMigrator.Core/Setup/DoctorResult.cs
+++ b/src/CloudMigrator.Core/Setup/DoctorResult.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace CloudMigrator.Dashboard;
+namespace CloudMigrator.Core.Setup;
 
 /// <summary>個別チェックのステータス。</summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/src/CloudMigrator.Core/Setup/SetupDoctorService.cs
+++ b/src/CloudMigrator.Core/Setup/SetupDoctorService.cs
@@ -3,7 +3,7 @@ using System.Net.Http.Headers;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
-namespace CloudMigrator.Dashboard;
+namespace CloudMigrator.Core.Setup;
 
 /// <summary>
 /// セットアップ診断サービスのオプション。

--- a/src/CloudMigrator.Core/Transfer/JobStatus.cs
+++ b/src/CloudMigrator.Core/Transfer/JobStatus.cs
@@ -1,4 +1,4 @@
-namespace CloudMigrator.Dashboard;
+namespace CloudMigrator.Core.Transfer;
 
 /// <summary>
 /// 転送ジョブの実行状態を表す列挙型。

--- a/src/CloudMigrator.Core/Transfer/TransferJobInfo.cs
+++ b/src/CloudMigrator.Core/Transfer/TransferJobInfo.cs
@@ -1,4 +1,4 @@
-namespace CloudMigrator.Dashboard;
+namespace CloudMigrator.Core.Transfer;
 
 /// <summary>
 /// 転送ジョブ状態レコード（ダッシュボード専用・インメモリ管理）。

--- a/src/CloudMigrator.Core/Transfer/TransferJobService.cs
+++ b/src/CloudMigrator.Core/Transfer/TransferJobService.cs
@@ -1,6 +1,6 @@
 using System.Collections.Concurrent;
 
-namespace CloudMigrator.Dashboard;
+namespace CloudMigrator.Core.Transfer;
 
 /// <summary>
 /// ジョブエラー時にクライアントへ返す汎用メッセージ定数。

--- a/src/CloudMigrator.Dashboard/App.xaml.cs
+++ b/src/CloudMigrator.Dashboard/App.xaml.cs
@@ -1,7 +1,9 @@
 using System.IO;
 using System.Windows;
 using CloudMigrator.Core.Configuration;
+using CloudMigrator.Core.Setup;
 using CloudMigrator.Core.State;
+using CloudMigrator.Core.Transfer;
 using CloudMigrator.Observability;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/CloudMigrator.Dashboard/_Imports.razor
+++ b/src/CloudMigrator.Dashboard/_Imports.razor
@@ -7,7 +7,10 @@
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.Extensions.DependencyInjection
 @using MudBlazor
+@using CloudMigrator.Core.Configuration
+@using CloudMigrator.Core.Setup
 @using CloudMigrator.Core.State
+@using CloudMigrator.Core.Transfer
 @using CloudMigrator.Observability
 @using CloudMigrator.Dashboard
 @using CloudMigrator.Dashboard.Components

--- a/src/CloudMigrator.Observability/ILogChannel.cs
+++ b/src/CloudMigrator.Observability/ILogChannel.cs
@@ -1,7 +1,6 @@
 using System.Threading.Channels;
-using CloudMigrator.Observability;
 
-namespace CloudMigrator.Dashboard;
+namespace CloudMigrator.Observability;
 
 /// <summary>
 /// Channel ベースのインプロセスログ配信サービスの契約。

--- a/tests/unit/ConfigurationServiceTests.cs
+++ b/tests/unit/ConfigurationServiceTests.cs
@@ -1,5 +1,5 @@
 using System.Text.Json;
-using CloudMigrator.Dashboard;
+using CloudMigrator.Core.Configuration;
 using FluentAssertions;
 
 namespace CloudMigrator.Tests.Unit;

--- a/tests/unit/SetupDoctorServiceTests.cs
+++ b/tests/unit/SetupDoctorServiceTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Text;
 using System.Text.Json;
-using CloudMigrator.Dashboard;
+using CloudMigrator.Core.Setup;
 using FluentAssertions;
 using Moq;
 using Moq.Protected;

--- a/tests/unit/TransferJobServiceTests.cs
+++ b/tests/unit/TransferJobServiceTests.cs
@@ -1,4 +1,4 @@
-using CloudMigrator.Dashboard;
+using CloudMigrator.Core.Transfer;
 using FluentAssertions;
 
 namespace CloudMigrator.Tests.Unit;


### PR DESCRIPTION
## 概要

`CloudMigrator.Dashboard` に混在していたサービス層を、テスト可能な適切なプロジェクトへ移動する。

Closes #117

## 変更内容

### 移動先

| ファイル | 移動先 | Namespace |
|---------|--------|-----------|
| `ConfigurationService.cs` / `IConfigurationService` / `ConfigDto` / `ConfigUpdateDto` | `CloudMigrator.Core/Configuration/` | `CloudMigrator.Core.Configuration` |
| `SetupDoctorService.cs` / `ISetupDoctorService` / `DoctorOptions` | `CloudMigrator.Core/Setup/` | `CloudMigrator.Core.Setup` |
| `DoctorResult.cs` / `DoctorCheck` / `DoctorStatus` / `OverallStatus` | `CloudMigrator.Core/Setup/` | `CloudMigrator.Core.Setup` |
| `ILogChannel.cs` / `LogChannelAdapter` | `CloudMigrator.Observability/` | `CloudMigrator.Observability` |
| `TransferJobService.cs` / `ITransferJobService` / `JobErrorMessages` | `CloudMigrator.Core/Transfer/` | `CloudMigrator.Core.Transfer` |
| `TransferJobInfo.cs` / `JobStatus.cs` | `CloudMigrator.Core/Transfer/` | `CloudMigrator.Core.Transfer` |

### その他の変更

- `CloudMigrator.Core.csproj`: `Microsoft.Extensions.Http` を追加（`IHttpClientFactory` 参照のため）
- `Dashboard/_Imports.razor`: 新 namespace の `@using` を追加
- `Dashboard/App.xaml.cs`: 新 namespace の `using` を追加
- `codecov.yml`: `ignore` を Dashboard の UI コード（`Components/**`, `MainWindow.xaml.cs`, `App.xaml.cs`, `WpfDialogService.cs`）のみに絞り込み
- `tests/unit`: `ConfigurationServiceTests`, `SetupDoctorServiceTests`, `TransferJobServiceTests` の `using` を新 namespace に更新

## テスト

```
Build succeeded.
  0 error(s)
  0 warning(s)

387 tests passed
```

## 期待する効果

- `ConfigurationServiceTests`, `SetupDoctorServiceTests`, `TransferJobServiceTests` が `CloudMigrator.Core` に属するため、codecov のカバレッジ計測対象になる
- `Dashboard` プロジェクトは UI コード（Razor コンポーネント・WPF クラス）のみになり、`ignore` の範囲が最小化される