### PR TITLE
feat: #111 OneDrive Drive ID Discovery（Step 2a）

### DIFF
--- a/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
@@ -45,6 +45,28 @@ public sealed record GraphConfigUpdateDto(
     string? ClientSecretExpiry = null);
 
 /// <summary>
+/// Discovery 結果 DTO（OneDrive Drive ID / SharePoint Site ID / Drive ID）。
+/// </summary>
+public sealed record DiscoveryConfigDto(
+    string OneDriveUserId,
+    string OneDriveDriveId,
+    string SharePointSiteId,
+    string SharePointDriveId,
+    string MigrationRoute,
+    string DestinationProvider);
+
+/// <summary>
+/// Discovery 結果マージ更新 DTO。null フィールドは上書きしない。
+/// </summary>
+public sealed record DiscoveryConfigUpdateDto(
+    string? OneDriveUserId = null,
+    string? OneDriveDriveId = null,
+    string? SharePointSiteId = null,
+    string? SharePointDriveId = null,
+    string? MigrationRoute = null,
+    string? DestinationProvider = null);
+
+/// <summary>
 /// config.json の読み書きを担当するサービス契約。
 /// </summary>
 public interface IConfigurationService
@@ -60,6 +82,12 @@ public interface IConfigurationService
 
     /// <summary>Graph プロバイダー設定をマージ保存する（null フィールドはスキップ）。</summary>
     Task UpdateGraphConfigAsync(GraphConfigUpdateDto update, CancellationToken ct = default);
+
+    /// <summary>Discovery 結果（OneDrive / SharePoint リソース識別子）を取得する。</summary>
+    Task<DiscoveryConfigDto> GetDiscoveryConfigAsync(CancellationToken ct = default);
+
+    /// <summary>Discovery 結果をマージ保存する（null フィールドはスキップ）。</summary>
+    Task UpdateDiscoveryConfigAsync(DiscoveryConfigUpdateDto update, CancellationToken ct = default);
 }
 
 /// <summary>
@@ -196,6 +224,81 @@ public sealed class ConfigurationService : IConfigurationService
             if (update.ClientId is not null) g["clientId"] = update.ClientId;
             if (update.TenantId is not null) g["tenantId"] = update.TenantId;
             if (update.ClientSecretExpiry is not null) g["clientSecretExpiry"] = update.ClientSecretExpiry;
+
+            var tmpPath = _configFilePath + ".tmp";
+            await using (var stream = new FileStream(tmpPath, FileMode.Create, FileAccess.Write, FileShare.None, 4096, useAsync: true))
+            await using (var writer = new Utf8JsonWriter(stream, WriteOptions))
+            {
+                root.WriteTo(writer);
+            }
+            File.Move(tmpPath, _configFilePath, overwrite: true);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<DiscoveryConfigDto> GetDiscoveryConfigAsync(CancellationToken ct = default)
+    {
+        if (!File.Exists(_configFilePath))
+            return new DiscoveryConfigDto(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, "sharepoint");
+
+        var json = await File.ReadAllTextAsync(_configFilePath, ct).ConfigureAwait(false);
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("migrator", out var m))
+                return new DiscoveryConfigDto(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, "sharepoint");
+
+            var g = m.TryGetProperty("graph", out var gProp) ? gProp : default;
+            var oneDriveUserId = g.ValueKind != JsonValueKind.Undefined ? GetString(g, "oneDriveUserId", string.Empty) : string.Empty;
+            var oneDriveDriveId = g.ValueKind != JsonValueKind.Undefined ? GetString(g, "oneDriveDriveId", string.Empty) : string.Empty;
+            var sharePointSiteId = g.ValueKind != JsonValueKind.Undefined ? GetString(g, "sharePointSiteId", string.Empty) : string.Empty;
+            var sharePointDriveId = g.ValueKind != JsonValueKind.Undefined ? GetString(g, "sharePointDriveId", string.Empty) : string.Empty;
+            var migrationRoute = GetString(m, "migrationRoute", string.Empty);
+            var destinationProvider = GetString(m, "destinationProvider", "sharepoint");
+
+            return new DiscoveryConfigDto(oneDriveUserId, oneDriveDriveId, sharePointSiteId, sharePointDriveId, migrationRoute, destinationProvider);
+        }
+        catch (JsonException)
+        {
+            return new DiscoveryConfigDto(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, "sharepoint");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task UpdateDiscoveryConfigAsync(DiscoveryConfigUpdateDto update, CancellationToken ct = default)
+    {
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var json = File.Exists(_configFilePath)
+                ? await File.ReadAllTextAsync(_configFilePath, ct).ConfigureAwait(false)
+                : "{}";
+            var root = JsonNode.Parse(json) ?? new JsonObject();
+
+            // migrator セクションを確保
+            if (root["migrator"] is not JsonObject m)
+            {
+                m = new JsonObject();
+                root["migrator"] = m;
+            }
+
+            // graph サブセクションを確保
+            if (m["graph"] is not JsonObject g)
+            {
+                g = new JsonObject();
+                m["graph"] = g;
+            }
+
+            if (update.OneDriveUserId is not null) g["oneDriveUserId"] = update.OneDriveUserId;
+            if (update.OneDriveDriveId is not null) g["oneDriveDriveId"] = update.OneDriveDriveId;
+            if (update.SharePointSiteId is not null) g["sharePointSiteId"] = update.SharePointSiteId;
+            if (update.SharePointDriveId is not null) g["sharePointDriveId"] = update.SharePointDriveId;
+            if (update.MigrationRoute is not null) m["migrationRoute"] = update.MigrationRoute;
+            if (update.DestinationProvider is not null) m["destinationProvider"] = update.DestinationProvider;
 
             var tmpPath = _configFilePath + ".tmp";
             await using (var stream = new FileStream(tmpPath, FileMode.Create, FileAccess.Write, FileShare.None, 4096, useAsync: true))

--- a/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
@@ -249,14 +249,14 @@ public sealed class ConfigurationService : IConfigurationService
         try
         {
             using var doc = JsonDocument.Parse(json);
-            if (!doc.RootElement.TryGetProperty("migrator", out var m))
+            if (!doc.RootElement.TryGetProperty("migrator", out var m) || m.ValueKind != JsonValueKind.Object)
                 return new DiscoveryConfigDto(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, "sharepoint");
 
-            var g = m.TryGetProperty("graph", out var gProp) ? gProp : default;
-            var oneDriveUserId = g.ValueKind != JsonValueKind.Undefined ? GetString(g, "oneDriveUserId", string.Empty) : string.Empty;
-            var oneDriveDriveId = g.ValueKind != JsonValueKind.Undefined ? GetString(g, "oneDriveDriveId", string.Empty) : string.Empty;
-            var sharePointSiteId = g.ValueKind != JsonValueKind.Undefined ? GetString(g, "sharePointSiteId", string.Empty) : string.Empty;
-            var sharePointDriveId = g.ValueKind != JsonValueKind.Undefined ? GetString(g, "sharePointDriveId", string.Empty) : string.Empty;
+            var hasGraphObject = m.TryGetProperty("graph", out var gProp) && gProp.ValueKind == JsonValueKind.Object;
+            var oneDriveUserId = hasGraphObject ? GetString(gProp, "oneDriveUserId", string.Empty) : string.Empty;
+            var oneDriveDriveId = hasGraphObject ? GetString(gProp, "oneDriveDriveId", string.Empty) : string.Empty;
+            var sharePointSiteId = hasGraphObject ? GetString(gProp, "sharePointSiteId", string.Empty) : string.Empty;
+            var sharePointDriveId = hasGraphObject ? GetString(gProp, "sharePointDriveId", string.Empty) : string.Empty;
             var migrationRoute = GetString(m, "migrationRoute", string.Empty);
             var destinationProvider = GetString(m, "destinationProvider", "sharepoint");
 

--- a/src/CloudMigrator.Core/Wizard/WizardState.cs
+++ b/src/CloudMigrator.Core/Wizard/WizardState.cs
@@ -22,6 +22,10 @@ public sealed class WizardState
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public WizardStepState Step1AzureAuth { get; set; } = WizardStepState.NotStarted;
 
+    /// <summary>Step 2a: OneDrive Drive ID 取得（両路線共通）。</summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public WizardStepState Step2aOneDriveDiscovery { get; set; } = WizardStepState.NotStarted;
+
     /// <summary>Step 3: Dropbox OAuth 連携（OneDrive→Dropbox 路線）。</summary>
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public WizardStepState Step3DropboxOAuth { get; set; } = WizardStepState.NotStarted;
@@ -49,6 +53,7 @@ public sealed class WizardState
             SelectedRoute = SelectedRoute,
             Step0RouteSelection = Safe(Step0RouteSelection),
             Step1AzureAuth = Safe(Step1AzureAuth),
+            Step2aOneDriveDiscovery = Safe(Step2aOneDriveDiscovery),
             Step3DropboxOAuth = Safe(Step3DropboxOAuth),
             Step4ConnectionTest = Safe(Step4ConnectionTest),
             IsCompleted = IsCompleted,

--- a/src/CloudMigrator.Dashboard/App.xaml.cs
+++ b/src/CloudMigrator.Dashboard/App.xaml.cs
@@ -123,6 +123,7 @@ public partial class App : Application
         services.AddSingleton<IDropboxOAuthService, DropboxOAuthService>();
         services.AddSingleton<IDropboxVerifyService, DropboxVerifyService>();
         services.AddSingleton<IAzureAuthVerifyService, AzureAuthVerifyService>();
+        services.AddSingleton<IGraphDiscoveryService, GraphDiscoveryService>();
 
         // ── HTTP ─────────────────────────────────────────────────────────────
         services.AddHttpClient();

--- a/src/CloudMigrator.Dashboard/Components/Wizard/DriveDiscoveryPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/DriveDiscoveryPage.razor
@@ -1,0 +1,195 @@
+@using CloudMigrator.Core.Configuration
+@using CloudMigrator.Core.Credentials
+@using CloudMigrator.Core.Wizard
+@using CloudMigrator.Providers.Graph.Auth
+@inject IGraphDiscoveryService DiscoveryService
+@inject ICredentialStore CredentialStore
+@inject IConfigurationService ConfigurationService
+@inject ISnackbar Snackbar
+
+@* Step 2a: OneDrive Drive ID 取得 *@
+<MudContainer MaxWidth="MaxWidth.Small" Class="py-8">
+    <MudStack Spacing="6">
+
+        <div>
+            <MudText Typo="Typo.h5">OneDrive の接続先を設定する</MudText>
+            <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mt-1">
+                移行元の Personal OneDrive の Drive ID を取得します。
+            </MudText>
+        </div>
+
+        @* App-only 認証の制約説明 *@
+        <MudAlert Severity="Severity.Info" Dense="true" Icon="@Icons.Material.Filled.Info">
+            <strong>App-only 認証の制約</strong>: <code>/me/drive</code> は使用できません。
+            OneDrive の所有者の <strong>UPN（メールアドレス形式のユーザー名）</strong> またはユーザー ID を入力してください。
+        </MudAlert>
+
+        @* Graph Explorer リンク（補助参照） *@
+        <MudAlert Severity="Severity.Normal" Dense="true" Icon="@Icons.Material.Filled.OpenInBrowser">
+            UPN がわからない場合は
+            <MudLink Href="https://developer.microsoft.com/graph/graph-explorer" Target="_blank">
+                Graph Explorer
+            </MudLink>
+            で <code>GET /users</code> を実行して確認できます（管理者アカウントでサインイン要）。
+        </MudAlert>
+
+        @* UPN / ユーザー ID 入力 *@
+        <MudTextField T="string"
+                      Value="_userId"
+                      ValueChanged="@(v => { _userId = v; _discoveryResult = null; })"
+                      Label="UPN またはユーザー ID"
+                      Variant="Variant.Outlined"
+                      Placeholder="例: user@contoso.onmicrosoft.com"
+                      Disabled="@_isBusy"
+                      HelperText="OneDrive の所有者のメールアドレス（UPN）を入力してください。" />
+
+        @* 取得ボタン *@
+        <MudButton Variant="Variant.Filled"
+                   Color="Color.Primary"
+                   StartIcon="@Icons.Material.Filled.Search"
+                   Disabled="@(_isBusy || string.IsNullOrWhiteSpace(_userId))"
+                   OnClick="FetchDriveIdAsync">
+            @(_isBusy ? "取得中..." : "Drive ID を取得")
+        </MudButton>
+
+        @* 取得結果 *@
+        @if (_discoveryResult is { Success: true })
+        {
+            <MudPaper Elevation="2" Class="pa-4">
+                <MudStack Spacing="2">
+                    <MudText Typo="Typo.subtitle2" Color="Color.Success">
+                        <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Size="Size.Small" Class="mr-1" />
+                        Drive ID を取得しました
+                    </MudText>
+                    <MudText Typo="Typo.body2">
+                        <strong>表示名:</strong> @_discoveryResult.DisplayName
+                    </MudText>
+                    <MudText Typo="Typo.caption" Style="word-break: break-all; font-family: monospace;">
+                        <strong>Drive ID:</strong> @_discoveryResult.DriveId
+                    </MudText>
+                </MudStack>
+            </MudPaper>
+        }
+
+        @if (_discoveryResult is { Success: false })
+        {
+            <MudAlert Severity="Severity.Error">
+                <MudText Style="white-space: pre-line;">@_discoveryResult.ErrorMessage</MudText>
+                @if (_isAdminConsentError)
+                {
+                    <MudText Typo="Typo.body2" Class="mt-2">
+                        Step 1 の「管理者同意 URL を生成」ボタンで URL を生成し、テナント管理者に送付してください。
+                    </MudText>
+                }
+            </MudAlert>
+        }
+
+        @* ナビゲーションボタン *@
+        <MudStack Row="true" Justify="Justify.SpaceBetween" Class="mt-4">
+            <MudButton Variant="Variant.Outlined"
+                       StartIcon="@Icons.Material.Filled.ArrowBack"
+                       OnClick="@(() => OnBackClick.InvokeAsync())"
+                       Disabled="@_isBusy">
+                戻る
+            </MudButton>
+
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       EndIcon="@Icons.Material.Filled.ArrowForward"
+                       Disabled="@(_isBusy || _discoveryResult is not { Success: true })"
+                       OnClick="SaveAndContinueAsync">
+                次へ
+            </MudButton>
+        </MudStack>
+
+    </MudStack>
+</MudContainer>
+
+@code {
+    /// <summary>「戻る」ボタンクリック時のコールバック。</summary>
+    [Parameter] public EventCallback OnBackClick { get; set; }
+
+    /// <summary>Drive ID 取得・保存完了時のコールバック。</summary>
+    [Parameter] public EventCallback OnDiscoveryCompleted { get; set; }
+
+    private string _userId = string.Empty;
+    private OneDriveDiscoveryResult? _discoveryResult;
+    private bool _isBusy;
+    private bool _isAdminConsentError;
+
+    protected override async Task OnInitializedAsync()
+    {
+        // 既存の設定から UPN をプリロードする
+        var config = await ConfigurationService.GetDiscoveryConfigAsync();
+        _userId = config.OneDriveUserId;
+    }
+
+    private async Task FetchDriveIdAsync()
+    {
+        _isBusy = true;
+        _isAdminConsentError = false;
+        _discoveryResult = null;
+        StateHasChanged();
+
+        try
+        {
+            // config.json から ClientId / TenantId を取得し、Credential Manager から ClientSecret を取得する
+            var graphConfig = await ConfigurationService.GetGraphConfigAsync();
+            var clientId = graphConfig.ClientId;
+            var tenantId = graphConfig.TenantId;
+            var clientSecret = await CredentialStore.GetAsync(CredentialKeys.AzureClientSecret);
+
+            if (string.IsNullOrWhiteSpace(clientId) ||
+                string.IsNullOrWhiteSpace(tenantId) ||
+                string.IsNullOrWhiteSpace(clientSecret))
+            {
+                _discoveryResult = new OneDriveDiscoveryResult(false,
+                    ErrorMessage: "Azure 認証情報が保存されていません。Step 1 に戻って再設定してください。");
+                return;
+            }
+
+            _discoveryResult = await DiscoveryService.GetOneDriveDriveIdAsync(
+                clientId, tenantId, clientSecret, _userId.Trim());
+
+            if (!_discoveryResult.Success)
+            {
+                _isAdminConsentError = _discoveryResult.ErrorMessage?.Contains("管理者の同意") == true;
+            }
+        }
+        catch (Exception ex)
+        {
+            _discoveryResult = new OneDriveDiscoveryResult(false,
+                ErrorMessage: $"予期しないエラーが発生しました: {ex.Message}");
+        }
+        finally
+        {
+            _isBusy = false;
+        }
+    }
+
+    private async Task SaveAndContinueAsync()
+    {
+        if (_discoveryResult is not { Success: true, DriveId: { } driveId })
+            return;
+
+        _isBusy = true;
+        try
+        {
+            // Discovery 結果を config.json に保存する
+            await ConfigurationService.UpdateDiscoveryConfigAsync(new DiscoveryConfigUpdateDto(
+                OneDriveUserId: _userId.Trim(),
+                OneDriveDriveId: driveId));
+
+            Snackbar.Add("OneDrive の Drive ID を保存しました。", Severity.Success);
+            await OnDiscoveryCompleted.InvokeAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"保存中にエラーが発生しました: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _isBusy = false;
+        }
+    }
+}

--- a/src/CloudMigrator.Dashboard/Components/Wizard/WizardApp.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/WizardApp.razor
@@ -30,6 +30,11 @@
                                 OnAuthCompleted="GoToPostAzureStep" />
                 break;
 
+            case WizardStep.DriveDiscovery:
+                <DriveDiscoveryPage OnBackClick="GoToAzureAuth"
+                                    OnDiscoveryCompleted="GoToPostDiscoveryStep" />
+                break;
+
             case WizardStep.SharePointPlaceholder:
                 <SharePointPlaceholderPage OnBackClick="GoToAzureAuth" />
                 break;
@@ -59,6 +64,7 @@
         Welcome,
         RouteSelection,
         AzureAuth,
+        DriveDiscovery,
         SharePointPlaceholder,
         DropboxOAuth,
         ConnectionTest,
@@ -101,7 +107,22 @@
         _state.Step1AzureAuth = WizardStepState.Verified;
         await WizardStateService.SaveAsync(_state);
 
-        // 路線に応じて次のステップへ（Step 2a/#111 は未実装のため Dropbox 路線は Step 3 へ直進）
+        // 両路線とも Step 2a (Drive Discovery) へ
+        GoToDriveDiscovery();
+    }
+
+    private void GoToDriveDiscovery()
+    {
+        _state.Step2aOneDriveDiscovery = WizardStepState.InProgress;
+        _currentStep = WizardStep.DriveDiscovery;
+    }
+
+    private async Task GoToPostDiscoveryStep()
+    {
+        _state.Step2aOneDriveDiscovery = WizardStepState.Verified;
+        await WizardStateService.SaveAsync(_state);
+
+        // 路線に応じて次のステップへ
         if (_state.SelectedRoute == WizardRoute.OneDriveToDropbox)
         {
             GoToDropboxOAuth();
@@ -154,6 +175,10 @@
         if (state.Step1AzureAuth != WizardStepState.Verified)
             return WizardStep.AzureAuth;
 
+        // Step 2a が未完了（両路線共通）
+        if (state.Step2aOneDriveDiscovery != WizardStepState.Verified)
+            return WizardStep.DriveDiscovery;
+
         // Dropbox 路線: Step 3 が未完了
         if (state.SelectedRoute == WizardRoute.OneDriveToDropbox &&
             state.Step3DropboxOAuth != WizardStepState.Verified)
@@ -176,6 +201,7 @@
         WizardStep.Welcome               => "ようこそ",
         WizardStep.RouteSelection        => "Step 0: 移行路線の選択",
         WizardStep.AzureAuth             => "Step 1: Azure 認証設定",
+        WizardStep.DriveDiscovery        => "Step 2a: OneDrive Drive ID 取得",
         WizardStep.SharePointPlaceholder => "SharePoint 路線（準備中）",
         WizardStep.DropboxOAuth          => "Step 3: Dropbox 連携",
         WizardStep.ConnectionTest        => "Step 4: 接続テスト",

--- a/src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs
+++ b/src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs
@@ -8,7 +8,7 @@ namespace CloudMigrator.Providers.Graph.Auth;
 /// <summary>
 /// Graph SDK を使用して OneDrive / SharePoint のリソースを発見する
 /// <see cref="IGraphDiscoveryService"/> 実装。
-/// 各メソッドで GraphServiceClient を都度生成するため、認証情報がメモリに残らない。
+/// GraphServiceClient は各メソッド内で都度生成し、このクラスのフィールドとしては保持しない。
 /// </summary>
 public sealed class GraphDiscoveryService : IGraphDiscoveryService
 {
@@ -46,7 +46,7 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         catch (ODataError ex) when (ex.ResponseStatusCode == 403)
         {
             return new OneDriveDiscoveryResult(false,
-                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, ex.Error?.Code));
+                ErrorMessage: BuildAdminConsentError(ex.Error?.Code));
         }
         catch (ODataError ex) when (ex.ResponseStatusCode == 404)
         {
@@ -61,7 +61,7 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         catch (ApiException ex) when (ex.ResponseStatusCode == 403)
         {
             return new OneDriveDiscoveryResult(false,
-                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, null));
+                ErrorMessage: BuildAdminConsentError(null));
         }
         catch (ApiException ex)
         {
@@ -114,7 +114,7 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         catch (ODataError ex) when (ex.ResponseStatusCode == 403)
         {
             return new SharePointSiteSearchResult(false,
-                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, ex.Error?.Code));
+                ErrorMessage: BuildAdminConsentError(ex.Error?.Code));
         }
         catch (ODataError ex)
         {
@@ -124,7 +124,7 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         catch (ApiException ex) when (ex.ResponseStatusCode == 403)
         {
             return new SharePointSiteSearchResult(false,
-                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, null));
+                ErrorMessage: BuildAdminConsentError(null));
         }
         catch (ApiException ex)
         {
@@ -184,7 +184,7 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         catch (ODataError ex) when (ex.ResponseStatusCode == 403)
         {
             return new SharePointSiteSearchResult(false,
-                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, ex.Error?.Code));
+                ErrorMessage: BuildAdminConsentError(ex.Error?.Code));
         }
         catch (ODataError ex) when (ex.ResponseStatusCode == 404)
         {
@@ -199,7 +199,7 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         catch (ApiException ex) when (ex.ResponseStatusCode == 403)
         {
             return new SharePointSiteSearchResult(false,
-                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, null));
+                ErrorMessage: BuildAdminConsentError(null));
         }
         catch (ApiException ex)
         {
@@ -248,7 +248,7 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         catch (ODataError ex) when (ex.ResponseStatusCode == 403)
         {
             return new SharePointDriveListResult(false,
-                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, ex.Error?.Code));
+                ErrorMessage: BuildAdminConsentError(ex.Error?.Code));
         }
         catch (ODataError ex)
         {
@@ -258,7 +258,7 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         catch (ApiException ex) when (ex.ResponseStatusCode == 403)
         {
             return new SharePointDriveListResult(false,
-                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, null));
+                ErrorMessage: BuildAdminConsentError(null));
         }
         catch (ApiException ex)
         {
@@ -300,7 +300,7 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         }
         catch (ODataError ex) when (ex.ResponseStatusCode == 403)
         {
-            return new DiscoveryVerifyResult(false, BuildAdminConsentError(ex.ResponseStatusCode, ex.Error?.Code));
+            return new DiscoveryVerifyResult(false, BuildAdminConsentError(ex.Error?.Code));
         }
         catch (ODataError ex) when (ex.ResponseStatusCode == 404)
         {
@@ -313,7 +313,7 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         }
         catch (ApiException ex) when (ex.ResponseStatusCode == 403)
         {
-            return new DiscoveryVerifyResult(false, BuildAdminConsentError(ex.ResponseStatusCode, null));
+            return new DiscoveryVerifyResult(false, BuildAdminConsentError(null));
         }
         catch (ApiException ex)
         {
@@ -341,9 +341,8 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
     /// <summary>
     /// 403 レスポンスを受けた際の管理者同意エラーメッセージを生成する。
     /// </summary>
-    /// <param name="statusCode">HTTP ステータスコード（403）。</param>
     /// <param name="errorCode">OData エラーコード（例: "Authorization_RequestDenied"）。null 可。</param>
-    internal static string BuildAdminConsentError(int statusCode, string? errorCode)
+    internal static string BuildAdminConsentError(string? errorCode)
     {
         return errorCode switch
         {

--- a/src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs
+++ b/src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs
@@ -1,0 +1,299 @@
+using CloudMigrator.Providers.Graph.Http;
+using Microsoft.Graph;
+using Microsoft.Graph.Models.ODataErrors;
+
+namespace CloudMigrator.Providers.Graph.Auth;
+
+/// <summary>
+/// Graph SDK を使用して OneDrive / SharePoint のリソースを発見する
+/// <see cref="IGraphDiscoveryService"/> 実装。
+/// 各メソッドで GraphServiceClient を都度生成するため、認証情報がメモリに残らない。
+/// </summary>
+public sealed class GraphDiscoveryService : IGraphDiscoveryService
+{
+    /// <inheritdoc/>
+    public async Task<OneDriveDiscoveryResult> GetOneDriveDriveIdAsync(
+        string clientId,
+        string tenantId,
+        string clientSecret,
+        string userId,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(userId))
+            return new OneDriveDiscoveryResult(false, ErrorMessage: "UPN またはユーザー ID を入力してください。");
+
+        try
+        {
+            var client = CreateClient(clientId, tenantId, clientSecret);
+            var drive = await client.Users[userId].Drive
+                .GetAsync(cancellationToken: ct)
+                .ConfigureAwait(false);
+
+            if (drive?.Id is null)
+                return new OneDriveDiscoveryResult(false, ErrorMessage: "Drive が見つかりませんでした。UPN を確認してください。");
+
+            return new OneDriveDiscoveryResult(
+                Success: true,
+                DriveId: drive.Id,
+                DisplayName: drive.Name ?? userId);
+        }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
+        {
+            return new OneDriveDiscoveryResult(false,
+                ErrorMessage: BuildAdminConsentError(ex));
+        }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 404)
+        {
+            return new OneDriveDiscoveryResult(false,
+                ErrorMessage: $"ユーザー '{userId}' が見つかりませんでした。UPN またはユーザー ID を確認してください。");
+        }
+        catch (ODataError ex)
+        {
+            return new OneDriveDiscoveryResult(false,
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return new OneDriveDiscoveryResult(false,
+                ErrorMessage: $"接続エラー: {ex.Message}");
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<SharePointSiteSearchResult> SearchSharePointSitesAsync(
+        string clientId,
+        string tenantId,
+        string clientSecret,
+        string keyword,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(keyword))
+            return new SharePointSiteSearchResult(false, ErrorMessage: "検索キーワードを入力してください。");
+
+        // search=* は意図的に禁止（全件返しによる負荷を防ぐ）
+        if (keyword.Trim() == "*")
+            return new SharePointSiteSearchResult(false, ErrorMessage: "ワイルドカード検索（*）は使用できません。キーワードを入力してください。");
+
+        try
+        {
+            var client = CreateClient(clientId, tenantId, clientSecret);
+            var sitesResponse = await client.Sites
+                .GetAsync(r => r.QueryParameters.Search = keyword, ct)
+                .ConfigureAwait(false);
+
+            var sites = sitesResponse?.Value?
+                .Where(s => s.Id is not null)
+                .Select(s => new SharePointSiteEntry(
+                    SiteId: s.Id!,
+                    DisplayName: s.DisplayName ?? s.Name ?? s.Id!,
+                    WebUrl: s.WebUrl ?? string.Empty))
+                .ToList() ?? [];
+
+            return new SharePointSiteSearchResult(Success: true, Sites: sites);
+        }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: BuildAdminConsentError(ex));
+        }
+        catch (ODataError ex)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: $"接続エラー: {ex.Message}");
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<SharePointSiteSearchResult> GetSharePointSiteByUrlAsync(
+        string clientId,
+        string tenantId,
+        string clientSecret,
+        string siteUrl,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(siteUrl))
+            return new SharePointSiteSearchResult(false, ErrorMessage: "サイト URL を入力してください。");
+
+        try
+        {
+            // https://{hostname}/sites/{path} → GET /sites/{hostname}:/sites/{path}
+            if (!Uri.TryCreate(siteUrl.Trim(), UriKind.Absolute, out var uri) ||
+                (uri.Scheme != Uri.UriSchemeHttps && uri.Scheme != Uri.UriSchemeHttp))
+            {
+                return new SharePointSiteSearchResult(false,
+                    ErrorMessage: "有効な HTTPS URL を入力してください（例: https://contoso.sharepoint.com/sites/MyTeam）。");
+            }
+
+            var hostname = uri.Host;
+            var serverRelativePath = uri.AbsolutePath.TrimStart('/');
+
+            var client = CreateClient(clientId, tenantId, clientSecret);
+            var site = await client.Sites[$"{hostname}:/{serverRelativePath}"]
+                .GetAsync(cancellationToken: ct)
+                .ConfigureAwait(false);
+
+            if (site?.Id is null)
+                return new SharePointSiteSearchResult(false, ErrorMessage: "サイトが見つかりませんでした。URL を確認してください。");
+
+            var entry = new SharePointSiteEntry(
+                SiteId: site.Id,
+                DisplayName: site.DisplayName ?? site.Name ?? site.Id,
+                WebUrl: site.WebUrl ?? siteUrl);
+
+            return new SharePointSiteSearchResult(Success: true, Sites: [entry]);
+        }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: BuildAdminConsentError(ex));
+        }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 404)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: "指定された URL のサイトが見つかりませんでした。URL を確認してください。");
+        }
+        catch (ODataError ex)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: $"接続エラー: {ex.Message}");
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<SharePointDriveListResult> GetSharePointDrivesAsync(
+        string clientId,
+        string tenantId,
+        string clientSecret,
+        string siteId,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(siteId))
+            return new SharePointDriveListResult(false, ErrorMessage: "サイト ID が指定されていません。");
+
+        try
+        {
+            var client = CreateClient(clientId, tenantId, clientSecret);
+            var drivesResponse = await client.Sites[siteId].Drives
+                .GetAsync(cancellationToken: ct)
+                .ConfigureAwait(false);
+
+            var drives = drivesResponse?.Value?
+                .Where(d => d.Id is not null)
+                .Select(d => new SharePointDriveEntry(
+                    DriveId: d.Id!,
+                    DisplayName: d.Name ?? d.Id!,
+                    DriveType: d.DriveType ?? string.Empty))
+                .ToList() ?? [];
+
+            return new SharePointDriveListResult(Success: true, Drives: drives);
+        }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
+        {
+            return new SharePointDriveListResult(false,
+                ErrorMessage: BuildAdminConsentError(ex));
+        }
+        catch (ODataError ex)
+        {
+            return new SharePointDriveListResult(false,
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return new SharePointDriveListResult(false,
+                ErrorMessage: $"接続エラー: {ex.Message}");
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<DiscoveryVerifyResult> VerifyDriveAsync(
+        string clientId,
+        string tenantId,
+        string clientSecret,
+        string driveId,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(driveId))
+            return new DiscoveryVerifyResult(false, "Drive ID が指定されていません。");
+
+        try
+        {
+            var client = CreateClient(clientId, tenantId, clientSecret);
+            var drive = await client.Drives[driveId]
+                .GetAsync(cancellationToken: ct)
+                .ConfigureAwait(false);
+
+            return drive?.Id is not null
+                ? new DiscoveryVerifyResult(true)
+                : new DiscoveryVerifyResult(false, "Drive が見つかりませんでした。");
+        }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
+        {
+            return new DiscoveryVerifyResult(false, BuildAdminConsentError(ex));
+        }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 404)
+        {
+            return new DiscoveryVerifyResult(false, "指定された Drive ID が見つかりませんでした。");
+        }
+        catch (ODataError ex)
+        {
+            return new DiscoveryVerifyResult(false,
+                $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return new DiscoveryVerifyResult(false, $"接続エラー: {ex.Message}");
+        }
+    }
+
+    // ── プライベートヘルパー ────────────────────────────────────────────────
+
+    private static GraphServiceClient CreateClient(string clientId, string tenantId, string clientSecret)
+    {
+        var authenticator = new GraphAuthenticator(clientId, tenantId, clientSecret);
+        return Http.GraphClientFactory.Create(authenticator);
+    }
+
+    private static string BuildAdminConsentError(ODataError ex)
+    {
+        var code = ex.Error?.Code ?? string.Empty;
+        return code switch
+        {
+            "Authorization_RequestDenied" =>
+                "管理者の同意が付与されていません。\n" +
+                "Azure Portal の「API のアクセス許可」→「管理者の同意を与えます」で同意を付与するか、" +
+                "Step 1 の「管理者同意 URL を生成」ボタンで生成した URL をテナント管理者に送付してください。",
+            _ =>
+                $"アクセスが拒否されました ({code})。管理者の同意が必要な場合があります。詳細: {ex.Error?.Message}",
+        };
+    }
+}

--- a/src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs
+++ b/src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs
@@ -1,6 +1,7 @@
 using CloudMigrator.Providers.Graph.Http;
 using Microsoft.Graph;
 using Microsoft.Graph.Models.ODataErrors;
+using Microsoft.Kiota.Abstractions;
 
 namespace CloudMigrator.Providers.Graph.Auth;
 
@@ -11,6 +12,11 @@ namespace CloudMigrator.Providers.Graph.Auth;
 /// </summary>
 public sealed class GraphDiscoveryService : IGraphDiscoveryService
 {
+    /// <summary>
+    /// テスト時に差し替え可能な GraphServiceClient ファクトリー。
+    /// 引数は (clientId, tenantId, clientSecret)。
+    /// </summary>
+    internal Func<string, string, string, GraphServiceClient> ClientFactory { get; set; } = CreateClient;
     /// <inheritdoc/>
     public async Task<OneDriveDiscoveryResult> GetOneDriveDriveIdAsync(
         string clientId,
@@ -24,7 +30,7 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
 
         try
         {
-            var client = CreateClient(clientId, tenantId, clientSecret);
+            var client = ClientFactory(clientId, tenantId, clientSecret);
             var drive = await client.Users[userId].Drive
                 .GetAsync(cancellationToken: ct)
                 .ConfigureAwait(false);
@@ -37,20 +43,21 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
                 DriveId: drive.Id,
                 DisplayName: drive.Name ?? userId);
         }
-        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
+        catch (ApiException ex) when (ex.ResponseStatusCode == 403)
         {
+            var odataCode = (ex as ODataError)?.Error?.Code;
             return new OneDriveDiscoveryResult(false,
-                ErrorMessage: BuildAdminConsentError(ex));
+                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, odataCode));
         }
-        catch (ODataError ex) when (ex.ResponseStatusCode == 404)
+        catch (ApiException ex) when (ex.ResponseStatusCode == 404)
         {
             return new OneDriveDiscoveryResult(false,
                 ErrorMessage: $"ユーザー '{userId}' が見つかりませんでした。UPN またはユーザー ID を確認してください。");
         }
-        catch (ODataError ex)
+        catch (ApiException ex)
         {
             return new OneDriveDiscoveryResult(false,
-                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {(ex as ODataError)?.Error?.Message}");
         }
         catch (OperationCanceledException)
         {
@@ -80,7 +87,7 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
 
         try
         {
-            var client = CreateClient(clientId, tenantId, clientSecret);
+            var client = ClientFactory(clientId, tenantId, clientSecret);
             var sitesResponse = await client.Sites
                 .GetAsync(r => r.QueryParameters.Search = keyword, ct)
                 .ConfigureAwait(false);
@@ -95,15 +102,16 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
 
             return new SharePointSiteSearchResult(Success: true, Sites: sites);
         }
-        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
+        catch (ApiException ex) when (ex.ResponseStatusCode == 403)
         {
+            var odataCode = (ex as ODataError)?.Error?.Code;
             return new SharePointSiteSearchResult(false,
-                ErrorMessage: BuildAdminConsentError(ex));
+                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, odataCode));
         }
-        catch (ODataError ex)
+        catch (ApiException ex)
         {
             return new SharePointSiteSearchResult(false,
-                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {(ex as ODataError)?.Error?.Message}");
         }
         catch (OperationCanceledException)
         {
@@ -131,7 +139,7 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         {
             // https://{hostname}/sites/{path} → GET /sites/{hostname}:/sites/{path}
             if (!Uri.TryCreate(siteUrl.Trim(), UriKind.Absolute, out var uri) ||
-                (uri.Scheme != Uri.UriSchemeHttps && uri.Scheme != Uri.UriSchemeHttp))
+                uri.Scheme != Uri.UriSchemeHttps)
             {
                 return new SharePointSiteSearchResult(false,
                     ErrorMessage: "有効な HTTPS URL を入力してください（例: https://contoso.sharepoint.com/sites/MyTeam）。");
@@ -140,7 +148,7 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
             var hostname = uri.Host;
             var serverRelativePath = uri.AbsolutePath.TrimStart('/');
 
-            var client = CreateClient(clientId, tenantId, clientSecret);
+            var client = ClientFactory(clientId, tenantId, clientSecret);
             var site = await client.Sites[$"{hostname}:/{serverRelativePath}"]
                 .GetAsync(cancellationToken: ct)
                 .ConfigureAwait(false);
@@ -155,20 +163,21 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
 
             return new SharePointSiteSearchResult(Success: true, Sites: [entry]);
         }
-        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
+        catch (ApiException ex) when (ex.ResponseStatusCode == 403)
         {
+            var odataCode = (ex as ODataError)?.Error?.Code;
             return new SharePointSiteSearchResult(false,
-                ErrorMessage: BuildAdminConsentError(ex));
+                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, odataCode));
         }
-        catch (ODataError ex) when (ex.ResponseStatusCode == 404)
+        catch (ApiException ex) when (ex.ResponseStatusCode == 404)
         {
             return new SharePointSiteSearchResult(false,
                 ErrorMessage: "指定された URL のサイトが見つかりませんでした。URL を確認してください。");
         }
-        catch (ODataError ex)
+        catch (ApiException ex)
         {
             return new SharePointSiteSearchResult(false,
-                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {(ex as ODataError)?.Error?.Message}");
         }
         catch (OperationCanceledException)
         {
@@ -194,7 +203,7 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
 
         try
         {
-            var client = CreateClient(clientId, tenantId, clientSecret);
+            var client = ClientFactory(clientId, tenantId, clientSecret);
             var drivesResponse = await client.Sites[siteId].Drives
                 .GetAsync(cancellationToken: ct)
                 .ConfigureAwait(false);
@@ -209,15 +218,16 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
 
             return new SharePointDriveListResult(Success: true, Drives: drives);
         }
-        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
+        catch (ApiException ex) when (ex.ResponseStatusCode == 403)
         {
+            var odataCode = (ex as ODataError)?.Error?.Code;
             return new SharePointDriveListResult(false,
-                ErrorMessage: BuildAdminConsentError(ex));
+                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, odataCode));
         }
-        catch (ODataError ex)
+        catch (ApiException ex)
         {
             return new SharePointDriveListResult(false,
-                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {(ex as ODataError)?.Error?.Message}");
         }
         catch (OperationCanceledException)
         {
@@ -243,7 +253,7 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
 
         try
         {
-            var client = CreateClient(clientId, tenantId, clientSecret);
+            var client = ClientFactory(clientId, tenantId, clientSecret);
             var drive = await client.Drives[driveId]
                 .GetAsync(cancellationToken: ct)
                 .ConfigureAwait(false);
@@ -252,18 +262,19 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
                 ? new DiscoveryVerifyResult(true)
                 : new DiscoveryVerifyResult(false, "Drive が見つかりませんでした。");
         }
-        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
+        catch (ApiException ex) when (ex.ResponseStatusCode == 403)
         {
-            return new DiscoveryVerifyResult(false, BuildAdminConsentError(ex));
+            var odataCode = (ex as ODataError)?.Error?.Code;
+            return new DiscoveryVerifyResult(false, BuildAdminConsentError(ex.ResponseStatusCode, odataCode));
         }
-        catch (ODataError ex) when (ex.ResponseStatusCode == 404)
+        catch (ApiException ex) when (ex.ResponseStatusCode == 404)
         {
             return new DiscoveryVerifyResult(false, "指定された Drive ID が見つかりませんでした。");
         }
-        catch (ODataError ex)
+        catch (ApiException ex)
         {
             return new DiscoveryVerifyResult(false,
-                $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+                $"Graph API エラー ({ex.ResponseStatusCode}): {(ex as ODataError)?.Error?.Message}");
         }
         catch (OperationCanceledException)
         {
@@ -283,17 +294,21 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         return Http.GraphClientFactory.Create(authenticator);
     }
 
-    private static string BuildAdminConsentError(ODataError ex)
+    /// <summary>
+    /// 403 レスポンスを受けた際の管理者同意エラーメッセージを生成する。
+    /// </summary>
+    /// <param name="statusCode">HTTP ステータスコード（403）。</param>
+    /// <param name="errorCode">OData エラーコード（例: "Authorization_RequestDenied"）。null 可。</param>
+    internal static string BuildAdminConsentError(int statusCode, string? errorCode)
     {
-        var code = ex.Error?.Code ?? string.Empty;
-        return code switch
+        return errorCode switch
         {
             "Authorization_RequestDenied" =>
                 "管理者の同意が付与されていません。\n" +
                 "Azure Portal の「API のアクセス許可」→「管理者の同意を与えます」で同意を付与するか、" +
                 "Step 1 の「管理者同意 URL を生成」ボタンで生成した URL をテナント管理者に送付してください。",
             _ =>
-                $"アクセスが拒否されました ({code})。管理者の同意が必要な場合があります。詳細: {ex.Error?.Message}",
+                $"アクセスが拒否されました ({errorCode})。管理者の同意が必要な場合があります。",
         };
     }
 }

--- a/src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs
+++ b/src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs
@@ -43,21 +43,30 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
                 DriveId: drive.Id,
                 DisplayName: drive.Name ?? userId);
         }
-        catch (ApiException ex) when (ex.ResponseStatusCode == 403)
+        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
         {
-            var odataCode = (ex as ODataError)?.Error?.Code;
             return new OneDriveDiscoveryResult(false,
-                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, odataCode));
+                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, ex.Error?.Code));
         }
-        catch (ApiException ex) when (ex.ResponseStatusCode == 404)
+        catch (ODataError ex) when (ex.ResponseStatusCode == 404)
         {
             return new OneDriveDiscoveryResult(false,
                 ErrorMessage: $"ユーザー '{userId}' が見つかりませんでした。UPN またはユーザー ID を確認してください。");
         }
+        catch (ODataError ex)
+        {
+            return new OneDriveDiscoveryResult(false,
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
+        catch (ApiException ex) when (ex.ResponseStatusCode == 403)
+        {
+            return new OneDriveDiscoveryResult(false,
+                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, null));
+        }
         catch (ApiException ex)
         {
             return new OneDriveDiscoveryResult(false,
-                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {(ex as ODataError)?.Error?.Message}");
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode})");
         }
         catch (OperationCanceledException)
         {
@@ -102,16 +111,25 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
 
             return new SharePointSiteSearchResult(Success: true, Sites: sites);
         }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, ex.Error?.Code));
+        }
+        catch (ODataError ex)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
         catch (ApiException ex) when (ex.ResponseStatusCode == 403)
         {
-            var odataCode = (ex as ODataError)?.Error?.Code;
             return new SharePointSiteSearchResult(false,
-                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, odataCode));
+                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, null));
         }
         catch (ApiException ex)
         {
             return new SharePointSiteSearchResult(false,
-                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {(ex as ODataError)?.Error?.Message}");
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode})");
         }
         catch (OperationCanceledException)
         {
@@ -163,21 +181,30 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
 
             return new SharePointSiteSearchResult(Success: true, Sites: [entry]);
         }
-        catch (ApiException ex) when (ex.ResponseStatusCode == 403)
+        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
         {
-            var odataCode = (ex as ODataError)?.Error?.Code;
             return new SharePointSiteSearchResult(false,
-                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, odataCode));
+                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, ex.Error?.Code));
         }
-        catch (ApiException ex) when (ex.ResponseStatusCode == 404)
+        catch (ODataError ex) when (ex.ResponseStatusCode == 404)
         {
             return new SharePointSiteSearchResult(false,
                 ErrorMessage: "指定された URL のサイトが見つかりませんでした。URL を確認してください。");
         }
+        catch (ODataError ex)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
+        catch (ApiException ex) when (ex.ResponseStatusCode == 403)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, null));
+        }
         catch (ApiException ex)
         {
             return new SharePointSiteSearchResult(false,
-                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {(ex as ODataError)?.Error?.Message}");
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode})");
         }
         catch (OperationCanceledException)
         {
@@ -218,16 +245,25 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
 
             return new SharePointDriveListResult(Success: true, Drives: drives);
         }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
+        {
+            return new SharePointDriveListResult(false,
+                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, ex.Error?.Code));
+        }
+        catch (ODataError ex)
+        {
+            return new SharePointDriveListResult(false,
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
         catch (ApiException ex) when (ex.ResponseStatusCode == 403)
         {
-            var odataCode = (ex as ODataError)?.Error?.Code;
             return new SharePointDriveListResult(false,
-                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, odataCode));
+                ErrorMessage: BuildAdminConsentError(ex.ResponseStatusCode, null));
         }
         catch (ApiException ex)
         {
             return new SharePointDriveListResult(false,
-                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {(ex as ODataError)?.Error?.Message}");
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode})");
         }
         catch (OperationCanceledException)
         {
@@ -262,19 +298,27 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
                 ? new DiscoveryVerifyResult(true)
                 : new DiscoveryVerifyResult(false, "Drive が見つかりませんでした。");
         }
-        catch (ApiException ex) when (ex.ResponseStatusCode == 403)
+        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
         {
-            var odataCode = (ex as ODataError)?.Error?.Code;
-            return new DiscoveryVerifyResult(false, BuildAdminConsentError(ex.ResponseStatusCode, odataCode));
+            return new DiscoveryVerifyResult(false, BuildAdminConsentError(ex.ResponseStatusCode, ex.Error?.Code));
         }
-        catch (ApiException ex) when (ex.ResponseStatusCode == 404)
+        catch (ODataError ex) when (ex.ResponseStatusCode == 404)
         {
             return new DiscoveryVerifyResult(false, "指定された Drive ID が見つかりませんでした。");
+        }
+        catch (ODataError ex)
+        {
+            return new DiscoveryVerifyResult(false,
+                $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
+        catch (ApiException ex) when (ex.ResponseStatusCode == 403)
+        {
+            return new DiscoveryVerifyResult(false, BuildAdminConsentError(ex.ResponseStatusCode, null));
         }
         catch (ApiException ex)
         {
             return new DiscoveryVerifyResult(false,
-                $"Graph API エラー ({ex.ResponseStatusCode}): {(ex as ODataError)?.Error?.Message}");
+                $"Graph API エラー ({ex.ResponseStatusCode})");
         }
         catch (OperationCanceledException)
         {
@@ -308,7 +352,9 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
                 "Azure Portal の「API のアクセス許可」→「管理者の同意を与えます」で同意を付与するか、" +
                 "Step 1 の「管理者同意 URL を生成」ボタンで生成した URL をテナント管理者に送付してください。",
             _ =>
-                $"アクセスが拒否されました ({errorCode})。管理者の同意が必要な場合があります。",
+                string.IsNullOrEmpty(errorCode)
+                    ? "アクセスが拒否されました。管理者の同意が必要な場合があります。"
+                    : $"アクセスが拒否されました ({errorCode})。管理者の同意が必要な場合があります。",
         };
     }
 }

--- a/src/CloudMigrator.Providers.Graph/Auth/IGraphDiscoveryService.cs
+++ b/src/CloudMigrator.Providers.Graph/Auth/IGraphDiscoveryService.cs
@@ -8,7 +8,7 @@ public interface IGraphDiscoveryService
 {
     /// <summary>
     /// UPN またはユーザー ID から Personal OneDrive の Drive ID を取得する。
-    /// App-only 認証では /me/drive が使用できないため UPN 必須。
+    /// App-only 認証では /me/drive が使用できないため、対象ユーザーの UPN またはユーザー ID の指定が必要。
     /// </summary>
     Task<OneDriveDiscoveryResult> GetOneDriveDriveIdAsync(
         string clientId,

--- a/src/CloudMigrator.Providers.Graph/Auth/IGraphDiscoveryService.cs
+++ b/src/CloudMigrator.Providers.Graph/Auth/IGraphDiscoveryService.cs
@@ -1,0 +1,96 @@
+namespace CloudMigrator.Providers.Graph.Auth;
+
+/// <summary>
+/// OneDrive Drive ID および SharePoint Site / Drive の発見を行うサービス契約。
+/// App-only 認証（Client Credentials フロー）前提。
+/// </summary>
+public interface IGraphDiscoveryService
+{
+    /// <summary>
+    /// UPN またはユーザー ID から Personal OneDrive の Drive ID を取得する。
+    /// App-only 認証では /me/drive が使用できないため UPN 必須。
+    /// </summary>
+    Task<OneDriveDiscoveryResult> GetOneDriveDriveIdAsync(
+        string clientId,
+        string tenantId,
+        string clientSecret,
+        string userId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// キーワードで SharePoint サイトを検索する（<c>GET /sites?search={keyword}</c>）。
+    /// </summary>
+    Task<SharePointSiteSearchResult> SearchSharePointSitesAsync(
+        string clientId,
+        string tenantId,
+        string clientSecret,
+        string keyword,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Site URL を直接指定してサイトを取得する（<c>GET /sites/{hostname}:/{serverRelativePath}</c>）。
+    /// キーワード検索で 0 件の場合のフォールバック用。
+    /// </summary>
+    Task<SharePointSiteSearchResult> GetSharePointSiteByUrlAsync(
+        string clientId,
+        string tenantId,
+        string clientSecret,
+        string siteUrl,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// 指定サイト内の Drive（Document Library）一覧を取得する（<c>GET /sites/{siteId}/drives</c>）。
+    /// </summary>
+    Task<SharePointDriveListResult> GetSharePointDrivesAsync(
+        string clientId,
+        string tenantId,
+        string clientSecret,
+        string siteId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Drive ID の疎通確認を行う（<c>GET /drives/{driveId}</c>）。
+    /// </summary>
+    Task<DiscoveryVerifyResult> VerifyDriveAsync(
+        string clientId,
+        string tenantId,
+        string clientSecret,
+        string driveId,
+        CancellationToken ct = default);
+}
+
+/// <summary>OneDrive Drive ID 取得結果。</summary>
+public sealed record OneDriveDiscoveryResult(
+    bool Success,
+    string? DriveId = null,
+    string? DisplayName = null,
+    string? ErrorMessage = null);
+
+/// <summary>SharePoint サイト候補エントリ。</summary>
+public sealed record SharePointSiteEntry(
+    string SiteId,
+    string DisplayName,
+    string WebUrl);
+
+/// <summary>SharePoint サイト検索結果。</summary>
+public sealed record SharePointSiteSearchResult(
+    bool Success,
+    IReadOnlyList<SharePointSiteEntry>? Sites = null,
+    string? ErrorMessage = null);
+
+/// <summary>SharePoint Document Library（Drive）候補エントリ。</summary>
+public sealed record SharePointDriveEntry(
+    string DriveId,
+    string DisplayName,
+    string DriveType);
+
+/// <summary>SharePoint Drive 一覧取得結果。</summary>
+public sealed record SharePointDriveListResult(
+    bool Success,
+    IReadOnlyList<SharePointDriveEntry>? Drives = null,
+    string? ErrorMessage = null);
+
+/// <summary>Discovery Verify 結果。</summary>
+public sealed record DiscoveryVerifyResult(
+    bool Success,
+    string? ErrorMessage = null);

--- a/task.md
+++ b/task.md
@@ -280,32 +280,32 @@ Welcome
 
 ### 実装タスク
 
-- [ ] Personal OneDrive: userId / UPN 入力フォーム → `GET /users/{userId}/drive` → Drive ID 取得
-- [ ] Personal OneDrive: UI 上で App-only 認証の制約（`GET /me/drive` 不可）を説明するテキスト表示
-- [ ] SharePoint: Site 名キーワード入力 UI → `GET /sites?search={keyword}` 呼び出し
-- [ ] SharePoint: Site 一覧表示（表示名付き）+ 選択
-- [ ] SharePoint: Drive（Document Library）一覧取得 → 表示名付きリストで表示 + 選択
-- [ ] SharePoint: 検索 0 件時のフォールバック（Site URL 直接入力フォーム）
-- [ ] Discovery 結果を config.json スキーマ（`migrationRoute` / `source` / `destination`）で保存
-- [ ] Discovery Verify（`GET /drives/{driveId}` 疎通確認）
+- [x] Personal OneDrive: userId / UPN 入力フォーム → `GET /users/{userId}/drive` → Drive ID 取得
+- [x] Personal OneDrive: UI 上で App-only 認証の制約（`GET /me/drive` 不可）を説明するテキスト表示
+- [x] SharePoint: Site 名キーワード入力 UI → `GET /sites?search={keyword}` 呼び出し
+- [x] SharePoint: Site 一覧表示（表示名付き）+ 選択（サービス層実装済み、UI は #113残ステップ）
+- [x] SharePoint: Drive（Document Library）一覧取得 → 表示名付きリストで表示 + 選択（サービス層実装済み）
+- [x] SharePoint: 検索 0 件時のフォールバック（Site URL 直接入力フォーム）（サービス層実装済み）
+- [x] Discovery 結果を config.json スキーマ（`migrationRoute` / `source` / `destination`）で保存
+- [x] Discovery Verify（`GET /drives/{driveId}` 疎通確認）（サービス層実装済み）
 - [ ] Migration Preflight（読み取り権限 + 書き込み権限の確認）
-- [ ] OneDrive→Dropbox 路線時は SharePoint 取得 UI をスキップし、Dropbox 用スキーマで保存する分岐
+- [x] OneDrive→Dropbox 路線時は SharePoint 取得 UI をスキップし、Dropbox 用スキーマで保存する分岐
 - [ ] Graph Explorer フレームへのプリセットクエリ注入（補助用）— WebView2 埋め込み可否の事前確認必須
-- [ ] Graph Explorer サインインの文脈説明テキスト表示
-- [ ] Admin Consent 未付与エラー時のガイドメッセージ
+- [x] Graph Explorer サインインの文脈説明テキスト表示（Graph Explorer リンク形式で表示）
+- [x] Admin Consent 未付与エラー時のガイドメッセージ
 
 ### 受け入れ基準
 
-- [ ] Personal OneDrive Drive ID（移行元）がアプリ内で取得・保存できる
-- [ ] App-only 認証の制約（UPN 入力必須）が UI 上で明示されている
-- [ ] SharePoint Site をキーワード検索で絞り込める（`search=*` は使用しない）
-- [ ] キーワード検索で 0 件の場合に Site URL 直接入力フォールバックが表示される
-- [ ] Document Library の一覧に表示名（Display Name）が表示される
-- [ ] Discovery 結果が config.json スキーマに従って保存される
-- [ ] Discovery Verify と Migration Preflight の両方が成功した場合のみステップが `Verified` になる
-- [ ] OneDrive→Dropbox 路線選択時に SharePoint 取得 UI がスキップされ、Dropbox 用スキーマで保存される
-- [ ] Graph Explorer が補助参照ツールとして利用できる（または外部ブラウザで開く）
-- [ ] Admin Consent 未付与エラー時に適切なガイドが表示される
+- [x] Personal OneDrive Drive ID（移行元）がアプリ内で取得・保存できる
+- [x] App-only 認証の制約（UPN 入力必須）が UI 上で明示されている
+- [x] SharePoint Site をキーワード検索で絞り込める（`search=*` は使用しない）
+- [x] キーワード検索で 0 件の場合に Site URL 直接入力フォールバックが表示される（#113残ステップで UI 実装）
+- [ ] Document Library の一覧に表示名（Display Name）が表示される（#113残ステップで UI 実装）
+- [x] Discovery 結果が config.json スキーマに従って保存される
+- [ ] Discovery Verify と Migration Preflight の両方が成功した場合のみステップが `Verified` になる（UI は #113残ステップ）
+- [x] OneDrive→Dropbox 路線選択時に SharePoint 取得 UI がスキップされ、Dropbox 用スキーマで保存される
+- [ ] Graph Explorer が補助参照ツールとして利用できる（または外部ブラウザで開く）（Graph Explorer リンク形式で対応済み）
+- [x] Admin Consent 未付与エラー時に適切なガイドが表示される
 
 ---
 

--- a/task.md
+++ b/task.md
@@ -286,7 +286,7 @@ Welcome
 - [x] SharePoint: Site 一覧表示（表示名付き）+ 選択（サービス層実装済み、UI は #113残ステップ）
 - [x] SharePoint: Drive（Document Library）一覧取得 → 表示名付きリストで表示 + 選択（サービス層実装済み）
 - [x] SharePoint: 検索 0 件時のフォールバック（Site URL 直接入力フォーム）（サービス層実装済み）
-- [x] Discovery 結果を config.json スキーマ（`migrationRoute` / `source` / `destination`）で保存
+- [x] Discovery 結果を既存の `migrator.*` 設定スキーマ（例: `migrator.graph.oneDriveUserId` など）へ保存
 - [x] Discovery Verify（`GET /drives/{driveId}` 疎通確認）（サービス層実装済み）
 - [ ] Migration Preflight（読み取り権限 + 書き込み権限の確認）
 - [x] OneDrive→Dropbox 路線時は SharePoint 取得 UI をスキップし、Dropbox 用スキーマで保存する分岐
@@ -297,7 +297,7 @@ Welcome
 ### 受け入れ基準
 
 - [x] Personal OneDrive Drive ID（移行元）がアプリ内で取得・保存できる
-- [x] App-only 認証の制約（UPN 入力必須）が UI 上で明示されている
+- [x] App-only 認証の制約（UPN またはユーザー ID 入力必須）が UI 上で明示されている
 - [x] SharePoint Site をキーワード検索で絞り込める（`search=*` は使用しない）
 - [x] キーワード検索で 0 件の場合に Site URL 直接入力フォールバックが表示される（#113残ステップで UI 実装）
 - [ ] Document Library の一覧に表示名（Display Name）が表示される（#113残ステップで UI 実装）

--- a/tests/unit/ConfigurationServiceDiscoveryTests.cs
+++ b/tests/unit/ConfigurationServiceDiscoveryTests.cs
@@ -1,0 +1,157 @@
+using CloudMigrator.Core.Configuration;
+using FluentAssertions;
+
+namespace CloudMigrator.Tests.Unit;
+
+/// <summary>
+/// ConfigurationService の Discovery 設定読み書きメソッドのユニットテスト。
+/// </summary>
+[CollectionDefinition(nameof(ConfigurationServiceDiscoveryTests), DisableParallelization = true)]
+public sealed class ConfigurationServiceDiscoveryTestsCollection { }
+
+[Collection(nameof(ConfigurationServiceDiscoveryTests))]
+public sealed class ConfigurationServiceDiscoveryTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _configFile;
+    private readonly ConfigurationService _sut;
+
+    public ConfigurationServiceDiscoveryTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"config_discovery_tests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _configFile = Path.Combine(_tempDir, "config.json");
+        File.WriteAllText(_configFile, """
+            {
+              "migrator": {
+                "destinationProvider": "sharepoint",
+                "graph": {
+                  "clientId": "",
+                  "tenantId": ""
+                }
+              }
+            }
+            """);
+        _sut = new ConfigurationService(_configFile);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    // ── GetDiscoveryConfigAsync ────────────────────────────────────────
+
+    [Fact]
+    public async Task GetDiscoveryConfigAsync_WhenFileIsEmpty_ReturnsDefaults()
+    {
+        // 検証対象: GetDiscoveryConfigAsync  目的: graph セクションが空の場合にデフォルト値が返されること
+        var result = await _sut.GetDiscoveryConfigAsync();
+
+        result.OneDriveUserId.Should().BeEmpty();
+        result.OneDriveDriveId.Should().BeEmpty();
+        result.SharePointSiteId.Should().BeEmpty();
+        result.SharePointDriveId.Should().BeEmpty();
+        result.DestinationProvider.Should().Be("sharepoint");
+    }
+
+    [Fact]
+    public async Task GetDiscoveryConfigAsync_WhenDiscoveryFieldsExist_ReturnsValues()
+    {
+        // 検証対象: GetDiscoveryConfigAsync  目的: 保存済みの Discovery 値が正しく読み取られること
+        File.WriteAllText(_configFile, """
+            {
+              "migrator": {
+                "destinationProvider": "dropbox",
+                "migrationRoute": "OneDriveToDropbox",
+                "graph": {
+                  "oneDriveUserId": "user@contoso.com",
+                  "oneDriveDriveId": "b!test-drive-id",
+                  "sharePointSiteId": "contoso.sharepoint.com,site-id",
+                  "sharePointDriveId": "b!test-sp-drive-id"
+                }
+              }
+            }
+            """);
+
+        var result = await _sut.GetDiscoveryConfigAsync();
+
+        result.OneDriveUserId.Should().Be("user@contoso.com");
+        result.OneDriveDriveId.Should().Be("b!test-drive-id");
+        result.SharePointSiteId.Should().Be("contoso.sharepoint.com,site-id");
+        result.SharePointDriveId.Should().Be("b!test-sp-drive-id");
+        result.MigrationRoute.Should().Be("OneDriveToDropbox");
+        result.DestinationProvider.Should().Be("dropbox");
+    }
+
+    [Fact]
+    public async Task GetDiscoveryConfigAsync_WhenFileNotExists_ReturnsDefaults()
+    {
+        // 検証対象: GetDiscoveryConfigAsync  目的: config.json が存在しない場合にデフォルト DTO が返されること
+        File.Delete(_configFile);
+
+        var result = await _sut.GetDiscoveryConfigAsync();
+
+        result.OneDriveUserId.Should().BeEmpty();
+        result.DestinationProvider.Should().Be("sharepoint");
+    }
+
+    // ── UpdateDiscoveryConfigAsync ─────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateDiscoveryConfigAsync_WhenOneDriveUserIdIsSet_PersistsValue()
+    {
+        // 検証対象: UpdateDiscoveryConfigAsync  目的: OneDriveUserId が config.json に保存されること
+        await _sut.UpdateDiscoveryConfigAsync(new DiscoveryConfigUpdateDto(
+            OneDriveUserId: "test@contoso.com"));
+
+        var result = await _sut.GetDiscoveryConfigAsync();
+        result.OneDriveUserId.Should().Be("test@contoso.com");
+    }
+
+    [Fact]
+    public async Task UpdateDiscoveryConfigAsync_WhenOneDriveDriveIdIsSet_PersistsValue()
+    {
+        // 検証対象: UpdateDiscoveryConfigAsync  目的: OneDriveDriveId が config.json に保存されること
+        await _sut.UpdateDiscoveryConfigAsync(new DiscoveryConfigUpdateDto(
+            OneDriveDriveId: "b!test-drive-id-12345"));
+
+        var result = await _sut.GetDiscoveryConfigAsync();
+        result.OneDriveDriveId.Should().Be("b!test-drive-id-12345");
+    }
+
+    [Fact]
+    public async Task UpdateDiscoveryConfigAsync_NullFieldsAreNotOverwritten()
+    {
+        // 検証対象: UpdateDiscoveryConfigAsync  目的: null フィールドは既存値を上書きしないこと
+        await _sut.UpdateDiscoveryConfigAsync(new DiscoveryConfigUpdateDto(
+            OneDriveUserId: "user@contoso.com",
+            OneDriveDriveId: "drive-id-1"));
+
+        // UserId のみ更新（DriveId は null = 変更しない）
+        await _sut.UpdateDiscoveryConfigAsync(new DiscoveryConfigUpdateDto(
+            OneDriveUserId: "updated@contoso.com"));
+
+        var result = await _sut.GetDiscoveryConfigAsync();
+        result.OneDriveUserId.Should().Be("updated@contoso.com");
+        result.OneDriveDriveId.Should().Be("drive-id-1"); // 変更されていないこと
+    }
+
+    [Fact]
+    public async Task UpdateDiscoveryConfigAsync_WhenSharePointFieldsSet_PersistsValues()
+    {
+        // 検証対象: UpdateDiscoveryConfigAsync  目的: SharePoint の SiteId / DriveId が保存されること
+        await _sut.UpdateDiscoveryConfigAsync(new DiscoveryConfigUpdateDto(
+            SharePointSiteId: "contoso.sharepoint.com,abc,def",
+            SharePointDriveId: "b!sp-drive",
+            MigrationRoute: "OneDriveToSharePoint",
+            DestinationProvider: "sharepoint"));
+
+        var result = await _sut.GetDiscoveryConfigAsync();
+        result.SharePointSiteId.Should().Be("contoso.sharepoint.com,abc,def");
+        result.SharePointDriveId.Should().Be("b!sp-drive");
+        result.MigrationRoute.Should().Be("OneDriveToSharePoint");
+        result.DestinationProvider.Should().Be("sharepoint");
+    }
+}

--- a/tests/unit/ConfigurationServiceDiscoveryTests.cs
+++ b/tests/unit/ConfigurationServiceDiscoveryTests.cs
@@ -44,9 +44,9 @@ public sealed class ConfigurationServiceDiscoveryTests : IDisposable
     // ── GetDiscoveryConfigAsync ────────────────────────────────────────
 
     [Fact]
-    public async Task GetDiscoveryConfigAsync_WhenFileIsEmpty_ReturnsDefaults()
+    public async Task GetDiscoveryConfigAsync_WhenDiscoveryFieldsAreMissing_ReturnsDefaults()
     {
-        // 検証対象: GetDiscoveryConfigAsync  目的: graph セクションが空の場合にデフォルト値が返されること
+        // 検証対象: GetDiscoveryConfigAsync  目的: Discovery 関連フィールドが未設定の場合にデフォルト値が返されること
         var result = await _sut.GetDiscoveryConfigAsync();
 
         result.OneDriveUserId.Should().BeEmpty();

--- a/tests/unit/GraphDiscoveryServiceTests.cs
+++ b/tests/unit/GraphDiscoveryServiceTests.cs
@@ -1,0 +1,152 @@
+using CloudMigrator.Providers.Graph.Auth;
+using FluentAssertions;
+
+namespace CloudMigrator.Tests.Unit;
+
+/// <summary>
+/// GraphDiscoveryService のユニットテスト（入力バリデーション + エラーハンドリング）。
+/// ネットワーク疎通が不要なケースのみテストする。実際の API 疎通は E2E テストで確認する。
+/// </summary>
+public sealed class GraphDiscoveryServiceTests
+{
+    private readonly GraphDiscoveryService _sut = new();
+
+    // ── GetOneDriveDriveIdAsync 入力バリデーション ─────────────────────
+
+    [Fact]
+    public async Task GetOneDriveDriveIdAsync_WhenUserIdIsEmpty_ReturnsFailure()
+    {
+        // 検証対象: GetOneDriveDriveIdAsync  目的: UserId 未入力時に失敗結果が返されること
+        var result = await _sut.GetOneDriveDriveIdAsync(
+            clientId: "client-id",
+            tenantId: "tenant-id",
+            clientSecret: "secret",
+            userId: string.Empty);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().NotBeNullOrEmpty();
+        result.DriveId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetOneDriveDriveIdAsync_WhenUserIdIsWhitespace_ReturnsFailure()
+    {
+        // 検証対象: GetOneDriveDriveIdAsync  目的: UserId が空白文字のみの場合に失敗結果が返されること
+        var result = await _sut.GetOneDriveDriveIdAsync(
+            clientId: "client-id",
+            tenantId: "tenant-id",
+            clientSecret: "secret",
+            userId: "   ");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().NotBeNullOrEmpty();
+    }
+
+    // ── SearchSharePointSitesAsync 入力バリデーション ──────────────────
+
+    [Fact]
+    public async Task SearchSharePointSitesAsync_WhenKeywordIsEmpty_ReturnsFailure()
+    {
+        // 検証対象: SearchSharePointSitesAsync  目的: キーワード未入力時に失敗結果が返されること
+        var result = await _sut.SearchSharePointSitesAsync(
+            clientId: "client-id",
+            tenantId: "tenant-id",
+            clientSecret: "secret",
+            keyword: string.Empty);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().NotBeNullOrEmpty();
+        result.Sites.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SearchSharePointSitesAsync_WhenKeywordIsWildcard_ReturnsFailure()
+    {
+        // 検証対象: SearchSharePointSitesAsync  目的: search=* ワイルドカードが拒否されること（全件返し防止）
+        var result = await _sut.SearchSharePointSitesAsync(
+            clientId: "client-id",
+            tenantId: "tenant-id",
+            clientSecret: "secret",
+            keyword: "*");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("ワイルドカード");
+    }
+
+    [Fact]
+    public async Task SearchSharePointSitesAsync_WhenKeywordIsWildcardWithSpaces_ReturnsFailure()
+    {
+        // 検証対象: SearchSharePointSitesAsync  目的: 前後空白付きワイルドカードも拒否されること
+        var result = await _sut.SearchSharePointSitesAsync(
+            clientId: "client-id",
+            tenantId: "tenant-id",
+            clientSecret: "secret",
+            keyword: "  *  ");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("ワイルドカード");
+    }
+
+    // ── GetSharePointSiteByUrlAsync 入力バリデーション ─────────────────
+
+    [Fact]
+    public async Task GetSharePointSiteByUrlAsync_WhenUrlIsEmpty_ReturnsFailure()
+    {
+        // 検証対象: GetSharePointSiteByUrlAsync  目的: URL 未入力時に失敗結果が返されること
+        var result = await _sut.GetSharePointSiteByUrlAsync(
+            clientId: "client-id",
+            tenantId: "tenant-id",
+            clientSecret: "secret",
+            siteUrl: string.Empty);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task GetSharePointSiteByUrlAsync_WhenUrlIsInvalid_ReturnsFailure()
+    {
+        // 検証対象: GetSharePointSiteByUrlAsync  目的: 無効な URL 形式の場合に失敗結果が返されること
+        var result = await _sut.GetSharePointSiteByUrlAsync(
+            clientId: "client-id",
+            tenantId: "tenant-id",
+            clientSecret: "secret",
+            siteUrl: "not-a-url");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("URL");
+    }
+
+    // ── GetSharePointDrivesAsync 入力バリデーション ────────────────────
+
+    [Fact]
+    public async Task GetSharePointDrivesAsync_WhenSiteIdIsEmpty_ReturnsFailure()
+    {
+        // 検証対象: GetSharePointDrivesAsync  目的: サイト ID 未入力時に失敗結果が返されること
+        var result = await _sut.GetSharePointDrivesAsync(
+            clientId: "client-id",
+            tenantId: "tenant-id",
+            clientSecret: "secret",
+            siteId: string.Empty);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().NotBeNullOrEmpty();
+        result.Drives.Should().BeNull();
+    }
+
+    // ── VerifyDriveAsync 入力バリデーション ───────────────────────────
+
+    [Fact]
+    public async Task VerifyDriveAsync_WhenDriveIdIsEmpty_ReturnsFailure()
+    {
+        // 検証対象: VerifyDriveAsync  目的: Drive ID 未入力時に失敗結果が返されること
+        var result = await _sut.VerifyDriveAsync(
+            clientId: "client-id",
+            tenantId: "tenant-id",
+            clientSecret: "secret",
+            driveId: string.Empty);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().NotBeNullOrEmpty();
+    }
+}

--- a/tests/unit/GraphDiscoveryServiceTests.cs
+++ b/tests/unit/GraphDiscoveryServiceTests.cs
@@ -117,6 +117,20 @@ public sealed class GraphDiscoveryServiceTests
         result.ErrorMessage.Should().Contain("URL");
     }
 
+    [Fact]
+    public async Task GetSharePointSiteByUrlAsync_WhenUrlIsHttp_ReturnsFailure()
+    {
+        // 検証対象: GetSharePointSiteByUrlAsync  目的: HTTP URL（非-HTTPS）が拒否されること
+        var result = await _sut.GetSharePointSiteByUrlAsync(
+            clientId: "client-id",
+            tenantId: "tenant-id",
+            clientSecret: "secret",
+            siteUrl: "http://contoso.sharepoint.com/sites/MyTeam");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("HTTPS");
+    }
+
     // ── GetSharePointDrivesAsync 入力バリデーション ────────────────────
 
     [Fact]
@@ -148,5 +162,37 @@ public sealed class GraphDiscoveryServiceTests
 
         result.Success.Should().BeFalse();
         result.ErrorMessage.Should().NotBeNullOrEmpty();
+    }
+
+    // ── BuildAdminConsentError ビジネスロジック ─────────────────────────────────
+
+    [Fact]
+    public void BuildAdminConsentError_WhenAuthorizationRequestDenied_ReturnsConsentGuide()
+    {
+        // 検証対象: BuildAdminConsentError  目的: "Authorization_RequestDenied" コード時に管理者同意ガイドが返されること
+        var message = GraphDiscoveryService.BuildAdminConsentError(403, "Authorization_RequestDenied");
+
+        message.Should().Contain("管理者の同意");
+        message.Should().Contain("Azure Portal");
+    }
+
+    [Fact]
+    public void BuildAdminConsentError_WhenUnknownErrorCode_ReturnsGenericMessage()
+    {
+        // 検証対象: BuildAdminConsentError  目的: 未知コード時に汎用エラーメッセージが返されること
+        var message = GraphDiscoveryService.BuildAdminConsentError(403, "Authorization_Forbidden");
+
+        message.Should().Contain("アクセスが拒否");
+        message.Should().Contain("Authorization_Forbidden");
+    }
+
+    [Fact]
+    public void BuildAdminConsentError_WhenErrorCodeIsNull_ReturnsGenericMessage()
+    {
+        // 検証対象: BuildAdminConsentError  目的: errorCode が null でもクラッシュせず汎用メッセージが返されること
+        var message = GraphDiscoveryService.BuildAdminConsentError(403, null);
+
+        message.Should().Contain("アクセスが拒否");
+        message.Should().NotBeNullOrEmpty();
     }
 }

--- a/tests/unit/GraphDiscoveryServiceTests.cs
+++ b/tests/unit/GraphDiscoveryServiceTests.cs
@@ -453,4 +453,139 @@ public sealed class GraphDiscoveryServiceTests
         result.Success.Should().BeFalse();
         result.ErrorMessage.Should().Contain("アクセスが拒否");
     }
+
+    [Fact]
+    public async Task VerifyDriveAsync_WhenGenericApiException_ReturnsGraphApiError()
+    {
+        // 検証対象: VerifyDriveAsync  目的: 汎用 ApiException で Graph API エラーメッセージが返されること
+        var result = await CreateSutThrowing(new ApiException { ResponseStatusCode = 500 })
+            .VerifyDriveAsync("c", "t", "s", "driveId");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Graph API エラー");
+    }
+
+    [Fact]
+    public async Task VerifyDriveAsync_WhenNetworkError_ReturnsConnectionError()
+    {
+        // 検証対象: VerifyDriveAsync  目的: ネットワークエラーで接続エラーメッセージが返されること
+        var result = await CreateSutThrowing(new HttpRequestException("Network error"))
+            .VerifyDriveAsync("c", "t", "s", "driveId");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("接続エラー");
+    }
+
+    // ── SearchSharePointSitesAsync 残欠落ブランチ ─────────────────────
+
+    [Fact]
+    public async Task SearchSharePointSitesAsync_WhenGenericApiException_ReturnsGraphApiError()
+    {
+        // 検証対象: SearchSharePointSitesAsync  目的: 汎用 ApiException（非 403）で Graph API エラーメッセージが返されること
+        var result = await CreateSutThrowing(new ApiException { ResponseStatusCode = 500 })
+            .SearchSharePointSitesAsync("c", "t", "s", "contoso");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Graph API エラー");
+    }
+
+    // ── GetSharePointSiteByUrlAsync 残欠落ブランチ ────────────────────
+
+    [Fact]
+    public async Task GetSharePointSiteByUrlAsync_WhenApiException403_ReturnsAdminConsentMessage()
+    {
+        // 検証対象: GetSharePointSiteByUrlAsync  目的: 非-OData ApiException 403 でも管理者同意メッセージが返されること
+        var result = await CreateSutThrowing(new ApiException { ResponseStatusCode = 403 })
+            .GetSharePointSiteByUrlAsync("c", "t", "s", "https://contoso.sharepoint.com/sites/MyTeam");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("アクセスが拒否");
+    }
+
+    [Fact]
+    public async Task GetSharePointSiteByUrlAsync_WhenGenericApiException_ReturnsGraphApiError()
+    {
+        // 検証対象: GetSharePointSiteByUrlAsync  目的: 汎用 ApiException で Graph API エラーメッセージが返されること
+        var result = await CreateSutThrowing(new ApiException { ResponseStatusCode = 500 })
+            .GetSharePointSiteByUrlAsync("c", "t", "s", "https://contoso.sharepoint.com/sites/MyTeam");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Graph API エラー");
+    }
+
+    [Fact]
+    public async Task GetSharePointSiteByUrlAsync_WhenNetworkError_ReturnsConnectionError()
+    {
+        // 検証対象: GetSharePointSiteByUrlAsync  目的: ネットワークエラーで接続エラーメッセージが返されること
+        var result = await CreateSutThrowing(new HttpRequestException("Network error"))
+            .GetSharePointSiteByUrlAsync("c", "t", "s", "https://contoso.sharepoint.com/sites/MyTeam");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("接続エラー");
+    }
+
+    // ── GetSharePointDrivesAsync 残欠落ブランチ ───────────────────────
+
+    [Fact]
+    public async Task GetSharePointDrivesAsync_WhenApiException403_ReturnsAdminConsentMessage()
+    {
+        // 検証対象: GetSharePointDrivesAsync  目的: 非-OData ApiException 403 でも管理者同意メッセージが返されること
+        var result = await CreateSutThrowing(new ApiException { ResponseStatusCode = 403 })
+            .GetSharePointDrivesAsync("c", "t", "s", "site-id");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("アクセスが拒否");
+    }
+
+    // ── OperationCanceledException rethrow 確認（全メソッド）────────────
+
+    [Fact]
+    public async Task GetOneDriveDriveIdAsync_WhenCanceled_ThrowsOperationCanceledException()
+    {
+        // 検証対象: GetOneDriveDriveIdAsync  目的: キャンセル時に OperationCanceledException が握り潰されず再スローされること
+        var act = async () => await CreateSutThrowing(new OperationCanceledException())
+            .GetOneDriveDriveIdAsync("c", "t", "s", "user@contoso.com");
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task SearchSharePointSitesAsync_WhenCanceled_ThrowsOperationCanceledException()
+    {
+        // 検証対象: SearchSharePointSitesAsync  目的: キャンセル時に OperationCanceledException が握り潰されず再スローされること
+        var act = async () => await CreateSutThrowing(new OperationCanceledException())
+            .SearchSharePointSitesAsync("c", "t", "s", "contoso");
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task GetSharePointSiteByUrlAsync_WhenCanceled_ThrowsOperationCanceledException()
+    {
+        // 検証対象: GetSharePointSiteByUrlAsync  目的: キャンセル時に OperationCanceledException が握り潰されず再スローされること
+        var act = async () => await CreateSutThrowing(new OperationCanceledException())
+            .GetSharePointSiteByUrlAsync("c", "t", "s", "https://contoso.sharepoint.com/sites/MyTeam");
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task GetSharePointDrivesAsync_WhenCanceled_ThrowsOperationCanceledException()
+    {
+        // 検証対象: GetSharePointDrivesAsync  目的: キャンセル時に OperationCanceledException が握り潰されず再スローされること
+        var act = async () => await CreateSutThrowing(new OperationCanceledException())
+            .GetSharePointDrivesAsync("c", "t", "s", "site-id");
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task VerifyDriveAsync_WhenCanceled_ThrowsOperationCanceledException()
+    {
+        // 検証対象: VerifyDriveAsync  目的: キャンセル時に OperationCanceledException が握り潰されず再スローされること
+        var act = async () => await CreateSutThrowing(new OperationCanceledException())
+            .VerifyDriveAsync("c", "t", "s", "driveId");
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
 }

--- a/tests/unit/GraphDiscoveryServiceTests.cs
+++ b/tests/unit/GraphDiscoveryServiceTests.cs
@@ -172,7 +172,7 @@ public sealed class GraphDiscoveryServiceTests
     public void BuildAdminConsentError_WhenAuthorizationRequestDenied_ReturnsConsentGuide()
     {
         // 検証対象: BuildAdminConsentError  目的: "Authorization_RequestDenied" コード時に管理者同意ガイドが返されること
-        var message = GraphDiscoveryService.BuildAdminConsentError(403, "Authorization_RequestDenied");
+        var message = GraphDiscoveryService.BuildAdminConsentError("Authorization_RequestDenied");
 
         message.Should().Contain("管理者の同意");
         message.Should().Contain("Azure Portal");
@@ -182,7 +182,7 @@ public sealed class GraphDiscoveryServiceTests
     public void BuildAdminConsentError_WhenUnknownErrorCode_ReturnsGenericMessage()
     {
         // 検証対象: BuildAdminConsentError  目的: 未知コード時に汎用エラーメッセージが返されること
-        var message = GraphDiscoveryService.BuildAdminConsentError(403, "Authorization_Forbidden");
+        var message = GraphDiscoveryService.BuildAdminConsentError("Authorization_Forbidden");
 
         message.Should().Contain("アクセスが拒否");
         message.Should().Contain("Authorization_Forbidden");
@@ -192,7 +192,7 @@ public sealed class GraphDiscoveryServiceTests
     public void BuildAdminConsentError_WhenErrorCodeIsNull_ReturnsGenericMessage()
     {
         // 検証対象: BuildAdminConsentError  目的: errorCode が null でもクラッシュせず汎用メッセージが返されること
-        var message = GraphDiscoveryService.BuildAdminConsentError(403, null);
+        var message = GraphDiscoveryService.BuildAdminConsentError(null);
 
         message.Should().Contain("アクセスが拒否");
         message.Should().NotBeNullOrEmpty();

--- a/tests/unit/GraphDiscoveryServiceTests.cs
+++ b/tests/unit/GraphDiscoveryServiceTests.cs
@@ -1,5 +1,7 @@
 using CloudMigrator.Providers.Graph.Auth;
 using FluentAssertions;
+using Microsoft.Graph.Models.ODataErrors;
+using Microsoft.Kiota.Abstractions;
 
 namespace CloudMigrator.Tests.Unit;
 
@@ -194,5 +196,261 @@ public sealed class GraphDiscoveryServiceTests
 
         message.Should().Contain("アクセスが拒否");
         message.Should().NotBeNullOrEmpty();
+    }
+
+    // ── API 応答エラーハンドリング（ClientFactory 注入による例外分岐テスト）──────
+
+    // ClientFactory は try ブロック内で呼ばれるため、ファクトリーから例外を throw するだけで
+    // 全 catch ブランチをカバーできる（ネットワーク疎通不要）。
+
+    private static GraphDiscoveryService CreateSutThrowing(Exception ex)
+    {
+        var sut = new GraphDiscoveryService();
+        sut.ClientFactory = (_, _, _) => throw ex;
+        return sut;
+    }
+
+    private static ODataError MakeODataError(int statusCode, string? code = null, string? message = null) =>
+        new() { ResponseStatusCode = statusCode, Error = new MainError { Code = code, Message = message } };
+
+    // ── GetOneDriveDriveIdAsync 例外ハンドリング ──────────────────────
+
+    [Fact]
+    public async Task GetOneDriveDriveIdAsync_When403ODataError_WithAuthorizationRequestDenied_ReturnsAdminConsentGuide()
+    {
+        // 検証対象: GetOneDriveDriveIdAsync  目的: 403 + Authorization_RequestDenied で管理者同意ガイドが返されること
+        var result = await CreateSutThrowing(MakeODataError(403, "Authorization_RequestDenied"))
+            .GetOneDriveDriveIdAsync("c", "t", "s", "user@contoso.com");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("管理者の同意");
+    }
+
+    [Fact]
+    public async Task GetOneDriveDriveIdAsync_When403ODataError_WithUnknownCode_ReturnsForbiddenMessage()
+    {
+        // 検証対象: GetOneDriveDriveIdAsync  目的: 403 + 未知コードで汎用拒否メッセージが返されること
+        var result = await CreateSutThrowing(MakeODataError(403, "Forbidden_Something"))
+            .GetOneDriveDriveIdAsync("c", "t", "s", "user@contoso.com");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("アクセスが拒否");
+    }
+
+    [Fact]
+    public async Task GetOneDriveDriveIdAsync_When404ODataError_ReturnsUserNotFound()
+    {
+        // 検証対象: GetOneDriveDriveIdAsync  目的: 404 でユーザー未発見メッセージが返されること
+        var result = await CreateSutThrowing(MakeODataError(404))
+            .GetOneDriveDriveIdAsync("c", "t", "s", "user@contoso.com");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("見つかりませんでした");
+    }
+
+    [Fact]
+    public async Task GetOneDriveDriveIdAsync_WhenGenericODataError_ReturnsGraphApiError()
+    {
+        // 検証対象: GetOneDriveDriveIdAsync  目的: 汎用 ODataError で Graph API エラーメッセージが返されること
+        var result = await CreateSutThrowing(MakeODataError(500, message: "Internal Server Error"))
+            .GetOneDriveDriveIdAsync("c", "t", "s", "user@contoso.com");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Graph API エラー");
+    }
+
+    [Fact]
+    public async Task GetOneDriveDriveIdAsync_WhenPureApiException403_ReturnsAdminConsentMessage()
+    {
+        // 検証対象: GetOneDriveDriveIdAsync  目的: 非-OData ApiException 403 でも管理者同意メッセージが返されること
+        var result = await CreateSutThrowing(new ApiException { ResponseStatusCode = 403 })
+            .GetOneDriveDriveIdAsync("c", "t", "s", "user@contoso.com");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("アクセスが拒否");
+    }
+
+    [Fact]
+    public async Task GetOneDriveDriveIdAsync_WhenGenericApiException_ReturnsGraphApiError()
+    {
+        // 検証対象: GetOneDriveDriveIdAsync  目的: 汎用 ApiException で Graph API エラーメッセージが返されること
+        var result = await CreateSutThrowing(new ApiException { ResponseStatusCode = 500 })
+            .GetOneDriveDriveIdAsync("c", "t", "s", "user@contoso.com");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Graph API エラー");
+    }
+
+    [Fact]
+    public async Task GetOneDriveDriveIdAsync_WhenNetworkError_ReturnsConnectionError()
+    {
+        // 検証対象: GetOneDriveDriveIdAsync  目的: ネットワークエラーで接続エラーメッセージが返されること
+        var result = await CreateSutThrowing(new HttpRequestException("Network error"))
+            .GetOneDriveDriveIdAsync("c", "t", "s", "user@contoso.com");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("接続エラー");
+    }
+
+    // ── SearchSharePointSitesAsync 例外ハンドリング ────────────────────
+
+    [Fact]
+    public async Task SearchSharePointSitesAsync_When403ODataError_ReturnsAdminConsentMessage()
+    {
+        // 検証対象: SearchSharePointSitesAsync  目的: 403 で管理者同意メッセージが返されること
+        var result = await CreateSutThrowing(MakeODataError(403, "Authorization_RequestDenied"))
+            .SearchSharePointSitesAsync("c", "t", "s", "contoso");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("管理者の同意");
+    }
+
+    [Fact]
+    public async Task SearchSharePointSitesAsync_WhenGenericODataError_ReturnsGraphApiError()
+    {
+        // 検証対象: SearchSharePointSitesAsync  目的: 汎用 ODataError で Graph API エラーメッセージが返されること
+        var result = await CreateSutThrowing(MakeODataError(500, message: "error"))
+            .SearchSharePointSitesAsync("c", "t", "s", "contoso");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Graph API エラー");
+    }
+
+    [Fact]
+    public async Task SearchSharePointSitesAsync_WhenPureApiException403_ReturnsAdminConsentMessage()
+    {
+        // 検証対象: SearchSharePointSitesAsync  目的: 非-OData ApiException 403 でも管理者同意メッセージが返されること
+        var result = await CreateSutThrowing(new ApiException { ResponseStatusCode = 403 })
+            .SearchSharePointSitesAsync("c", "t", "s", "contoso");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("アクセスが拒否");
+    }
+
+    [Fact]
+    public async Task SearchSharePointSitesAsync_WhenNetworkError_ReturnsConnectionError()
+    {
+        // 検証対象: SearchSharePointSitesAsync  目的: ネットワークエラーで接続エラーメッセージが返されること
+        var result = await CreateSutThrowing(new HttpRequestException("Network error"))
+            .SearchSharePointSitesAsync("c", "t", "s", "contoso");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("接続エラー");
+    }
+
+    // ── GetSharePointSiteByUrlAsync 例外ハンドリング ───────────────────
+
+    [Fact]
+    public async Task GetSharePointSiteByUrlAsync_When403ODataError_ReturnsAdminConsentMessage()
+    {
+        // 検証対象: GetSharePointSiteByUrlAsync  目的: 403 で管理者同意メッセージが返されること
+        var result = await CreateSutThrowing(MakeODataError(403, "Authorization_RequestDenied"))
+            .GetSharePointSiteByUrlAsync("c", "t", "s", "https://contoso.sharepoint.com/sites/MyTeam");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("管理者の同意");
+    }
+
+    [Fact]
+    public async Task GetSharePointSiteByUrlAsync_When404ODataError_ReturnsSiteNotFound()
+    {
+        // 検証対象: GetSharePointSiteByUrlAsync  目的: 404 でサイト未発見メッセージが返されること
+        var result = await CreateSutThrowing(MakeODataError(404))
+            .GetSharePointSiteByUrlAsync("c", "t", "s", "https://contoso.sharepoint.com/sites/MyTeam");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("見つかりませんでした");
+    }
+
+    [Fact]
+    public async Task GetSharePointSiteByUrlAsync_WhenGenericODataError_ReturnsGraphApiError()
+    {
+        // 検証対象: GetSharePointSiteByUrlAsync  目的: 汎用 ODataError で Graph API エラーメッセージが返されること
+        var result = await CreateSutThrowing(MakeODataError(500, message: "error"))
+            .GetSharePointSiteByUrlAsync("c", "t", "s", "https://contoso.sharepoint.com/sites/MyTeam");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Graph API エラー");
+    }
+
+    // ── GetSharePointDrivesAsync 例外ハンドリング ──────────────────────
+
+    [Fact]
+    public async Task GetSharePointDrivesAsync_When403ODataError_ReturnsAdminConsentMessage()
+    {
+        // 検証対象: GetSharePointDrivesAsync  目的: 403 で管理者同意メッセージが返されること
+        var result = await CreateSutThrowing(MakeODataError(403, "Authorization_RequestDenied"))
+            .GetSharePointDrivesAsync("c", "t", "s", "site-id");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("管理者の同意");
+    }
+
+    [Fact]
+    public async Task GetSharePointDrivesAsync_WhenGenericODataError_ReturnsGraphApiError()
+    {
+        // 検証対象: GetSharePointDrivesAsync  目的: 汎用 ODataError で Graph API エラーメッセージが返されること
+        var result = await CreateSutThrowing(MakeODataError(500, message: "error"))
+            .GetSharePointDrivesAsync("c", "t", "s", "site-id");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Graph API エラー");
+    }
+
+    [Fact]
+    public async Task GetSharePointDrivesAsync_WhenPureApiException_ReturnsGraphApiError()
+    {
+        // 検証対象: GetSharePointDrivesAsync  目的: 非-OData ApiException で Graph API エラーメッセージが返されること
+        var result = await CreateSutThrowing(new ApiException { ResponseStatusCode = 500 })
+            .GetSharePointDrivesAsync("c", "t", "s", "site-id");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Graph API エラー");
+    }
+
+    // ── VerifyDriveAsync 例外ハンドリング ──────────────────────────────
+
+    [Fact]
+    public async Task VerifyDriveAsync_When403ODataError_ReturnsAdminConsentMessage()
+    {
+        // 検証対象: VerifyDriveAsync  目的: 403 で管理者同意メッセージが返されること
+        var result = await CreateSutThrowing(MakeODataError(403, "Authorization_RequestDenied"))
+            .VerifyDriveAsync("c", "t", "s", "driveId");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("管理者の同意");
+    }
+
+    [Fact]
+    public async Task VerifyDriveAsync_When404ODataError_ReturnsDriveNotFound()
+    {
+        // 検証対象: VerifyDriveAsync  目的: 404 で Drive 未発見メッセージが返されること
+        var result = await CreateSutThrowing(MakeODataError(404))
+            .VerifyDriveAsync("c", "t", "s", "driveId");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Drive ID");
+    }
+
+    [Fact]
+    public async Task VerifyDriveAsync_WhenGenericODataError_ReturnsGraphApiError()
+    {
+        // 検証対象: VerifyDriveAsync  目的: 汎用 ODataError で Graph API エラーメッセージが返されること
+        var result = await CreateSutThrowing(MakeODataError(500, message: "error"))
+            .VerifyDriveAsync("c", "t", "s", "driveId");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Graph API エラー");
+    }
+
+    [Fact]
+    public async Task VerifyDriveAsync_WhenPureApiException403_ReturnsAdminConsentMessage()
+    {
+        // 検証対象: VerifyDriveAsync  目的: 非-OData ApiException 403 でも管理者同意メッセージが返されること
+        var result = await CreateSutThrowing(new ApiException { ResponseStatusCode = 403 })
+            .VerifyDriveAsync("c", "t", "s", "driveId");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("アクセスが拒否");
     }
 }


### PR DESCRIPTION
## 概要

Issue #111 の実装（OneDrive Drive ID Discovery — Step 2a）。

Azure Entra ID App-only 認証（Client Credentials フロー）を使用して、Personal OneDrive の Drive ID を取得し、SharePoint サイト / ドキュメントライブラリの発見を支援する機能を実装しました。

## 変更内容

### 新規ファイル
- `src/CloudMigrator.Providers.Graph/Auth/IGraphDiscoveryService.cs` — Discovery サービス契約 + 結果型
- `src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs` — Graph SDK v5 実装
  - `GET /users/{userId}/drive` — OneDrive Drive ID 取得
  - `GET /sites?search={keyword}` — SharePoint サイト検索（`search=*` 禁止）
  - `GET /sites/{hostname}:/{path}` — サイト URL 直接解決（0件フォールバック）
  - `GET /sites/{siteId}/drives` — Document Library 一覧取得
  - `GET /drives/{driveId}` — Discovery Verify
  - Admin Consent 未付与エラー (403) の日本語ガイドメッセージ
- `src/CloudMigrator.Dashboard/Components/Wizard/DriveDiscoveryPage.razor` — Step 2a UI
  - UPN / ユーザー ID 入力フォーム
  - App-only 認証制約の説明テキスト（`/me/drive` 不可の旨）
  - Graph Explorer リンク（補助参照）
  - Drive ID 取得・表示・config.json 保存
- `tests/unit/GraphDiscoveryServiceTests.cs` — 入力バリデーション 9 件
- `tests/unit/ConfigurationServiceDiscoveryTests.cs` — 読み書きテスト 7 件

### 変更ファイル
- `src/CloudMigrator.Core/Configuration/ConfigurationService.cs`
  - `DiscoveryConfigDto` / `DiscoveryConfigUpdateDto` 追加
  - `GetDiscoveryConfigAsync` / `UpdateDiscoveryConfigAsync` メソッド追加
- `src/CloudMigrator.Core/Wizard/WizardState.cs`
  - `Step2aOneDriveDiscovery` プロパティ追加（`ToSafeForPersistence` 対応）
- `src/CloudMigrator.Dashboard/Components/Wizard/WizardApp.razor`
  - `WizardStep.DriveDiscovery` ステップ挿入
  - 両路線で AzureAuth → DriveDiscovery → 次ステップへのルーティング
- `src/CloudMigrator.Dashboard/App.xaml.cs`
  - `IGraphDiscoveryService` → `GraphDiscoveryService` DI 登録追加

## テスト結果

```
成功: 16、失敗: 0、スキップ: 0
```

## 受け入れ基準対応状況

- [x] Personal OneDrive Drive ID（移行元）がアプリ内で取得・保存できる
- [x] App-only 認証の制約（UPN 入力必須）が UI 上で明示されている
- [x] SharePoint Site をキーワード検索で絞り込める（`search=*` は使用しない）
- [x] キーワード検索で 0 件の場合に Site URL 直接入力フォールバックが表示される（サービス層のみ、UI は #113残ステップ）
- [x] Discovery 結果が config.json スキーマに従って保存される
- [x] OneDrive→Dropbox 路線選択時に Step 2a が正常に機能する
- [x] Admin Consent 未付与エラー時に適切なガイドが表示される

## 未対応（次ステップ #113残で対応）

- SharePoint Discovery UI（Step 2b: サイト検索・Library 選択）
- Discovery Verify + Migration Preflight の UI 統合
- Graph Explorer フレーム埋め込み（WebView2 可否確認後）