### PR TITLE
fix: 起動テストで発見したバグ修正5件

### DIFF
--- a/src/CloudMigrator.Core/Credentials/WindowsCredentialStore.cs
+++ b/src/CloudMigrator.Core/Credentials/WindowsCredentialStore.cs
@@ -78,8 +78,13 @@ public sealed class WindowsCredentialStore : ICredentialStore
             var bytes = new byte[cred.CredentialBlobSize];
             Marshal.Copy(cred.CredentialBlob, bytes, 0, bytes.Length);
 
-            // UTF-8 でデコード（SaveAsync と対称）
-            var value = Encoding.UTF8.GetString(bytes).TrimEnd('\0');
+            // UTF-8 でデコードを試みる（SaveAsync の新方式）。
+            // 旧バージョンは Encoding.Unicode（UTF-16LE）で保存していたため、
+            // UTF-8 デコード結果に \0 が含まれる場合は UTF-16LE へフォールバックする。
+            var utf8Decoded = Encoding.UTF8.GetString(bytes);
+            var value = utf8Decoded.Contains('\0')
+                ? Encoding.Unicode.GetString(bytes).TrimEnd('\0')
+                : utf8Decoded;
             return Task.FromResult<string?>(string.IsNullOrEmpty(value) ? null : value);
         }
         finally

--- a/src/CloudMigrator.Core/Credentials/WindowsCredentialStore.cs
+++ b/src/CloudMigrator.Core/Credentials/WindowsCredentialStore.cs
@@ -78,7 +78,8 @@ public sealed class WindowsCredentialStore : ICredentialStore
             var bytes = new byte[cred.CredentialBlobSize];
             Marshal.Copy(cred.CredentialBlob, bytes, 0, bytes.Length);
 
-            var value = Encoding.Unicode.GetString(bytes).TrimEnd('\0');
+            // UTF-8 でデコード（SaveAsync と対称）
+            var value = Encoding.UTF8.GetString(bytes).TrimEnd('\0');
             return Task.FromResult<string?>(string.IsNullOrEmpty(value) ? null : value);
         }
         finally
@@ -94,7 +95,16 @@ public sealed class WindowsCredentialStore : ICredentialStore
         ArgumentNullException.ThrowIfNull(value);
         cancellationToken.ThrowIfCancellationRequested();
 
-        var blob = Encoding.Unicode.GetBytes(value);
+        // ASCII トークン等は UTF-8 (1 バイト/文字) でエンコードすることで
+        // CRED_TYPE_GENERIC のサイズ上限 (2560 バイト) 内に収める
+        var blob = Encoding.UTF8.GetBytes(value);
+
+        // CRED_TYPE_GENERIC の CredentialBlobSize 上限は 5 * 512 = 2560 バイト
+        const int MaxBlobSize = 2560;
+        if (blob.Length > MaxBlobSize)
+            throw new InvalidOperationException(
+                $"Credential Manager への書き込みに失敗しました: {key} の値が上限サイズ（{MaxBlobSize} バイト）を超えています（{blob.Length} バイト）。");
+
         var blobHandle = GCHandle.Alloc(blob, GCHandleType.Pinned);
         try
         {
@@ -105,7 +115,8 @@ public sealed class WindowsCredentialStore : ICredentialStore
                 CredentialBlobSize = (uint)blob.Length,
                 CredentialBlob = blobHandle.AddrOfPinnedObject(),
                 Persist = CRED_PERSIST_LOCAL_MACHINE,
-                UserName = Environment.UserName,
+                // CRED_TYPE_GENERIC では UserName は任意フィールド。
+                // 環境によってはユーザー名の内容が CredWrite を失敗させるため省略する。
             };
             if (!CredWrite(ref cred, 0))
             {

--- a/src/CloudMigrator.Dashboard/CloudMigrator.Dashboard.csproj
+++ b/src/CloudMigrator.Dashboard/CloudMigrator.Dashboard.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net10.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>

--- a/src/CloudMigrator.Dashboard/Components/DashboardApp.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardApp.razor
@@ -54,7 +54,7 @@ else
         </MudNavMenu>
     </MudDrawer>
 
-    <MudMainContent>
+    <MudMainContent Style="overflow-y: auto; height: calc(100vh - 64px);">
         <MudContainer MaxWidth="MaxWidth.ExtraLarge" Class="pa-4">
             @switch (_currentPage)
             {

--- a/src/CloudMigrator.Dashboard/Components/Wizard/DropboxOAuthPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/DropboxOAuthPage.razor
@@ -22,14 +22,20 @@
                     <MudText Typo="Typo.body2"><strong>D-1.</strong> <MudLink Href="https://www.dropbox.com/developers/apps" Target="_blank">Dropbox App Console</MudLink> を開く</MudText>
                     <MudText Typo="Typo.body2"><strong>D-2.</strong> 「Create app」→「Scoped access」→「Full Dropbox」を選択</MudText>
                     <MudText Typo="Typo.body2"><strong>D-3.</strong> アプリ名を入力して作成</MudText>
-                    <MudText Typo="Typo.body2"><strong>D-4.</strong> 「Permissions」タブで <code>files.content.write</code> / <code>files.content.read</code> にチェック →「Submit」</MudText>
+                    <MudText Typo="Typo.body2"><strong>D-4.</strong> 「Permissions」タブで以下にチェック →「Submit」:</MudText>
+                    <MudPaper Elevation="0" Class="pa-2" Style="background: var(--mud-palette-background-grey); font-family: monospace; font-size: 12px;">
+                        files.metadata.write<br />
+                        files.metadata.read<br />
+                        files.content.write<br />
+                        files.content.read
+                    </MudPaper>
                     <MudText Typo="Typo.body2"><strong>D-5.</strong> 「Settings」タブの「Redirect URIs」に以下を登録:</MudText>
                     <MudPaper Elevation="0" Class="pa-2" Style="background: var(--mud-palette-background-grey); font-family: monospace; font-size: 12px;">
-                        http://127.0.0.1:54321/callback<br />
-                        http://127.0.0.1:54322/callback<br />
-                        http://127.0.0.1:54323/callback<br />
-                        http://127.0.0.1:54324/callback<br />
-                        http://127.0.0.1:54325/callback
+                        http://127.0.0.1:54321/callback/<br />
+                        http://127.0.0.1:54322/callback/<br />
+                        http://127.0.0.1:54323/callback/<br />
+                        http://127.0.0.1:54324/callback/<br />
+                        http://127.0.0.1:54325/callback/
                     </MudPaper>
                     <MudText Typo="Typo.body2"><strong>D-6.</strong> 「App key」をコピーして下の入力欄に貼り付ける</MudText>
                 </MudStack>

--- a/src/CloudMigrator.Dashboard/Components/Wizard/WizardApp.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/WizardApp.razor
@@ -13,7 +13,7 @@
         </MudText>
     </MudAppBar>
 
-    <MudMainContent>
+    <MudMainContent Style="overflow-y: auto; height: calc(100vh - 64px);">
         @switch (_currentStep)
         {
             case WizardStep.Welcome:

--- a/tests/unit/CloudMigrator.Tests.Unit.csproj
+++ b/tests/unit/CloudMigrator.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## 概要

PR #121 (Phase 113 Wizard UI) マージ後の実機起動テストで発見したバグ修正。

## 修正内容

| # | ファイル | 問題 | 修正 |
|---|---------|------|------|
| 1 | `CloudMigrator.Dashboard.csproj` | TFM `net10.0-windows` では `Microsoft.Windows.SDK.NET` が解決されず起動クラッシュ | `net10.0-windows10.0.19041.0` に変更 |
| 2 | `WizardApp.razor` / `DashboardApp.razor` | ウィンドウを縮めるとボタンが見えなくなる | `MudMainContent` に `overflow-y:auto` + `height:calc(100vh-64px)` を追加 |
| 3 | `DropboxOAuthPage.razor` | ガイドの Redirect URI が末尾スラッシュなし (`/callback`) だが、コードは末尾スラッシュ付き (`/callback/`) を送信するため認証エラー | ガイドを `/callback/` に修正 |
| 4 | `DropboxOAuthPage.razor` | Permissions ガイドに `files.metadata.write` / `files.metadata.read` が案内されていなかった（`create_folder_v2` / `delete_v2` に必要） | 4 スコープすべてを案内するよう更新 |
| 5 | `WindowsCredentialStore.cs` | `CREDENTIAL.UserName` 設定が Win32 エラー 1783 を引き起こす / UTF-16 エンコードで Dropbox アクセストークン（2662 バイト）が上限 2560 バイトを超える | `UserName` を省略、エンコードを UTF-8 に変更（1331 バイトに削減） |

## テスト結果

- ユニットテスト: 427件 全成功
- 実機起動テスト: ウィザード表示 → Dropbox OAuth 認証 → 接続テスト すべて成功