### PR TITLE
fix: TransferJobService バグ修正（ロガー注入・Cancel()/CurrentJob・例外握りつぶし解消）

### DIFF
--- a/src/CloudMigrator.Core/Transfer/TransferJobService.cs
+++ b/src/CloudMigrator.Core/Transfer/TransferJobService.cs
@@ -26,6 +26,15 @@ public interface ITransferJobService
     Task<TransferJobInfo?> TryStartAsync();
 
     /// <summary>
+    /// 旧シグネチャとの互換用オーバーロード。
+    /// キャンセル制御は <see cref="Cancel"/> に移行したため、
+    /// 渡された <paramref name="cancellationToken"/> は使用せず
+    /// 現行の <see cref="TryStartAsync()"/> に委譲する。
+    /// </summary>
+    Task<TransferJobInfo?> TryStartAsync(CancellationToken cancellationToken)
+        => TryStartAsync();
+
+    /// <summary>
     /// 実行中のジョブをキャンセルする。ジョブがなければ何もしない。
     /// </summary>
     void Cancel();
@@ -107,7 +116,22 @@ public sealed class TransferJobService : ITransferJobService
     }
 
     /// <inheritdoc />
-    public void Cancel() => _currentJobCts?.Cancel();
+    public void Cancel()
+    {
+        var currentJobCts = _currentJobCts;
+        if (currentJobCts is null)
+            return;
+
+        try
+        {
+            currentJobCts.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // RunJobAsync の終了処理と競合して CTS が破棄済みでも、
+            // 外部から見れば「既に終了済みのためキャンセル不要」と同義として扱う。
+        }
+    }
 
     /// <inheritdoc />
     public TransferJobInfo? GetJob(string jobId)

--- a/src/CloudMigrator.Core/Transfer/TransferJobService.cs
+++ b/src/CloudMigrator.Core/Transfer/TransferJobService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
 
 namespace CloudMigrator.Core.Transfer;
 
@@ -22,14 +23,24 @@ public interface ITransferJobService
     /// 新しい転送ジョブを開始する。
     /// 既にジョブが実行中または待機中の場合は <c>null</c> を返す（HTTP 409 Conflict 用）。
     /// </summary>
-    /// <param name="ct">ジョブ停止シグナルとして伝播するキャンセルトークン。</param>
-    Task<TransferJobInfo?> TryStartAsync(CancellationToken ct = default);
+    Task<TransferJobInfo?> TryStartAsync();
+
+    /// <summary>
+    /// 実行中のジョブをキャンセルする。ジョブがなければ何もしない。
+    /// </summary>
+    void Cancel();
 
     /// <summary>
     /// 指定 ID のジョブ状態を取得する。
     /// 存在しない jobId の場合は <c>null</c> を返す（HTTP 404 NotFound 用）。
     /// </summary>
     TransferJobInfo? GetJob(string jobId);
+
+    /// <summary>現在実行中のジョブ情報。なければ <c>null</c>。</summary>
+    TransferJobInfo? CurrentJob { get; }
+
+    /// <summary>ジョブが現在実行中（または待機中）かどうか。</summary>
+    bool IsRunning { get; }
 }
 
 /// <summary>
@@ -52,18 +63,24 @@ public sealed class TransferJobService : ITransferJobService
     private readonly SemaphoreSlim _semaphore = new(1, 1);
     private readonly ConcurrentDictionary<string, TransferJobInfo> _jobs = new();
     private readonly Queue<string> _jobOrder = new();
+    private readonly ILogger<TransferJobService> _logger;
+    private CancellationTokenSource? _currentJobCts;
+    private string? _currentJobId;
 
     /// <param name="work">
     /// ジョブで実行する非同期処理。
-    /// <c>null</c> の場合は即時完了する（Phase 5 で実際の移行処理を注入予定）。
+    /// <c>null</c> の場合は即時完了する。
     /// </param>
-    public TransferJobService(Func<CancellationToken, Task>? work = null)
+    public TransferJobService(
+        ILogger<TransferJobService> logger,
+        Func<CancellationToken, Task>? work = null)
     {
+        _logger = logger;
         _work = work;
     }
 
     /// <inheritdoc />
-    public async Task<TransferJobInfo?> TryStartAsync(CancellationToken ct = default)
+    public async Task<TransferJobInfo?> TryStartAsync()
     {
         // ノンブロッキング取得: 既に別ジョブが保有中なら即座に false が返る
         if (!await _semaphore.WaitAsync(0, CancellationToken.None).ConfigureAwait(false))
@@ -73,6 +90,7 @@ public sealed class TransferJobService : ITransferJobService
         var job = new TransferJobInfo(jobId, JobStatus.Pending, null, null, null);
         _jobs[jobId] = job;
         _jobOrder.Enqueue(jobId);
+        _currentJobId = jobId;
 
         // 上限超過時は最古エントリを削除する
         while (_jobOrder.Count > MaxJobHistoryCount)
@@ -81,11 +99,15 @@ public sealed class TransferJobService : ITransferJobService
                 _jobs.TryRemove(oldId, out _);
         }
 
-        // セマフォは RunJobAsync の finally で解放する（fire-and-forget）
-        _ = RunJobAsync(jobId, ct);
+        // 内部 CTS を新規作成・セマフォは RunJobAsync の finally で解放（fire-and-forget）
+        _currentJobCts = new CancellationTokenSource();
+        _ = RunJobAsync(jobId, _currentJobCts.Token);
 
         return job;
     }
+
+    /// <inheritdoc />
+    public void Cancel() => _currentJobCts?.Cancel();
 
     /// <inheritdoc />
     public TransferJobInfo? GetJob(string jobId)
@@ -93,6 +115,13 @@ public sealed class TransferJobService : ITransferJobService
         _jobs.TryGetValue(jobId, out var job);
         return job;
     }
+
+    /// <inheritdoc />
+    public TransferJobInfo? CurrentJob =>
+        _currentJobId is null ? null : GetJob(_currentJobId);
+
+    /// <inheritdoc />
+    public bool IsRunning => _semaphore.CurrentCount == 0;
 
     private async Task RunJobAsync(string jobId, CancellationToken ct)
     {
@@ -109,12 +138,13 @@ public sealed class TransferJobService : ITransferJobService
                 CompletedAt = DateTimeOffset.UtcNow,
             };
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException ex)
         {
             // ct 由来のキャンセルのみ Cancelled に遷移する。
             // ct と無関係な内部タイムアウト等の OCE は Failed として扱う。
             if (ct.IsCancellationRequested)
             {
+                _logger.LogInformation("ジョブ {JobId} はキャンセルされました。", jobId);
                 _jobs[jobId] = _jobs[jobId] with
                 {
                     Status = JobStatus.Cancelled,
@@ -123,7 +153,7 @@ public sealed class TransferJobService : ITransferJobService
             }
             else
             {
-                // TODO: Phase 5 でロガー注入後、ここで ex の詳細をログに記録する
+                _logger.LogError(ex, "ジョブ {JobId} が内部 OperationCanceledException で失敗しました。", jobId);
                 _jobs[jobId] = _jobs[jobId] with
                 {
                     Status = JobStatus.Failed,
@@ -132,9 +162,9 @@ public sealed class TransferJobService : ITransferJobService
                 };
             }
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            // TODO: Phase 5 でロガー注入後、ここで例外詳細をログに記録する
+            _logger.LogError(ex, "ジョブ {JobId} が予期せぬ例外で失敗しました。", jobId);
             _jobs[jobId] = _jobs[jobId] with
             {
                 Status = JobStatus.Failed,
@@ -144,6 +174,9 @@ public sealed class TransferJobService : ITransferJobService
         }
         finally
         {
+            _currentJobId = null;
+            _currentJobCts?.Dispose();
+            _currentJobCts = null;
             _semaphore.Release();
         }
     }

--- a/tests/unit/TransferJobServiceTests.cs
+++ b/tests/unit/TransferJobServiceTests.cs
@@ -1,5 +1,6 @@
 using CloudMigrator.Core.Transfer;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace CloudMigrator.Tests.Unit;
 
@@ -13,7 +14,7 @@ public sealed class TransferJobServiceTests
     public async Task TryStartAsync_ReturnsJob_WhenNoJobRunning()
     {
         // 検証対象: TryStartAsync  目的: ジョブがない場合 Pending 状態の TransferJobInfo を返す
-        var service = new TransferJobService();
+        var service = new TransferJobService(NullLogger<TransferJobService>.Instance);
 
         var job = await service.TryStartAsync();
 
@@ -28,7 +29,7 @@ public sealed class TransferJobServiceTests
     {
         // 検証対象: TryStartAsync  目的: ジョブ実行中の場合 null を返す（HTTP 409 Conflict 用）
         var tcs = new TaskCompletionSource();
-        var service = new TransferJobService(_ => tcs.Task);
+        var service = new TransferJobService(NullLogger<TransferJobService>.Instance, _ => tcs.Task);
 
         var firstJob = await service.TryStartAsync();
         var secondJob = await service.TryStartAsync();
@@ -43,7 +44,7 @@ public sealed class TransferJobServiceTests
     public async Task GetJob_ReturnsJob_WhenExists()
     {
         // 検証対象: GetJob  目的: TryStartAsync で登録したジョブを jobId で取得できる
-        var service = new TransferJobService();
+        var service = new TransferJobService(NullLogger<TransferJobService>.Instance);
         var job = await service.TryStartAsync();
 
         var found = service.GetJob(job!.JobId);
@@ -56,7 +57,7 @@ public sealed class TransferJobServiceTests
     public void GetJob_ReturnsNull_WhenNotExists()
     {
         // 検証対象: GetJob  目的: 存在しない jobId に対して null を返す（HTTP 404 NotFound 用）
-        var service = new TransferJobService();
+        var service = new TransferJobService(NullLogger<TransferJobService>.Instance);
 
         var result = service.GetJob("nonexistent-id");
 
@@ -68,7 +69,7 @@ public sealed class TransferJobServiceTests
     {
         // 検証対象: RunJobAsync → Completed 遷移  目的: 正常完了後に Completed 状態になる
         var tcs = new TaskCompletionSource();
-        var service = new TransferJobService(_ => tcs.Task);
+        var service = new TransferJobService(NullLogger<TransferJobService>.Instance, _ => tcs.Task);
         var job = await service.TryStartAsync();
 
         tcs.SetResult();
@@ -84,6 +85,7 @@ public sealed class TransferJobServiceTests
     {
         // 検証対象: RunJobAsync → Failed 遷移  目的: 例外発生時に Failed 状態とエラーメッセージを設定する
         var service = new TransferJobService(
+            NullLogger<TransferJobService>.Instance,
             _ => Task.FromException(new InvalidOperationException("テストエラー")));
         var job = await service.TryStartAsync();
 
@@ -101,13 +103,12 @@ public sealed class TransferJobServiceTests
     public async Task RunJob_SetsStatusCancelled_WhenCancelled()
     {
         // 検証対象: RunJobAsync → Cancelled 遷移  目的: キャンセル時に Cancelled 状態になる
-        using var cts = new CancellationTokenSource();
-        var service = new TransferJobService(async ct => await Task.Delay(Timeout.Infinite, ct));
-        var job = await service.TryStartAsync(cts.Token);
+        var service = new TransferJobService(NullLogger<TransferJobService>.Instance, async ct => await Task.Delay(Timeout.Infinite, ct));
+        var job = await service.TryStartAsync();
 
         // ジョブが Running 状態に遷移するまで待ってからキャンセル
         await WaitUntilAsync(() => service.GetJob(job!.JobId)?.Status == JobStatus.Running);
-        cts.Cancel();
+        service.Cancel();
         await WaitUntilAsync(() => service.GetJob(job!.JobId)?.Status == JobStatus.Cancelled);
 
         var updated = service.GetJob(job!.JobId);
@@ -120,7 +121,7 @@ public sealed class TransferJobServiceTests
     {
         // 検証対象: SemaphoreSlim 解放  目的: 先行ジョブ完了後は新たなジョブを開始できる
         var tcs = new TaskCompletionSource();
-        var service = new TransferJobService(_ => tcs.Task);
+        var service = new TransferJobService(NullLogger<TransferJobService>.Instance, _ => tcs.Task);
 
         var job1 = await service.TryStartAsync();
         var midCheck = await service.TryStartAsync(); // Running 中は null


### PR DESCRIPTION
## 概要
タブ切替でジョブが停止するバグ（#129 相当）と、例外が握りつぶされていた問題を修正します。

## 変更内容

### TransferJobService.cs
- `ILogger<TransferJobService>` をコンストラクタ注入
- `TryStartAsync()` から外部 `CancellationToken` パラメータを除去し、内部 `_currentJobCts` で管理
- `Cancel()` メソッド追加（`_currentJobCts?.Cancel()` 経由）
- `CurrentJob` プロパティ追加（現在の `TransferJob` を返す）
- `catch` ブロックで `_logger.LogError(ex, ...)` 追加（例外握りつぶし解消）
- `finally` で `_currentJobId = null; _currentJobCts?.Dispose()` を確実に実行

### TransferJobServiceTests.cs
- `NullLogger<TransferJobService>.Instance` を全コンストラクタ呼び出しに追加
- キャンセルテスト: `cts.Cancel()` → `service.Cancel()` に修正

## テスト
- ユニットテスト 8件すべて PASS 確認済み

## 関連 PR（スタック）
- PR-B（ダッシュボード改善）がこのブランチを base にしています
- PR-C（Config + Provider 修正）がこのブランチを base にしています