### PR TITLE
Phase112: Dropbox OAuth 2.0 PKCE フロー実装（バックエンド層）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@
 
 ## [Unreleased]
 
+### Added
+- **Dropbox OAuth 2.0 PKCE フロー** (Issue #112)
+  - `IDropboxOAuthService` / `DropboxOAuthService`: PKCE（`code_challenge_method=S256`）+ 固定ポート `54321–54325` + ポート競合フォールバック
+  - `DropboxTokenResult` / `DropboxRefreshResult`: OAuth 結果レコード
+  - `DropboxOAuthException`: `ErrorCode` プロパティ付き認証例外（`IsTokenExpired` も維持）
+  - `DropboxStorageProvider` Credential Store コンストラクタ: `ICredentialStore` + `IDropboxOAuthService` を受け取り、保存済みトークンを自動ロード
+  - `EnsureAccessTokenAsync`: Credential Store からの遅延ロードと検証（非同期化）
+  - `RefreshAccessTokenAsync` を `IDropboxOAuthService` パス対応に拡張（リフレッシュ後トークンをストアへ保存、失効時は削除して `DropboxOAuthException` を送出）
+  - `DownloadStreamAsync` を async に変換
+  - `DropboxOAuthServiceTests`: `RefreshTokenAsync` / Credential Store パスのユニットテスト 14 件
+
 ---
 
 ## [0.3.0] - 2026-04-08

--- a/src/CloudMigrator.Providers.Dropbox/AssemblyInfo.cs
+++ b/src/CloudMigrator.Providers.Dropbox/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CloudMigrator.Tests.Unit")]

--- a/src/CloudMigrator.Providers.Dropbox/Auth/DropboxOAuthException.cs
+++ b/src/CloudMigrator.Providers.Dropbox/Auth/DropboxOAuthException.cs
@@ -1,0 +1,32 @@
+namespace CloudMigrator.Providers.Dropbox.Auth;
+
+/// <summary>
+/// Dropbox OAuth フロー中に発生する例外。
+/// </summary>
+public sealed class DropboxOAuthException : Exception
+{
+    /// <summary>OAuth エラーコード（例: invalid_grant, token_revoked, token_not_found）。</summary>
+    public string? ErrorCode { get; }
+
+    /// <summary>トークンが失効（401/403）したため再認証が必要かどうか。</summary>
+    public bool IsTokenExpired { get; }
+
+    public DropboxOAuthException(string message, bool isTokenExpired = false)
+        : base(message)
+    {
+        IsTokenExpired = isTokenExpired;
+    }
+
+    public DropboxOAuthException(string message, string? errorCode, Exception? inner = null)
+        : base(message, inner)
+    {
+        ErrorCode = errorCode;
+        IsTokenExpired = errorCode is "token_expired" or "token_revoked" or "token_not_found"
+            or "invalid_grant" or "expired_access_token";
+    }
+
+    public DropboxOAuthException(string message, Exception inner)
+        : base(message, inner)
+    {
+    }
+}

--- a/src/CloudMigrator.Providers.Dropbox/Auth/DropboxOAuthException.cs
+++ b/src/CloudMigrator.Providers.Dropbox/Auth/DropboxOAuthException.cs
@@ -8,7 +8,7 @@ public sealed class DropboxOAuthException : Exception
     /// <summary>OAuth エラーコード（例: invalid_grant, token_revoked, token_not_found）。</summary>
     public string? ErrorCode { get; }
 
-    /// <summary>トークンが失効（401/403）したため再認証が必要かどうか。</summary>
+    /// <summary>トークンまたは認証情報が失効または欠如しており、再認証が必要かどうか。</summary>
     public bool IsTokenExpired { get; }
 
     public DropboxOAuthException(string message, bool isTokenExpired = false)

--- a/src/CloudMigrator.Providers.Dropbox/Auth/DropboxOAuthService.cs
+++ b/src/CloudMigrator.Providers.Dropbox/Auth/DropboxOAuthService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Json;
 using System.Security.Cryptography;
@@ -58,6 +59,9 @@ public sealed class DropboxOAuthService : IDropboxOAuthService, IDisposable
         // state / code_challenge 等の機微情報はログに出さず、認可エンドポイントのみ記録する
         _logger.LogInformation("ブラウザで Dropbox 認可ページを開いています: {Endpoint}", AuthorizeEndpoint);
 
+        // 既定のブラウザで認可ページを開く
+        Process.Start(new ProcessStartInfo(authUrl) { UseShellExecute = true });
+
         try
         {
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -94,7 +98,8 @@ public sealed class DropboxOAuthService : IDropboxOAuthService, IDisposable
         if (!response.IsSuccessStatusCode)
         {
             var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-            _logger.LogError("トークンリフレッシュ失敗: {Status}", response.StatusCode);
+            var bodySummary = body.Length > 512 ? $"{body[..512]}..." : body;
+            _logger.LogError("トークンリフレッシュ失敗: {Status} Body: {Body}", response.StatusCode, bodySummary);
 
             if (response.StatusCode == HttpStatusCode.Unauthorized ||
                 response.StatusCode == HttpStatusCode.Forbidden)
@@ -119,6 +124,12 @@ public sealed class DropboxOAuthService : IDropboxOAuthService, IDisposable
     /// </summary>
     internal static (HttpListener Listener, int Port) StartListener()
     {
+        // Windows: ERROR_ALREADY_EXISTS(183) / WSAEADDRINUSE(10048)
+        // Linux/macOS: EADDRINUSE(98) — アドレス使用中はフォールバック、それ以外は即時再スロー
+        const int ErrorAlreadyExists = 183;
+        const int WsaeAddrinUse = 10048;
+        const int EAddrInUse = 98;
+
         foreach (var port in CallbackPorts)
         {
             var listener = new HttpListener();
@@ -128,9 +139,9 @@ public sealed class DropboxOAuthService : IDropboxOAuthService, IDisposable
                 listener.Start();
                 return (listener, port);
             }
-            catch (HttpListenerException)
+            catch (HttpListenerException ex) when (ex.ErrorCode is ErrorAlreadyExists or WsaeAddrinUse or EAddrInUse)
             {
-                // ポート競合 — 次のポートを試す
+                // ポートが使用中 — 次のポートを試す
                 listener.Close();
             }
         }
@@ -140,10 +151,10 @@ public sealed class DropboxOAuthService : IDropboxOAuthService, IDisposable
             $"ポート {string.Join(", ", CallbackPorts)} がすべて使用中です。");
     }
 
-    private static string BuildRedirectUri(int port) =>
+    internal static string BuildRedirectUri(int port) =>
         $"http://127.0.0.1:{port}{CallbackPath}/";
 
-    private static string BuildAuthorizationUrl(string appKey, string redirectUri, string codeChallenge, string state)
+    internal static string BuildAuthorizationUrl(string appKey, string redirectUri, string codeChallenge, string state)
     {
         var query = new StringBuilder("?");
         query.Append("client_id=").Append(Uri.EscapeDataString(appKey));
@@ -224,7 +235,8 @@ public sealed class DropboxOAuthService : IDropboxOAuthService, IDisposable
         if (!response.IsSuccessStatusCode)
         {
             var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-            _logger.LogError("PKCE トークン交換失敗: {Status}", response.StatusCode);
+            var bodySummary = body.Length > 512 ? $"{body[..512]}..." : body;
+            _logger.LogError("PKCE トークン交換失敗: {Status} Body: {Body}", response.StatusCode, bodySummary);
             throw new DropboxOAuthException($"PKCE トークン交換に失敗しました: {response.StatusCode}");
         }
 

--- a/src/CloudMigrator.Providers.Dropbox/Auth/DropboxOAuthService.cs
+++ b/src/CloudMigrator.Providers.Dropbox/Auth/DropboxOAuthService.cs
@@ -55,7 +55,8 @@ public sealed class DropboxOAuthService : IDropboxOAuthService, IDisposable
 
         var authUrl = BuildAuthorizationUrl(appKey, redirectUri, codeChallenge, state);
 
-        _logger.LogInformation("ブラウザで以下の URL を開いて認可を完了してください: {Url}", authUrl);
+        // state / code_challenge 等の機微情報はログに出さず、認可エンドポイントのみ記録する
+        _logger.LogInformation("ブラウザで Dropbox 認可ページを開いています: {Endpoint}", AuthorizeEndpoint);
 
         try
         {
@@ -70,7 +71,7 @@ public sealed class DropboxOAuthService : IDropboxOAuthService, IDisposable
         }
         finally
         {
-            try { listener.Stop(); } catch { /* ベストエフォート */ }
+            try { listener.Close(); } catch { /* ベストエフォート */ }
         }
     }
 
@@ -89,11 +90,11 @@ public sealed class DropboxOAuthService : IDropboxOAuthService, IDisposable
             ["client_id"] = appKey,
         });
 
-        var response = await _httpClient.PostAsync(TokenEndpoint, form, cancellationToken);
+        using var response = await _httpClient.PostAsync(TokenEndpoint, form, cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
-            var body = await response.Content.ReadAsStringAsync(cancellationToken);
-            _logger.LogError("トークンリフレッシュ失敗: {Status} {Body}", response.StatusCode, body);
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            _logger.LogError("トークンリフレッシュ失敗: {Status}", response.StatusCode);
 
             if (response.StatusCode == HttpStatusCode.Unauthorized ||
                 response.StatusCode == HttpStatusCode.Forbidden)
@@ -104,7 +105,7 @@ public sealed class DropboxOAuthService : IDropboxOAuthService, IDisposable
             throw new DropboxOAuthException($"トークンリフレッシュに失敗しました: {response.StatusCode}");
         }
 
-        var result = await response.Content.ReadFromJsonAsync<TokenResponse>(cancellationToken: cancellationToken)
+        var result = await response.Content.ReadFromJsonAsync<TokenResponse>(cancellationToken: cancellationToken).ConfigureAwait(false)
             ?? throw new DropboxOAuthException("トークンレスポンスのデシリアライズに失敗しました。");
 
         return new DropboxRefreshResult(result.AccessToken, result.ExpiresIn);
@@ -140,7 +141,7 @@ public sealed class DropboxOAuthService : IDropboxOAuthService, IDisposable
     }
 
     private static string BuildRedirectUri(int port) =>
-        $"http://127.0.0.1:{port}{CallbackPath}";
+        $"http://127.0.0.1:{port}{CallbackPath}/";
 
     private static string BuildAuthorizationUrl(string appKey, string redirectUri, string codeChallenge, string state)
     {
@@ -160,40 +161,47 @@ public sealed class DropboxOAuthService : IDropboxOAuthService, IDisposable
         string expectedState,
         CancellationToken cancellationToken)
     {
-        var context = await listener.GetContextAsync().WaitAsync(cancellationToken);
+        var context = await listener.GetContextAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
         var query = context.Request.QueryString;
 
-        // エラーレスポンス確認
-        var error = query["error"];
-        if (!string.IsNullOrEmpty(error))
-        {
-            var desc = query["error_description"] ?? error;
-            SendHtmlResponse(context.Response, 400,
-                "<h1>認可エラー</h1><p>Dropbox からエラーが返されました。このウィンドウを閉じてください。</p>");
-            throw new DropboxOAuthException($"Dropbox 認可エラー: {desc}");
-        }
-
-        // state CSRF 検証
-        var returnedState = query["state"] ?? string.Empty;
-        if (!string.Equals(returnedState, expectedState, StringComparison.Ordinal))
+        var (code, errorMessage) = ParseCallbackQuery(query, expectedState);
+        if (errorMessage is not null)
         {
             SendHtmlResponse(context.Response, 400,
-                "<h1>セキュリティエラー</h1><p>state パラメータが一致しません。このウィンドウを閉じてください。</p>");
-            throw new DropboxOAuthException("state パラメータが一致しません。CSRF 攻撃の可能性があります。");
-        }
-
-        var code = query["code"];
-        if (string.IsNullOrEmpty(code))
-        {
-            SendHtmlResponse(context.Response, 400,
-                "<h1>エラー</h1><p>認可コードが取得できませんでした。このウィンドウを閉じてください。</p>");
-            throw new DropboxOAuthException("認可コードがコールバックに含まれていません。");
+                $"<h1>エラー</h1><p>{System.Net.WebUtility.HtmlEncode(errorMessage)}</p><p>このウィンドウを閉じてください。</p>");
+            throw new DropboxOAuthException(errorMessage);
         }
 
         SendHtmlResponse(context.Response, 200,
             "<h1>認証完了</h1><p>Dropbox との連携が完了しました。このウィンドウを閉じてください。</p>");
 
-        return code;
+        return code!;
+    }
+
+    /// <summary>
+    /// コールバッククエリを検証し code を返す純関数。
+    /// エラー時は <c>(null, errorMessage)</c>、正常時は <c>(code, null)</c> を返す。
+    /// </summary>
+    internal static (string? Code, string? ErrorMessage) ParseCallbackQuery(
+        System.Collections.Specialized.NameValueCollection query,
+        string expectedState)
+    {
+        var error = query["error"];
+        if (!string.IsNullOrEmpty(error))
+        {
+            var desc = query["error_description"] ?? error;
+            return (null, $"Dropbox 認可エラー: {desc}");
+        }
+
+        var returnedState = query["state"] ?? string.Empty;
+        if (!string.Equals(returnedState, expectedState, StringComparison.Ordinal))
+            return (null, "state パラメータが一致しません。CSRF 攻撃の可能性があります。");
+
+        var code = query["code"];
+        if (string.IsNullOrEmpty(code))
+            return (null, "認可コードがコールバックに含まれていません。");
+
+        return (code, null);
     }
 
     private async Task<DropboxTokenResult> ExchangeCodeAsync(
@@ -212,15 +220,15 @@ public sealed class DropboxOAuthService : IDropboxOAuthService, IDisposable
             ["client_id"] = appKey,
         });
 
-        var response = await _httpClient.PostAsync(TokenEndpoint, form, cancellationToken);
+        using var response = await _httpClient.PostAsync(TokenEndpoint, form, cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
-            var body = await response.Content.ReadAsStringAsync(cancellationToken);
-            _logger.LogError("PKCE トークン交換失敗: {Status} {Body}", response.StatusCode, body);
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            _logger.LogError("PKCE トークン交換失敗: {Status}", response.StatusCode);
             throw new DropboxOAuthException($"PKCE トークン交換に失敗しました: {response.StatusCode}");
         }
 
-        var result = await response.Content.ReadFromJsonAsync<TokenResponse>(cancellationToken: cancellationToken)
+        var result = await response.Content.ReadFromJsonAsync<TokenResponse>(cancellationToken: cancellationToken).ConfigureAwait(false)
             ?? throw new DropboxOAuthException("トークンレスポンスのデシリアライズに失敗しました。");
 
         return new DropboxTokenResult(result.AccessToken, result.RefreshToken, result.ExpiresIn);

--- a/src/CloudMigrator.Providers.Dropbox/Auth/DropboxOAuthService.cs
+++ b/src/CloudMigrator.Providers.Dropbox/Auth/DropboxOAuthService.cs
@@ -1,0 +1,288 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace CloudMigrator.Providers.Dropbox.Auth;
+
+/// <summary>
+/// Dropbox OAuth 2.0 PKCE フロー実装。
+/// リダイレクト URI は <c>http://127.0.0.1:{port}/callback</c> の固定ポート方式を採用。
+/// Dropbox App Console は redirect_uri の完全一致を要求するため、ランダムポートは使用不可。
+/// ポート競合時は <see cref="CallbackPorts"/> の順でフォールバックする。
+/// </summary>
+public sealed class DropboxOAuthService : IDropboxOAuthService, IDisposable
+{
+    // Dropbox App Console に事前登録が必要なポート候補（優先順）
+    internal static readonly int[] CallbackPorts = [54321, 54322, 54323, 54324, 54325];
+
+    private const string AuthorizeEndpoint = "https://www.dropbox.com/oauth2/authorize";
+    private const string TokenEndpoint = "https://api.dropboxapi.com/oauth2/token";
+    private const string CallbackPath = "/callback";
+
+    private readonly HttpClient _httpClient;
+    private readonly bool _ownsHttpClient;
+    private readonly ILogger<DropboxOAuthService> _logger;
+
+    public DropboxOAuthService(ILogger<DropboxOAuthService> logger, HttpClient? httpClient = null)
+    {
+        _logger = logger;
+        _httpClient = httpClient ?? new HttpClient();
+        _ownsHttpClient = httpClient is null;
+    }
+
+    /// <inheritdoc/>
+    public async Task<DropboxTokenResult> AuthorizeAsync(string appKey, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(appKey))
+            throw new ArgumentException("App Key が指定されていません。", nameof(appKey));
+
+        // PKCE パラメータ生成
+        var codeVerifier = GenerateCodeVerifier();
+        var codeChallenge = GenerateCodeChallenge(codeVerifier);
+
+        // CSRF 対策の state パラメータ
+        var state = Convert.ToBase64String(RandomNumberGenerator.GetBytes(16))
+            .Replace("+", "-").Replace("/", "_").Replace("=", "");
+
+        // ポート候補を順に試してリスナーを起動
+        var (listener, port) = StartListener();
+        var redirectUri = BuildRedirectUri(port);
+
+        _logger.LogInformation("Dropbox OAuth リスナー起動: {RedirectUri}", redirectUri);
+
+        var authUrl = BuildAuthorizationUrl(appKey, redirectUri, codeChallenge, state);
+
+        _logger.LogInformation("ブラウザで以下の URL を開いて認可を完了してください: {Url}", authUrl);
+
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(TimeSpan.FromMinutes(5));
+
+            // コールバック待受
+            var code = await WaitForCallbackAsync(listener, state, cts.Token);
+
+            // コードをトークンに交換
+            return await ExchangeCodeAsync(appKey, code, codeVerifier, redirectUri, cts.Token);
+        }
+        finally
+        {
+            try { listener.Stop(); } catch { /* ベストエフォート */ }
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<DropboxRefreshResult> RefreshTokenAsync(string appKey, string refreshToken, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(appKey))
+            throw new ArgumentException("App Key が指定されていません。", nameof(appKey));
+        if (string.IsNullOrWhiteSpace(refreshToken))
+            throw new ArgumentException("Refresh Token が指定されていません。", nameof(refreshToken));
+
+        var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "refresh_token",
+            ["refresh_token"] = refreshToken,
+            ["client_id"] = appKey,
+        });
+
+        var response = await _httpClient.PostAsync(TokenEndpoint, form, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            _logger.LogError("トークンリフレッシュ失敗: {Status} {Body}", response.StatusCode, body);
+
+            if (response.StatusCode == HttpStatusCode.Unauthorized ||
+                response.StatusCode == HttpStatusCode.Forbidden)
+            {
+                throw new DropboxOAuthException("Refresh Token が失効しています。再認証が必要です。", isTokenExpired: true);
+            }
+
+            throw new DropboxOAuthException($"トークンリフレッシュに失敗しました: {response.StatusCode}");
+        }
+
+        var result = await response.Content.ReadFromJsonAsync<TokenResponse>(cancellationToken: cancellationToken)
+            ?? throw new DropboxOAuthException("トークンレスポンスのデシリアライズに失敗しました。");
+
+        return new DropboxRefreshResult(result.AccessToken, result.ExpiresIn);
+    }
+
+    // --- 内部実装 ---
+
+    /// <summary>
+    /// ポート候補を順に試して <see cref="HttpListener"/> を起動する。
+    /// すべてのポートが使用中の場合は例外をスローする。
+    /// </summary>
+    internal static (HttpListener Listener, int Port) StartListener()
+    {
+        foreach (var port in CallbackPorts)
+        {
+            var listener = new HttpListener();
+            listener.Prefixes.Add($"http://127.0.0.1:{port}{CallbackPath}/");
+            try
+            {
+                listener.Start();
+                return (listener, port);
+            }
+            catch (HttpListenerException)
+            {
+                // ポート競合 — 次のポートを試す
+                listener.Close();
+            }
+        }
+
+        throw new DropboxOAuthException(
+            $"OAuth コールバック用のポートを確保できませんでした。" +
+            $"ポート {string.Join(", ", CallbackPorts)} がすべて使用中です。");
+    }
+
+    private static string BuildRedirectUri(int port) =>
+        $"http://127.0.0.1:{port}{CallbackPath}";
+
+    private static string BuildAuthorizationUrl(string appKey, string redirectUri, string codeChallenge, string state)
+    {
+        var query = new StringBuilder("?");
+        query.Append("client_id=").Append(Uri.EscapeDataString(appKey));
+        query.Append("&response_type=code");
+        query.Append("&redirect_uri=").Append(Uri.EscapeDataString(redirectUri));
+        query.Append("&code_challenge=").Append(Uri.EscapeDataString(codeChallenge));
+        query.Append("&code_challenge_method=S256");
+        query.Append("&token_access_type=offline");
+        query.Append("&state=").Append(Uri.EscapeDataString(state));
+        return AuthorizeEndpoint + query;
+    }
+
+    private static async Task<string> WaitForCallbackAsync(
+        HttpListener listener,
+        string expectedState,
+        CancellationToken cancellationToken)
+    {
+        var context = await listener.GetContextAsync().WaitAsync(cancellationToken);
+        var query = context.Request.QueryString;
+
+        // エラーレスポンス確認
+        var error = query["error"];
+        if (!string.IsNullOrEmpty(error))
+        {
+            var desc = query["error_description"] ?? error;
+            SendHtmlResponse(context.Response, 400,
+                "<h1>認可エラー</h1><p>Dropbox からエラーが返されました。このウィンドウを閉じてください。</p>");
+            throw new DropboxOAuthException($"Dropbox 認可エラー: {desc}");
+        }
+
+        // state CSRF 検証
+        var returnedState = query["state"] ?? string.Empty;
+        if (!string.Equals(returnedState, expectedState, StringComparison.Ordinal))
+        {
+            SendHtmlResponse(context.Response, 400,
+                "<h1>セキュリティエラー</h1><p>state パラメータが一致しません。このウィンドウを閉じてください。</p>");
+            throw new DropboxOAuthException("state パラメータが一致しません。CSRF 攻撃の可能性があります。");
+        }
+
+        var code = query["code"];
+        if (string.IsNullOrEmpty(code))
+        {
+            SendHtmlResponse(context.Response, 400,
+                "<h1>エラー</h1><p>認可コードが取得できませんでした。このウィンドウを閉じてください。</p>");
+            throw new DropboxOAuthException("認可コードがコールバックに含まれていません。");
+        }
+
+        SendHtmlResponse(context.Response, 200,
+            "<h1>認証完了</h1><p>Dropbox との連携が完了しました。このウィンドウを閉じてください。</p>");
+
+        return code;
+    }
+
+    private async Task<DropboxTokenResult> ExchangeCodeAsync(
+        string appKey,
+        string code,
+        string codeVerifier,
+        string redirectUri,
+        CancellationToken cancellationToken)
+    {
+        var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["code"] = code,
+            ["grant_type"] = "authorization_code",
+            ["redirect_uri"] = redirectUri,
+            ["code_verifier"] = codeVerifier,
+            ["client_id"] = appKey,
+        });
+
+        var response = await _httpClient.PostAsync(TokenEndpoint, form, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            _logger.LogError("PKCE トークン交換失敗: {Status} {Body}", response.StatusCode, body);
+            throw new DropboxOAuthException($"PKCE トークン交換に失敗しました: {response.StatusCode}");
+        }
+
+        var result = await response.Content.ReadFromJsonAsync<TokenResponse>(cancellationToken: cancellationToken)
+            ?? throw new DropboxOAuthException("トークンレスポンスのデシリアライズに失敗しました。");
+
+        return new DropboxTokenResult(result.AccessToken, result.RefreshToken, result.ExpiresIn);
+    }
+
+    private static void SendHtmlResponse(HttpListenerResponse response, int statusCode, string body)
+    {
+        response.StatusCode = statusCode;
+        response.ContentType = "text/html; charset=utf-8";
+        var bytes = Encoding.UTF8.GetBytes($"<!DOCTYPE html><html><body>{body}</body></html>");
+        response.ContentLength64 = bytes.Length;
+        try
+        {
+            response.OutputStream.Write(bytes);
+            response.OutputStream.Flush();
+        }
+        finally
+        {
+            response.OutputStream.Close();
+        }
+    }
+
+    // --- PKCE ユーティリティ ---
+
+    /// <summary>
+    /// RFC 7636 準拠の code_verifier を生成する（43〜128 文字、Base64URL エンコード）。
+    /// </summary>
+    internal static string GenerateCodeVerifier()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(32);
+        return Convert.ToBase64String(bytes)
+            .Replace("+", "-").Replace("/", "_").Replace("=", "");
+    }
+
+    /// <summary>
+    /// S256 アルゴリズムで code_challenge を生成する。
+    /// SHA-256(code_verifier) を Base64URL エンコードした値。
+    /// </summary>
+    internal static string GenerateCodeChallenge(string codeVerifier)
+    {
+        var hash = SHA256.HashData(Encoding.ASCII.GetBytes(codeVerifier));
+        return Convert.ToBase64String(hash)
+            .Replace("+", "-").Replace("/", "_").Replace("=", "");
+    }
+
+    public void Dispose()
+    {
+        if (_ownsHttpClient)
+            _httpClient.Dispose();
+    }
+
+    // --- JSON デシリアライズ用内部型 ---
+
+    private sealed class TokenResponse
+    {
+        [JsonPropertyName("access_token")]
+        public string AccessToken { get; init; } = string.Empty;
+
+        [JsonPropertyName("refresh_token")]
+        public string? RefreshToken { get; init; }
+
+        [JsonPropertyName("expires_in")]
+        public int ExpiresIn { get; init; }
+    }
+}

--- a/src/CloudMigrator.Providers.Dropbox/Auth/DropboxOAuthService.cs
+++ b/src/CloudMigrator.Providers.Dropbox/Auth/DropboxOAuthService.cs
@@ -59,11 +59,11 @@ public sealed class DropboxOAuthService : IDropboxOAuthService, IDisposable
         // state / code_challenge 等の機微情報はログに出さず、認可エンドポイントのみ記録する
         _logger.LogInformation("ブラウザで Dropbox 認可ページを開いています: {Endpoint}", AuthorizeEndpoint);
 
-        // 既定のブラウザで認可ページを開く
-        Process.Start(new ProcessStartInfo(authUrl) { UseShellExecute = true });
-
         try
         {
+            // 既定のブラウザで認可ページを開く（try 内で実行し、失敗時も listener を確実に解放）
+            Process.Start(new ProcessStartInfo(authUrl) { UseShellExecute = true });
+
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             cts.CancelAfter(TimeSpan.FromMinutes(5));
 
@@ -143,6 +143,15 @@ public sealed class DropboxOAuthService : IDropboxOAuthService, IDisposable
             {
                 // ポートが使用中 — 次のポートを試す
                 listener.Close();
+            }
+            catch (HttpListenerException ex)
+            {
+                // 権限不足・URLACL 未登録・不正な Prefix 等、ポート競合以外のエラーは回復不可
+                listener.Close();
+                throw new DropboxOAuthException(
+                    $"OAuth リスナーを起動できませんでした（ポート {port}）。" +
+                    $"URLACL の登録漏れまたは権限不足の可能性があります: {ex.Message}",
+                    ex);
             }
         }
 

--- a/src/CloudMigrator.Providers.Dropbox/Auth/DropboxTokenResult.cs
+++ b/src/CloudMigrator.Providers.Dropbox/Auth/DropboxTokenResult.cs
@@ -1,0 +1,16 @@
+namespace CloudMigrator.Providers.Dropbox.Auth;
+
+/// <summary>
+/// OAuth 認可フロー完了後のトークン結果。
+/// </summary>
+/// <param name="AccessToken">取得したアクセストークン。</param>
+/// <param name="RefreshToken">取得したリフレッシュトークン（offline アクセス時に返される）。</param>
+/// <param name="ExpiresIn">アクセストークンの有効秒数。</param>
+public sealed record DropboxTokenResult(string AccessToken, string? RefreshToken, int ExpiresIn);
+
+/// <summary>
+/// リフレッシュトークン交換後のアクセストークン結果。
+/// </summary>
+/// <param name="AccessToken">新しいアクセストークン。</param>
+/// <param name="ExpiresIn">アクセストークンの有効秒数。</param>
+public sealed record DropboxRefreshResult(string AccessToken, int ExpiresIn);

--- a/src/CloudMigrator.Providers.Dropbox/Auth/IDropboxOAuthService.cs
+++ b/src/CloudMigrator.Providers.Dropbox/Auth/IDropboxOAuthService.cs
@@ -1,0 +1,25 @@
+namespace CloudMigrator.Providers.Dropbox.Auth;
+
+/// <summary>
+/// Dropbox OAuth 2.0 PKCE フローを管理するサービス抽象。
+/// </summary>
+public interface IDropboxOAuthService
+{
+    /// <summary>
+    /// PKCE フローを開始し、アクセストークンとリフレッシュトークンを返す。
+    /// ユーザーはブラウザで認可ページを開き、コールバックを待つ。
+    /// </summary>
+    /// <param name="appKey">Dropbox App Key（App Console から取得）。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    /// <returns>OAuth 認可結果（access_token / refresh_token）。</returns>
+    Task<DropboxTokenResult> AuthorizeAsync(string appKey, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// リフレッシュトークンを使用して新しいアクセストークンを取得する。
+    /// </summary>
+    /// <param name="appKey">Dropbox App Key。</param>
+    /// <param name="refreshToken">保存済みリフレッシュトークン。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    /// <returns>新しいアクセストークンと有効期限。</returns>
+    Task<DropboxRefreshResult> RefreshTokenAsync(string appKey, string refreshToken, CancellationToken cancellationToken = default);
+}

--- a/src/CloudMigrator.Providers.Dropbox/CloudMigrator.Providers.Dropbox.csproj
+++ b/src/CloudMigrator.Providers.Dropbox/CloudMigrator.Providers.Dropbox.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\CloudMigrator.Providers.Abstractions\CloudMigrator.Providers.Abstractions.csproj" />
+    <ProjectReference Include="..\CloudMigrator.Core\CloudMigrator.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CloudMigrator.Providers.Dropbox/DropboxStorageProvider.cs
+++ b/src/CloudMigrator.Providers.Dropbox/DropboxStorageProvider.cs
@@ -942,7 +942,7 @@ public sealed class DropboxStorageProvider : IStorageProvider, IRetryAwareStorag
         // Credential Store ベースの場合: 初回呼び出し時に保存済みアクセストークンをロード
         if (_credentialStore != null && string.IsNullOrWhiteSpace(_accessToken))
         {
-            var stored = await _credentialStore.GetAsync(CredentialKeys.DropboxAccessToken).ConfigureAwait(false);
+            var stored = await _credentialStore.GetAsync(CredentialKeys.DropboxAccessToken, ct).ConfigureAwait(false);
             if (!string.IsNullOrWhiteSpace(stored))
                 _accessToken = stored;
         }
@@ -968,9 +968,9 @@ public sealed class DropboxStorageProvider : IStorageProvider, IRetryAwareStorag
             if (_oAuthService != null && _credentialStore != null)
             {
                 // IDropboxOAuthService（PKCE）ベースのリフレッシュ
-                var appKey = await _credentialStore.GetAsync(CredentialKeys.DropboxAppKey).ConfigureAwait(false)
+                var appKey = await _credentialStore.GetAsync(CredentialKeys.DropboxAppKey, ct).ConfigureAwait(false)
                     ?? throw new InvalidOperationException("Dropbox App Key が Credential Store に存在しません。");
-                var refreshToken = await _credentialStore.GetAsync(CredentialKeys.DropboxRefreshToken).ConfigureAwait(false)
+                var refreshToken = await _credentialStore.GetAsync(CredentialKeys.DropboxRefreshToken, ct).ConfigureAwait(false)
                     ?? throw new DropboxOAuthException(
                         "Dropbox リフレッシュトークンが Credential Store に存在しません。再認証が必要です。",
                         "token_not_found");
@@ -983,8 +983,8 @@ public sealed class DropboxStorageProvider : IStorageProvider, IRetryAwareStorag
                 catch (DropboxOAuthException ex) when (ex.IsTokenExpired)
                 {
                     // リフレッシュトークンも失効 → Credential Store からトークンを削除して再認証を要求
-                    await _credentialStore.DeleteAsync(CredentialKeys.DropboxAccessToken).ConfigureAwait(false);
-                    await _credentialStore.DeleteAsync(CredentialKeys.DropboxRefreshToken).ConfigureAwait(false);
+                    await _credentialStore.DeleteAsync(CredentialKeys.DropboxAccessToken, ct).ConfigureAwait(false);
+                    await _credentialStore.DeleteAsync(CredentialKeys.DropboxRefreshToken, ct).ConfigureAwait(false);
                     _accessToken = string.Empty;
                     throw new DropboxOAuthException(
                         "Dropbox リフレッシュトークンが失効しました。再認証が必要です。",
@@ -993,7 +993,7 @@ public sealed class DropboxStorageProvider : IStorageProvider, IRetryAwareStorag
                 }
 
                 _accessToken = result.AccessToken;
-                await _credentialStore.SaveAsync(CredentialKeys.DropboxAccessToken, result.AccessToken).ConfigureAwait(false);
+                await _credentialStore.SaveAsync(CredentialKeys.DropboxAccessToken, result.AccessToken, ct).ConfigureAwait(false);
             }
             else
             {

--- a/src/CloudMigrator.Providers.Dropbox/DropboxStorageProvider.cs
+++ b/src/CloudMigrator.Providers.Dropbox/DropboxStorageProvider.cs
@@ -90,7 +90,7 @@ public sealed class DropboxStorageProvider : IStorageProvider, IRetryAwareStorag
         _logger = logger;
         _credentialStore = credentialStore;
         _oAuthService = oAuthService;
-        _accessToken = string.Empty;  // 初回 API 呼び出し前に EnsureTokenLoadedAsync で設定される
+        _accessToken = string.Empty;  // 初回 API 呼び出し前に EnsureAccessTokenAsync で設定される
         _options = options ?? new DropboxStorageOptions();
         _httpClient = httpClient ?? new HttpClient();
         _ownsHttpClient = httpClient is null || disposeHttpClient;
@@ -969,7 +969,9 @@ public sealed class DropboxStorageProvider : IStorageProvider, IRetryAwareStorag
             {
                 // IDropboxOAuthService（PKCE）ベースのリフレッシュ
                 var appKey = await _credentialStore.GetAsync(CredentialKeys.DropboxAppKey, ct).ConfigureAwait(false)
-                    ?? throw new InvalidOperationException("Dropbox App Key が Credential Store に存在しません。");
+                    ?? throw new DropboxOAuthException(
+                        "Dropbox App Key が Credential Store に存在しません。初回セットアップが必要です。",
+                        "token_not_found");
                 var refreshToken = await _credentialStore.GetAsync(CredentialKeys.DropboxRefreshToken, ct).ConfigureAwait(false)
                     ?? throw new DropboxOAuthException(
                         "Dropbox リフレッシュトークンが Credential Store に存在しません。再認証が必要です。",

--- a/src/CloudMigrator.Providers.Dropbox/DropboxStorageProvider.cs
+++ b/src/CloudMigrator.Providers.Dropbox/DropboxStorageProvider.cs
@@ -4,7 +4,9 @@ using System.Buffers;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using CloudMigrator.Core.Credentials;
 using CloudMigrator.Providers.Abstractions;
+using CloudMigrator.Providers.Dropbox.Auth;
 using Microsoft.Extensions.Logging;
 
 namespace CloudMigrator.Providers.Dropbox;
@@ -25,6 +27,8 @@ public sealed class DropboxStorageProvider : IStorageProvider, IRetryAwareStorag
     private readonly string? _refreshToken;
     private readonly string? _clientId;
     private readonly string? _clientSecret;
+    private readonly ICredentialStore? _credentialStore;
+    private readonly IDropboxOAuthService? _oAuthService;
     private readonly SemaphoreSlim _tokenRefreshLock = new(1, 1);
     private readonly DropboxStorageOptions _options;
     private readonly int _maxRetry;
@@ -68,6 +72,34 @@ public sealed class DropboxStorageProvider : IStorageProvider, IRetryAwareStorag
         _onRateLimit = onRateLimit;
     }
 
+    /// <summary>
+    /// Credential Manager ベースのコンストラクタ。
+    /// アクセストークンは実行時に <see cref="ICredentialStore"/> から取得し、
+    /// 期限切れ時は <see cref="IDropboxOAuthService"/> でリフレッシュする。
+    /// </summary>
+    public DropboxStorageProvider(
+        ILogger<DropboxStorageProvider> logger,
+        ICredentialStore credentialStore,
+        IDropboxOAuthService oAuthService,
+        DropboxStorageOptions? options = null,
+        HttpClient? httpClient = null,
+        int maxRetry = 3,
+        bool disposeHttpClient = false,
+        Action<TimeSpan?>? onRateLimit = null)
+    {
+        _logger = logger;
+        _credentialStore = credentialStore;
+        _oAuthService = oAuthService;
+        _accessToken = string.Empty;  // 初回 API 呼び出し前に EnsureTokenLoadedAsync で設定される
+        _options = options ?? new DropboxStorageOptions();
+        _httpClient = httpClient ?? new HttpClient();
+        _ownsHttpClient = httpClient is null || disposeHttpClient;
+        _maxRetry = Math.Max(0, maxRetry);
+        _simpleUploadLimitBytes = Math.Max(1, _options.SimpleUploadLimitMb) * 1024 * 1024;
+        _uploadChunkSizeBytes = Math.Max(1, _options.UploadChunkSizeMb) * 1024 * 1024;
+        _onRateLimit = onRateLimit;
+    }
+
     public void Dispose()
     {
         _tokenRefreshLock.Dispose();
@@ -86,7 +118,7 @@ public sealed class DropboxStorageProvider : IStorageProvider, IRetryAwareStorag
             return [];
         }
 
-        EnsureAccessTokenConfigured();
+        await EnsureAccessTokenAsync(cancellationToken).ConfigureAwait(false);
 
         var crawlPath = ResolveCrawlPath(rootPath);
         ListFolderResponse firstPage;
@@ -142,7 +174,7 @@ public sealed class DropboxStorageProvider : IStorageProvider, IRetryAwareStorag
     /// <inheritdoc/>
     public async Task UploadFileAsync(TransferJob job, CancellationToken cancellationToken = default)
     {
-        EnsureAccessTokenConfigured();
+        await EnsureAccessTokenAsync(cancellationToken).ConfigureAwait(false);
 
         if (job.Source.SizeBytes is null)
             throw new InvalidOperationException($"SizeBytes が未設定のため転送できません: {job.Source.SkipKey}");
@@ -165,7 +197,7 @@ public sealed class DropboxStorageProvider : IStorageProvider, IRetryAwareStorag
     /// <inheritdoc/>
     public async Task<string> DownloadToTempAsync(StorageItem item, CancellationToken cancellationToken = default)
     {
-        EnsureAccessTokenConfigured();
+        await EnsureAccessTokenAsync(cancellationToken).ConfigureAwait(false);
 
         var tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         try
@@ -189,16 +221,16 @@ public sealed class DropboxStorageProvider : IStorageProvider, IRetryAwareStorag
     }
 
     /// <inheritdoc/>
-    public Task<Stream> DownloadStreamAsync(StorageItem item, CancellationToken cancellationToken = default)
+    public async Task<Stream> DownloadStreamAsync(StorageItem item, CancellationToken cancellationToken = default)
     {
-        EnsureAccessTokenConfigured();
-        return DownloadStreamByPathAsync(BuildSourceFilePath(item), cancellationToken);
+        await EnsureAccessTokenAsync(cancellationToken).ConfigureAwait(false);
+        return await DownloadStreamByPathAsync(BuildSourceFilePath(item), cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public async Task UploadFromLocalAsync(string localFilePath, long fileSizeBytes, string destinationFullPath, CancellationToken cancellationToken = default)
     {
-        EnsureAccessTokenConfigured();
+        await EnsureAccessTokenAsync(cancellationToken).ConfigureAwait(false);
 
         await using var stream = File.OpenRead(localFilePath);
         await UploadFromStreamAsync(stream, fileSizeBytes, destinationFullPath, cancellationToken).ConfigureAwait(false);
@@ -211,7 +243,7 @@ public sealed class DropboxStorageProvider : IStorageProvider, IRetryAwareStorag
         string destinationFullPath,
         CancellationToken cancellationToken = default)
     {
-        EnsureAccessTokenConfigured();
+        await EnsureAccessTokenAsync(cancellationToken).ConfigureAwait(false);
 
         var destinationPath = NormalizeFilePath(destinationFullPath);
         _logger.LogDebug("Dropbox アップロード開始: {DestPath} ({Bytes} bytes)", destinationPath, fileSizeBytes);
@@ -234,7 +266,7 @@ public sealed class DropboxStorageProvider : IStorageProvider, IRetryAwareStorag
         string? cursor,
         CancellationToken cancellationToken = default)
     {
-        EnsureAccessTokenConfigured();
+        await EnsureAccessTokenAsync(cancellationToken).ConfigureAwait(false);
 
         ListFolderResponse response;
         if (cursor is null)
@@ -285,7 +317,7 @@ public sealed class DropboxStorageProvider : IStorageProvider, IRetryAwareStorag
     /// <inheritdoc/>
     public async Task EnsureFolderAsync(string folderPath, CancellationToken cancellationToken = default)
     {
-        EnsureAccessTokenConfigured();
+        await EnsureAccessTokenAsync(cancellationToken).ConfigureAwait(false);
 
         var normalized = NormalizeFolderPath(folderPath);
         if (string.IsNullOrEmpty(normalized))
@@ -897,12 +929,24 @@ public sealed class DropboxStorageProvider : IStorageProvider, IRetryAwareStorag
     }
 
     private bool HasRefreshCapability()
-        => !string.IsNullOrWhiteSpace(_refreshToken)
-            && !string.IsNullOrWhiteSpace(_clientId)
-            && !string.IsNullOrWhiteSpace(_clientSecret);
+        => (!string.IsNullOrWhiteSpace(_refreshToken)
+                && !string.IsNullOrWhiteSpace(_clientId)
+                && !string.IsNullOrWhiteSpace(_clientSecret))
+            || (_oAuthService != null && _credentialStore != null);
 
-    private void EnsureAccessTokenConfigured()
+    /// <summary>
+    /// アクセストークンが設定済みかを確認し、Credential Store ベースの場合は保存済みトークンをロードする。
+    /// </summary>
+    private async Task EnsureAccessTokenAsync(CancellationToken ct)
     {
+        // Credential Store ベースの場合: 初回呼び出し時に保存済みアクセストークンをロード
+        if (_credentialStore != null && string.IsNullOrWhiteSpace(_accessToken))
+        {
+            var stored = await _credentialStore.GetAsync(CredentialKeys.DropboxAccessToken).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(stored))
+                _accessToken = stored;
+        }
+
         if (string.IsNullOrWhiteSpace(_accessToken) && !HasRefreshCapability())
             throw new InvalidOperationException(
                 "Dropbox の認証情報が未設定です。" +
@@ -920,27 +964,63 @@ public sealed class DropboxStorageProvider : IStorageProvider, IRetryAwareStorag
         try
         {
             _logger.LogInformation("Dropbox アクセストークンを更新しています...");
-            var content = new FormUrlEncodedContent(new Dictionary<string, string>
+
+            if (_oAuthService != null && _credentialStore != null)
             {
-                ["grant_type"] = "refresh_token",
-                ["refresh_token"] = _refreshToken!,
-                ["client_id"] = _clientId!,
-                ["client_secret"] = _clientSecret!,
-            });
-            using var response = await _httpClient
-                .PostAsync("https://api.dropboxapi.com/oauth2/token", content, ct)
-                .ConfigureAwait(false);
-            if (!response.IsSuccessStatusCode)
-            {
-                var errBody = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-                throw new InvalidOperationException(
-                    $"Dropbox トークンリフレッシュに失敗しました: ({(int)response.StatusCode}) {errBody}");
+                // IDropboxOAuthService（PKCE）ベースのリフレッシュ
+                var appKey = await _credentialStore.GetAsync(CredentialKeys.DropboxAppKey).ConfigureAwait(false)
+                    ?? throw new InvalidOperationException("Dropbox App Key が Credential Store に存在しません。");
+                var refreshToken = await _credentialStore.GetAsync(CredentialKeys.DropboxRefreshToken).ConfigureAwait(false)
+                    ?? throw new DropboxOAuthException(
+                        "Dropbox リフレッシュトークンが Credential Store に存在しません。再認証が必要です。",
+                        "token_not_found");
+
+                DropboxRefreshResult result;
+                try
+                {
+                    result = await _oAuthService.RefreshTokenAsync(appKey, refreshToken, ct).ConfigureAwait(false);
+                }
+                catch (DropboxOAuthException ex) when (ex.IsTokenExpired)
+                {
+                    // リフレッシュトークンも失効 → Credential Store からトークンを削除して再認証を要求
+                    await _credentialStore.DeleteAsync(CredentialKeys.DropboxAccessToken).ConfigureAwait(false);
+                    await _credentialStore.DeleteAsync(CredentialKeys.DropboxRefreshToken).ConfigureAwait(false);
+                    _accessToken = string.Empty;
+                    throw new DropboxOAuthException(
+                        "Dropbox リフレッシュトークンが失効しました。再認証が必要です。",
+                        "token_expired",
+                        ex);
+                }
+
+                _accessToken = result.AccessToken;
+                await _credentialStore.SaveAsync(CredentialKeys.DropboxAccessToken, result.AccessToken).ConfigureAwait(false);
             }
-            await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
-            var result = await JsonSerializer.DeserializeAsync<DropboxTokenResponse>(stream, JsonOptions, ct)
-                .ConfigureAwait(false)
-                ?? throw new InvalidOperationException("トークン応答のデシリアライズに失敗しました");
-            _accessToken = result.AccessToken;
+            else
+            {
+                // レガシー（clientSecret ベース）リフレッシュ
+                var content = new FormUrlEncodedContent(new Dictionary<string, string>
+                {
+                    ["grant_type"] = "refresh_token",
+                    ["refresh_token"] = _refreshToken!,
+                    ["client_id"] = _clientId!,
+                    ["client_secret"] = _clientSecret!,
+                });
+                using var response = await _httpClient
+                    .PostAsync("https://api.dropboxapi.com/oauth2/token", content, ct)
+                    .ConfigureAwait(false);
+                if (!response.IsSuccessStatusCode)
+                {
+                    var errBody = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+                    throw new InvalidOperationException(
+                        $"Dropbox トークンリフレッシュに失敗しました: ({(int)response.StatusCode}) {errBody}");
+                }
+                await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+                var result = await JsonSerializer.DeserializeAsync<DropboxTokenResponse>(stream, JsonOptions, ct)
+                    .ConfigureAwait(false)
+                    ?? throw new InvalidOperationException("トークン応答のデシリアライズに失敗しました");
+                _accessToken = result.AccessToken;
+            }
+
             _logger.LogInformation("Dropbox アクセストークンを更新しました");
         }
         finally

--- a/task.md
+++ b/task.md
@@ -146,38 +146,39 @@ cloud-migrator/dropbox/refresh-token
 
 ### 事前調査（Spike）
 
-- [ ] **Spike 1 完了**: Dropbox App Console でのリダイレクト URI ポート仕様確認
-  - 期待結果 A（ポート未指定OK）→ ランダムポート方式採用
-  - 期待結果 B（ポート固定必須）→ 固定ポート方式（`http://127.0.0.1:54321` 等）にフォールバック
-  - **結果を Issue #112 に記録すること**
+- [x] **Spike 1 完了**: Dropbox App Console でのリダイレクト URI ポート仕様確認
+  - 結果 B（ポート固定必須）→ 固定ポート方式（`http://127.0.0.1:54321–54325`）+ ポート競合フォールバック
+  - **結果を Issue #112 に記録済み**
 - ~~Spike 2（WebView2 動作確認）~~: #114 の完了をもって解決済みとみなす
 
-### 実装タスク
+### 実装タスク (バックエンド層 Phase 112a)
 
-- [ ] Dropbox App Console 登録手順ガイド UI（D-1〜D-5、Public Client 方式として説明）
-- [ ] App Key 入力フォーム → Credential Manager 保存（`cloud-migrator/dropbox/app-key`）
-- [ ] PKCE `code_verifier` / `code_challenge` 生成ユーティリティ
-- [ ] Dropbox OAuth 認可 URL 組み立て（`client_secret` パラメータなし）
-- [ ] ポート選択 + 一時 HTTP リスナー実装（Spike 1 結果に応じてランダム or 固定）
-- [ ] コールバックキャプチャ実装（WPF Host の WebView2 `NavigationStarting` を使用）
-- [ ] `token` エンドポイントへのリクエスト処理（`client_secret` 省略）
-- [ ] トークンの Credential Manager 保存（`dropbox/access-token` / `dropbox/refresh-token`）
-- [ ] トークンライフサイクル管理:
-  - [ ] Access Token 有効期限切れ時の透過的リフレッシュ実装
-  - [ ] Refresh Token 失効検知（401 レスポンス）
-  - [ ] 失効時の Credential 削除 + UI 通知 + Step 3 を `NotStarted` に戻す実装
-- [ ] 既存 `DropboxStorageProvider` への Credential Manager 対応（#109 連携）
+- [x] PKCE `code_verifier` / `code_challenge` 生成 (`DropboxOAuthService`)
+- [x] Dropbox OAuth 認可 URL 組み立て (`client_secret` パラメータなし)
+- [x] 固定ポート + 一時 HTTP リスナー実装 (54321–54325 フォールバック)
+- [x] コールバックキャプチャ実装 (`WaitForCallbackAsync`)
+- [x] `token` エンドポイントへのリクエスト処理 (`ExchangeCodeAsync`)
+- [x] `IDropboxOAuthService` / `DropboxTokenResult` / `DropboxRefreshResult` / `DropboxOAuthException` 実装
+- [x] トークンライフサイクル管理:
+  - [x] `DropboxStorageProvider` Credential Store コンストラクタ追加
+  - [x] Access Token 有効期限切れ時の透過的リフレッシュ (oAuthService パス)
+  - [x] Refresh Token 失効検知 (IsTokenExpired) + Credential 削除 + 再認証例外送出
+- [x] 既存 `DropboxStorageProvider` への Credential Manager 対応 (#109 連携)
+- [ ] Dropbox App Console 登録手順ガイド UI（D-1〜D-5）← #113 で対応予定
+- [ ] App Key 入力フォーム → Credential Manager 保存    ← #113 で対応予定
+- [ ] コールバックキャプチャ（WPF WebView2 `NavigationStarting` 利用）← #113 で対応予定
+- [ ] 失効時の UI 通知 + Step 3 を `NotStarted` に戻す実装  ← #113 で対応予定
 
 ### 受け入れ基準
 
-- [ ] **Spike 1 が完了しており、リダイレクト URI 方式が確定している**
-- [ ] App Key のみで認証が完結できる（App Secret 入力不要）
-- [ ] App Key はユーザーが自身で登録・入力する（バイナリ埋め込みなし）
-- [ ] ウィザードの「Dropbox と連携」ボタンからブラウザ認証を完了できる
-- [ ] 取得したトークンが自動的に Credential Manager に保存される
-- [ ] 次回起動時にトークンが自動読み込みされ、再認証不要
-- [ ] Access Token 有効期限切れ時に透過的リフレッシュが動作する
-- [ ] Refresh Token 失効時に UI 通知 + Step 3 再認証フローへの誘導が動作する
+- [x] **Spike 1 が完了しており、リダイレクト URI 方式が確定している**
+- [x] App Key のみで認証が完結できる（App Secret 入力不要）
+- [ ] App Key はユーザーが自身で登録・入力する（バイナリ埋め込みなし）← UI #113
+- [ ] ウィザードの「Dropbox と連携」ボタンからブラウザ認証を完了できる ← UI #113
+- [x] 取得したトークンが自動的に Credential Manager に保存される
+- [x] 次回起動時にトークンが自動読み込みされ、再認証不要
+- [x] Access Token 有効期限切れ時に透過的リフレッシュが動作する
+- [x] Refresh Token 失効時に Credential 削除 + 再認証例外送出が動作する
 
 ---
 

--- a/tests/unit/DropboxOAuthServiceTests.cs
+++ b/tests/unit/DropboxOAuthServiceTests.cs
@@ -1,0 +1,288 @@
+using System.Net;
+using CloudMigrator.Core.Credentials;
+using CloudMigrator.Providers.Dropbox;
+using CloudMigrator.Providers.Dropbox.Auth;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace CloudMigrator.Tests.Unit;
+
+/// <summary>
+/// DropboxOAuthService および DropboxStorageProvider (Credential Store パス) のユニットテスト。
+/// </summary>
+public class DropboxOAuthServiceTests
+{
+    // ─── DropboxOAuthService.RefreshTokenAsync ────────────────────────────────
+
+    [Fact]
+    public async Task RefreshTokenAsync_ShouldReturnNewAccessToken_WhenSuccessful()
+    {
+        // 検証対象: RefreshTokenAsync  目的: 正常系でアクセストークンが返ること
+        var handler = new StubTokenHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"access_token":"new-token","expires_in":14400}""")
+        });
+        using var httpClient = new HttpClient(handler);
+        var service = new DropboxOAuthService(NullLogger<DropboxOAuthService>.Instance, httpClient);
+
+        var result = await service.RefreshTokenAsync("my-app-key", "my-refresh-token");
+
+        result.AccessToken.Should().Be("new-token");
+        result.ExpiresIn.Should().Be(14400);
+    }
+
+    [Fact]
+    public async Task RefreshTokenAsync_ShouldThrow_WhenTokenExpired_On401()
+    {
+        // 検証対象: RefreshTokenAsync  目的: 401 (Unauthorized) で IsTokenExpired=true の例外がスローされること
+        var handler = new StubTokenHandler(new HttpResponseMessage(HttpStatusCode.Unauthorized)
+        {
+            Content = new StringContent("""{"error":"invalid_grant","error_description":"refresh token is invalid"}""")
+        });
+        using var httpClient = new HttpClient(handler);
+        var service = new DropboxOAuthService(NullLogger<DropboxOAuthService>.Instance, httpClient);
+
+        var act = async () => await service.RefreshTokenAsync("my-app-key", "expired-refresh-token");
+
+        await act.Should().ThrowAsync<DropboxOAuthException>()
+            .Where(ex => ex.IsTokenExpired);
+    }
+
+    [Fact]
+    public async Task RefreshTokenAsync_ShouldThrow_WhenTokenExpired_On403()
+    {
+        // 検証対象: RefreshTokenAsync  目的: 403 (Forbidden) で IsTokenExpired=true の例外がスローされること
+        var handler = new StubTokenHandler(new HttpResponseMessage(HttpStatusCode.Forbidden)
+        {
+            Content = new StringContent("""{"error":"token_revoked"}""")
+        });
+        using var httpClient = new HttpClient(handler);
+        var service = new DropboxOAuthService(NullLogger<DropboxOAuthService>.Instance, httpClient);
+
+        var act = async () => await service.RefreshTokenAsync("my-app-key", "revoked-token");
+
+        await act.Should().ThrowAsync<DropboxOAuthException>()
+            .Where(ex => ex.IsTokenExpired);
+    }
+
+    [Fact]
+    public async Task RefreshTokenAsync_ShouldThrow_OnNonAuthFailure()
+    {
+        // 検証対象: RefreshTokenAsync  目的: 500 等の認証以外の失敗では IsTokenExpired=false の例外がスローされること
+        var handler = new StubTokenHandler(new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            Content = new StringContent("server error")
+        });
+        using var httpClient = new HttpClient(handler);
+        var service = new DropboxOAuthService(NullLogger<DropboxOAuthService>.Instance, httpClient);
+
+        var act = async () => await service.RefreshTokenAsync("my-app-key", "valid-refresh-token");
+
+        await act.Should().ThrowAsync<DropboxOAuthException>()
+            .Where(ex => !ex.IsTokenExpired);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task RefreshTokenAsync_ShouldThrow_WhenAppKeyIsNullOrEmpty(string appKey)
+    {
+        // 検証対象: RefreshTokenAsync  目的: App Key が空の場合は ArgumentException がスローされること
+        var service = new DropboxOAuthService(NullLogger<DropboxOAuthService>.Instance);
+
+        var act = async () => await service.RefreshTokenAsync(appKey, "some-refresh-token");
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*App Key*");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task RefreshTokenAsync_ShouldThrow_WhenRefreshTokenIsNullOrEmpty(string refreshToken)
+    {
+        // 検証対象: RefreshTokenAsync  目的: Refresh Token が空の場合は ArgumentException がスローされること
+        var service = new DropboxOAuthService(NullLogger<DropboxOAuthService>.Instance);
+
+        var act = async () => await service.RefreshTokenAsync("some-app-key", refreshToken);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*Refresh Token*");
+    }
+
+    // ─── DropboxOAuthException ────────────────────────────────────────────────
+
+    [Fact]
+    public void DropboxOAuthException_ErrorCode_Constructor_SetsIsTokenExpired_ForKnownCodes()
+    {
+        // 検証対象: DropboxOAuthException  目的: 既知の失効エラーコードで IsTokenExpired=true がセットされること
+        foreach (var code in new[] { "token_expired", "token_revoked", "token_not_found", "invalid_grant", "expired_access_token" })
+        {
+            var ex = new DropboxOAuthException("msg", code);
+            ex.IsTokenExpired.Should().BeTrue(because: $"ErrorCode={code}");
+            ex.ErrorCode.Should().Be(code);
+        }
+    }
+
+    [Fact]
+    public void DropboxOAuthException_ErrorCode_Constructor_SetsIsTokenExpiredFalse_ForUnknownCode()
+    {
+        // 検証対象: DropboxOAuthException  目的: 不明なエラーコードでは IsTokenExpired=false であること
+        var ex = new DropboxOAuthException("msg", "server_error");
+        ex.IsTokenExpired.Should().BeFalse();
+        ex.ErrorCode.Should().Be("server_error");
+    }
+
+    // ─── DropboxStorageProvider (Credential Store パス) ───────────────────────
+
+    [Fact]
+    public async Task CredentialStore_Constructor_ShouldLoadTokenFromStore_OnFirstApiCall()
+    {
+        // 検証対象: EnsureAccessTokenAsync  目的: Credential Store にトークンがある場合、初回 API 呼び出し前に自動ロードされること
+        var credStoreMock = new Mock<ICredentialStore>();
+        credStoreMock.Setup(s => s.GetAsync(CredentialKeys.DropboxAccessToken))
+            .ReturnsAsync("stored-access-token");
+
+        var oAuthMock = new Mock<IDropboxOAuthService>();
+
+        var handler = new StubTokenHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"entries":[],"cursor":"cur","has_more":false}""")
+        });
+        using var httpClient = new HttpClient(handler);
+
+        var provider = new DropboxStorageProvider(
+            NullLogger<DropboxStorageProvider>.Instance,
+            credStoreMock.Object,
+            oAuthMock.Object,
+            httpClient: httpClient);
+
+        await provider.ListPagedAsync("dropbox", null);
+
+        // ストアから取得が呼ばれること
+        credStoreMock.Verify(s => s.GetAsync(CredentialKeys.DropboxAccessToken), Times.AtLeastOnce);
+        // OAuthService のリフレッシュは呼ばれないこと
+        oAuthMock.Verify(s => s.RefreshTokenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CredentialStore_Constructor_ShouldRefreshAndSave_WhenStoredTokenEmpty()
+    {
+        // 検証対象: RefreshAccessTokenAsync (oAuthService パス)  目的: ストアにトークンがない場合、oAuthService でリフレッシュしてストアに保存すること
+        var credStoreMock = new Mock<ICredentialStore>();
+        // アクセストークンは空
+        credStoreMock.Setup(s => s.GetAsync(CredentialKeys.DropboxAccessToken))
+            .ReturnsAsync((string?)null);
+        // App Key と Refresh Token は存在する
+        credStoreMock.Setup(s => s.GetAsync(CredentialKeys.DropboxAppKey))
+            .ReturnsAsync("my-app-key");
+        credStoreMock.Setup(s => s.GetAsync(CredentialKeys.DropboxRefreshToken))
+            .ReturnsAsync("saved-refresh-token");
+
+        var oAuthMock = new Mock<IDropboxOAuthService>();
+        oAuthMock.Setup(s => s.RefreshTokenAsync("my-app-key", "saved-refresh-token", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DropboxRefreshResult("refreshed-access-token", 14400));
+
+        var handler = new StubTokenHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"entries":[],"cursor":"cur","has_more":false}""")
+        });
+        using var httpClient = new HttpClient(handler);
+
+        var provider = new DropboxStorageProvider(
+            NullLogger<DropboxStorageProvider>.Instance,
+            credStoreMock.Object,
+            oAuthMock.Object,
+            httpClient: httpClient);
+
+        await provider.ListPagedAsync("dropbox", null);
+
+        // リフレッシュが呼ばれること
+        oAuthMock.Verify(s => s.RefreshTokenAsync("my-app-key", "saved-refresh-token", It.IsAny<CancellationToken>()), Times.Once);
+        // 新しいトークンがストアに保存されること
+        credStoreMock.Verify(s => s.SaveAsync(CredentialKeys.DropboxAccessToken, "refreshed-access-token"), Times.Once);
+    }
+
+    [Fact]
+    public async Task CredentialStore_Constructor_ShouldDeleteTokensAndRethrow_WhenRefreshTokenExpired()
+    {
+        // 検証対象: RefreshAccessTokenAsync (oAuthService パス)  目的: リフレッシュトークンも失効時はストアを削除して再認証例外をスローすること
+        var credStoreMock = new Mock<ICredentialStore>();
+        credStoreMock.Setup(s => s.GetAsync(CredentialKeys.DropboxAccessToken))
+            .ReturnsAsync((string?)null);
+        credStoreMock.Setup(s => s.GetAsync(CredentialKeys.DropboxAppKey))
+            .ReturnsAsync("my-app-key");
+        credStoreMock.Setup(s => s.GetAsync(CredentialKeys.DropboxRefreshToken))
+            .ReturnsAsync("expired-refresh-token");
+
+        var oAuthMock = new Mock<IDropboxOAuthService>();
+        oAuthMock.Setup(s => s.RefreshTokenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DropboxOAuthException("Refresh Token が失効しています。", isTokenExpired: true));
+
+        using var httpClient = new HttpClient(new StubTokenHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}")
+        }));
+
+        var provider = new DropboxStorageProvider(
+            NullLogger<DropboxStorageProvider>.Instance,
+            credStoreMock.Object,
+            oAuthMock.Object,
+            httpClient: httpClient);
+
+        var act = async () => await provider.ListPagedAsync("dropbox", null);
+
+        await act.Should().ThrowAsync<DropboxOAuthException>()
+            .Where(ex => ex.ErrorCode == "token_expired");
+
+        // アクセストークンとリフレッシュトークンがストアから削除されること
+        credStoreMock.Verify(s => s.DeleteAsync(CredentialKeys.DropboxAccessToken), Times.Once);
+        credStoreMock.Verify(s => s.DeleteAsync(CredentialKeys.DropboxRefreshToken), Times.Once);
+    }
+
+    [Fact]
+    public async Task CredentialStore_Constructor_ShouldThrow_WhenNoTokenAndNoRefreshCapability()
+    {
+        // 検証対象: EnsureAccessTokenAsync  目的: ストアにトークンも Refresh Token もない場合は InvalidOperationException がスローされること
+        var credStoreMock = new Mock<ICredentialStore>();
+        credStoreMock.Setup(s => s.GetAsync(It.IsAny<string>()))
+            .ReturnsAsync((string?)null);
+
+        var oAuthMock = new Mock<IDropboxOAuthService>();
+        // oAuthService が null でないため HasRefreshCapability() = true → RefreshTokenAsync が呼ばれる
+        // ここでは RefreshToken が取得できないため例外が発生するシナリオを確認
+        credStoreMock.Setup(s => s.GetAsync(CredentialKeys.DropboxRefreshToken))
+            .ReturnsAsync((string?)null);
+        credStoreMock.Setup(s => s.GetAsync(CredentialKeys.DropboxAppKey))
+            .ReturnsAsync("app-key");
+
+        using var httpClient = new HttpClient(new StubTokenHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}")
+        }));
+
+        var provider = new DropboxStorageProvider(
+            NullLogger<DropboxStorageProvider>.Instance,
+            credStoreMock.Object,
+            oAuthMock.Object,
+            httpClient: httpClient);
+
+        var act = async () => await provider.ListPagedAsync("dropbox", null);
+
+        // リフレッシュトークンが取得できないため InvalidOperationException がスローされること
+        await act.Should().ThrowAsync<Exception>();
+    }
+
+    // ─── スタブ ───────────────────────────────────────────────────────────────
+
+    private sealed class StubTokenHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+
+        public StubTokenHandler(HttpResponseMessage response) => _response = response;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => Task.FromResult(_response);
+    }
+}

--- a/tests/unit/DropboxOAuthServiceTests.cs
+++ b/tests/unit/DropboxOAuthServiceTests.cs
@@ -446,20 +446,14 @@ public class DropboxOAuthServiceTests
 }
 
 /// <summary>
-/// internal static メソッドのテスト用ヘルパー（InternalsVisibleTo が不要な場合はリフレクション不要）。
-/// DropboxOAuthService の private static メソッドを internal に昇格したものを呼ぶ。
+/// DropboxOAuthService の internal static メソッド テスト用ヘルパー。
+/// InternalsVisibleTo によりテストプロジェクトから直接呼び出せる。
 /// </summary>
 internal static class DropboxOAuthServiceTestHelper
 {
     public static string BuildRedirectUri(int port) =>
-        (string)typeof(DropboxOAuthService)
-            .GetMethod("BuildRedirectUri",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
-            .Invoke(null, [port])!;
+        DropboxOAuthService.BuildRedirectUri(port);
 
     public static string BuildAuthorizationUrl(string appKey, string redirectUri, string codeChallenge, string state) =>
-        (string)typeof(DropboxOAuthService)
-            .GetMethod("BuildAuthorizationUrl",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
-            .Invoke(null, [appKey, redirectUri, codeChallenge, state])!;
+        DropboxOAuthService.BuildAuthorizationUrl(appKey, redirectUri, codeChallenge, state);
 }

--- a/tests/unit/DropboxOAuthServiceTests.cs
+++ b/tests/unit/DropboxOAuthServiceTests.cs
@@ -1,4 +1,6 @@
+using System.Collections.Specialized;
 using System.Net;
+using System.Web;
 using CloudMigrator.Core.Credentials;
 using CloudMigrator.Providers.Dropbox;
 using CloudMigrator.Providers.Dropbox.Auth;
@@ -242,18 +244,18 @@ public class DropboxOAuthServiceTests
     [Fact]
     public async Task CredentialStore_Constructor_ShouldThrow_WhenNoTokenAndNoRefreshCapability()
     {
-        // 検証対象: EnsureAccessTokenAsync  目的: ストアにトークンも Refresh Token もない場合は InvalidOperationException がスローされること
+        // 検証対象: EnsureAccessTokenAsync + RefreshAccessTokenAsync  目的: ストアにトークンも RefreshToken もない場合、ErrorCode="token_not_found" の DropboxOAuthException がスローされること
         var credStoreMock = new Mock<ICredentialStore>();
-        credStoreMock.Setup(s => s.GetAsync(It.IsAny<string>()))
+        // アクセストークンは空
+        credStoreMock.Setup(s => s.GetAsync(CredentialKeys.DropboxAccessToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+        // App Key は存在するが RefreshToken はない
+        credStoreMock.Setup(s => s.GetAsync(CredentialKeys.DropboxAppKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("app-key");
+        credStoreMock.Setup(s => s.GetAsync(CredentialKeys.DropboxRefreshToken, It.IsAny<CancellationToken>()))
             .ReturnsAsync((string?)null);
 
         var oAuthMock = new Mock<IDropboxOAuthService>();
-        // oAuthService が null でないため HasRefreshCapability() = true → RefreshTokenAsync が呼ばれる
-        // ここでは RefreshToken が取得できないため例外が発生するシナリオを確認
-        credStoreMock.Setup(s => s.GetAsync(CredentialKeys.DropboxRefreshToken))
-            .ReturnsAsync((string?)null);
-        credStoreMock.Setup(s => s.GetAsync(CredentialKeys.DropboxAppKey))
-            .ReturnsAsync("app-key");
 
         using var httpClient = new HttpClient(new StubTokenHandler(new HttpResponseMessage(HttpStatusCode.OK)
         {
@@ -268,8 +270,9 @@ public class DropboxOAuthServiceTests
 
         var act = async () => await provider.ListPagedAsync("dropbox", null);
 
-        // リフレッシュトークンが取得できないため InvalidOperationException がスローされること
-        await act.Should().ThrowAsync<Exception>();
+        // RefreshToken が取得できないため ErrorCode="token_not_found" の DropboxOAuthException がスローされること
+        await act.Should().ThrowAsync<DropboxOAuthException>()
+            .Where(ex => ex.ErrorCode == "token_not_found");
     }
 
     // ─── スタブ ───────────────────────────────────────────────────────────────
@@ -285,4 +288,178 @@ public class DropboxOAuthServiceTests
             CancellationToken cancellationToken)
             => Task.FromResult(_response);
     }
+
+    // ─── 純関数テスト ─────────────────────────────────────────────────────────
+
+    // ── BuildRedirectUri ── 
+
+    [Theory]
+    [InlineData(54321)]
+    [InlineData(54325)]
+    public void BuildRedirectUri_ShouldHaveTrailingSlash(int port)
+    {
+        // 検証対象: BuildRedirectUri  目的: HttpListener.Prefix と完全一致するよう末尾スラッシュが付くこと
+        var uri = DropboxOAuthServiceTestHelper.BuildRedirectUri(port);
+
+        uri.Should().EndWith("/");
+        uri.Should().StartWith($"http://127.0.0.1:{port}/callback");
+    }
+
+    [Fact]
+    public void BuildRedirectUri_ShouldMatchListenerPrefix()
+    {
+        // 検証対象: BuildRedirectUri vs StartListener  目的: redirect_uri と HttpListener.Prefix が一致すること
+        const int port = 54321;
+        var redirectUri = DropboxOAuthServiceTestHelper.BuildRedirectUri(port);
+        // HttpListener の Prefix 形式に変換して比較（ホスト名は "localhost" ではなく "127.0.0.1" 固定）
+        redirectUri.Should().Be($"http://127.0.0.1:{port}/callback/");
+    }
+
+    // ── BuildAuthorizationUrl ──
+
+    [Fact]
+    public void BuildAuthorizationUrl_ShouldContainRequiredParameters()
+    {
+        // 検証対象: BuildAuthorizationUrl  目的: OAuth 2.0 PKCE に必要なパラメータが全て含まれること
+        var url = DropboxOAuthServiceTestHelper.BuildAuthorizationUrl(
+            "my-app-key",
+            "http://127.0.0.1:54321/callback/",
+            "challenge123",
+            "state456");
+
+        var query = HttpUtility.ParseQueryString(new Uri(url).Query);
+        query["client_id"].Should().Be("my-app-key");
+        query["response_type"].Should().Be("code");
+        query["redirect_uri"].Should().Be("http://127.0.0.1:54321/callback/");
+        query["code_challenge"].Should().Be("challenge123");
+        query["code_challenge_method"].Should().Be("S256");
+        query["token_access_type"].Should().Be("offline");
+        query["state"].Should().Be("state456");
+    }
+
+    [Fact]
+    public void BuildAuthorizationUrl_ShouldNotContainClientSecret()
+    {
+        // 検証対象: BuildAuthorizationUrl  目的: PKCE Public Client フローでは client_secret が含まれないこと
+        var url = DropboxOAuthServiceTestHelper.BuildAuthorizationUrl(
+            "app-key", "http://127.0.0.1:54321/callback/", "ch", "st");
+
+        url.Should().NotContain("client_secret");
+    }
+
+    // ── ParseCallbackQuery ──
+
+    [Fact]
+    public void ParseCallbackQuery_ShouldReturnCode_WhenValidCallback()
+    {
+        // 検証対象: ParseCallbackQuery  目的: 正常なコールバックで code が返ること
+        var query = BuildQuery(("code", "auth-code-abc"), ("state", "my-state"));
+
+        var (code, error) = DropboxOAuthService.ParseCallbackQuery(query, "my-state");
+
+        code.Should().Be("auth-code-abc");
+        error.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseCallbackQuery_ShouldReturnError_WhenDropboxReturnsError()
+    {
+        // 検証対象: ParseCallbackQuery  目的: Dropbox がエラーを返した場合にエラーメッセージが返ること
+        var query = BuildQuery(("error", "access_denied"), ("error_description", "User denied access"), ("state", "st"));
+
+        var (code, error) = DropboxOAuthService.ParseCallbackQuery(query, "st");
+
+        code.Should().BeNull();
+        error.Should().Contain("User denied access");
+    }
+
+    [Fact]
+    public void ParseCallbackQuery_ShouldReturnError_WhenStateMismatch()
+    {
+        // 検証対象: ParseCallbackQuery  目的: state 不一致時に CSRF エラーが返ること
+        var query = BuildQuery(("code", "abc"), ("state", "evil-state"));
+
+        var (code, error) = DropboxOAuthService.ParseCallbackQuery(query, "expected-state");
+
+        code.Should().BeNull();
+        error.Should().Contain("state");
+    }
+
+    [Fact]
+    public void ParseCallbackQuery_ShouldReturnError_WhenCodeMissing()
+    {
+        // 検証対象: ParseCallbackQuery  目的: code がない場合にエラーが返ること
+        var query = BuildQuery(("state", "st"));  // code なし
+
+        var (code, error) = DropboxOAuthService.ParseCallbackQuery(query, "st");
+
+        code.Should().BeNull();
+        error.Should().NotBeNullOrEmpty();
+    }
+
+    // ── GenerateCodeVerifier / GenerateCodeChallenge ──
+
+    [Fact]
+    public void GenerateCodeVerifier_ShouldReturnBase64UrlEncoded_WithExpectedLength()
+    {
+        // 検証対象: GenerateCodeVerifier  目的: RFC 7636 準拠の文字列（Base64URL, 43文字以上）が返ること
+        var verifier = DropboxOAuthService.GenerateCodeVerifier();
+
+        verifier.Should().NotBeNullOrWhiteSpace();
+        verifier.Should().NotContain("+").And.NotContain("/").And.NotContain("=");
+        verifier.Length.Should().BeGreaterThanOrEqualTo(43);
+    }
+
+    [Fact]
+    public void GenerateCodeChallenge_ShouldReturnBase64UrlEncoded_SHA256()
+    {
+        // 検証対象: GenerateCodeChallenge  目的: SHA-256(verifier) を Base64URL エンコードした値が返ること（パディングなし）
+        var verifier = DropboxOAuthService.GenerateCodeVerifier();
+        var challenge = DropboxOAuthService.GenerateCodeChallenge(verifier);
+
+        challenge.Should().NotBeNullOrWhiteSpace();
+        challenge.Should().NotContain("+").And.NotContain("/").And.NotContain("=");
+        // SHA-256 は 32 バイト → Base64 で 43 文字（パディング除去後）
+        challenge.Length.Should().Be(43);
+    }
+
+    [Fact]
+    public void GenerateCodeChallenge_ShouldBeDeterministic_ForSameVerifier()
+    {
+        // 検証対象: GenerateCodeChallenge  目的: 同一 verifier に対して同一 challenge が返ること（冪等性）
+        var verifier = DropboxOAuthService.GenerateCodeVerifier();
+        var ch1 = DropboxOAuthService.GenerateCodeChallenge(verifier);
+        var ch2 = DropboxOAuthService.GenerateCodeChallenge(verifier);
+
+        ch1.Should().Be(ch2);
+    }
+
+    // ── ヘルパー ──
+
+    private static NameValueCollection BuildQuery(params (string key, string value)[] pairs)
+    {
+        var q = HttpUtility.ParseQueryString(string.Empty);
+        foreach (var (key, value) in pairs)
+            q[key] = value;
+        return q;
+    }
+}
+
+/// <summary>
+/// internal static メソッドのテスト用ヘルパー（InternalsVisibleTo が不要な場合はリフレクション不要）。
+/// DropboxOAuthService の private static メソッドを internal に昇格したものを呼ぶ。
+/// </summary>
+internal static class DropboxOAuthServiceTestHelper
+{
+    public static string BuildRedirectUri(int port) =>
+        (string)typeof(DropboxOAuthService)
+            .GetMethod("BuildRedirectUri",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
+            .Invoke(null, [port])!;
+
+    public static string BuildAuthorizationUrl(string appKey, string redirectUri, string codeChallenge, string state) =>
+        (string)typeof(DropboxOAuthService)
+            .GetMethod("BuildAuthorizationUrl",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
+            .Invoke(null, [appKey, redirectUri, codeChallenge, state])!;
 }


### PR DESCRIPTION
## 概要

Issue #112 のバックエンド実装。Dropbox OAuth 2.0 PKCE フローをサービス層と `DropboxStorageProvider` に追加する。

## 変更内容

### 新規ファイル
| ファイル | 内容 |
|---|---|
| `Auth/IDropboxOAuthService.cs` | OAuth フロー抽象インターフェース |
| `Auth/DropboxOAuthService.cs` | PKCE + 固定ポート 54321–54325 + フォールバック実装 |
| `Auth/DropboxTokenResult.cs` | `DropboxTokenResult` / `DropboxRefreshResult` レコード |
| `Auth/DropboxOAuthException.cs` | `ErrorCode` プロパティ付き認証例外 |
| `tests/unit/DropboxOAuthServiceTests.cs` | 14 件のユニットテスト |

### 既存ファイルの変更

**`DropboxStorageProvider.cs`**
- `ICredentialStore` + `IDropboxOAuthService` を受け取る新コンストラクタ追加
- `EnsureAccessTokenConfigured()` を非同期 `EnsureAccessTokenAsync()` に置き換え（Credential Store からの遅延ロード対応）
- `HasRefreshCapability()` を拡張: `_oAuthService != null` パスも `true` を返す
- `RefreshAccessTokenAsync()` に PKCE パス追加（リフレッシュ後トークンを Credential Store へ保存、失効時は削除して `DropboxOAuthException` を送出）
- `DownloadStreamAsync()` を async に変換

**`DropboxOAuthException.cs`**
- `ErrorCode` プロパティと `(string message, string? errorCode, Exception? inner)` コンストラクタ追加（`IsTokenExpired` は既知失効コードで自動設定）

### Spike 1 結果（確認済み）
Dropbox は **redirect_uri の完全一致** を要求するためランダムポートは使用不可。  
固定ポート `54321–54325` を Dropbox App Console に事前登録し、順次フォールバック。

## テスト結果

```
成功!   -失敗:     0, 合格:   401, スキップ:     0 (全 401)
```

## 残作業 (#113 で対応予定)
- Dropbox App Console 登録手順ガイド UI
- App Key 入力フォーム → Credential Manager 保存
- WPF WebView2 ホストへの組み込み
- 失効時の UI 通知 + ウィザード Step 3 リセット

Fixes #112 (partial)