### PR TITLE
feat: ダッシュボード全面再実装・フェーズバッジ修正・フルリビルド機能・ウィザード改善

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,7 +14,3 @@ ignore:
   - "src/CloudMigrator.Dashboard/WpfDialogService.cs"
   - "src/CloudMigrator.Cli/Commands/DashboardCommand.cs"
   - "src/CloudMigrator.Cli/Program.cs"
-  # インターフェース定義はカバレッジ対象外
-  - "src/CloudMigrator.Providers.Graph/Auth/ISharePointVerifyService.cs"
-  # テストは別 PR（issue: テスト追加）で対応予定
-  - "src/CloudMigrator.Providers.Graph/Auth/SharePointVerifyService.cs"

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,3 +14,7 @@ ignore:
   - "src/CloudMigrator.Dashboard/WpfDialogService.cs"
   - "src/CloudMigrator.Cli/Commands/DashboardCommand.cs"
   - "src/CloudMigrator.Cli/Program.cs"
+  # インターフェース定義はカバレッジ対象外
+  - "src/CloudMigrator.Providers.Graph/Auth/ISharePointVerifyService.cs"
+  # テストは別 PR（issue: テスト追加）で対応予定
+  - "src/CloudMigrator.Providers.Graph/Auth/SharePointVerifyService.cs"

--- a/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
@@ -50,8 +50,12 @@ public sealed record GraphConfigUpdateDto(
 public sealed record DiscoveryConfigDto(
     string OneDriveUserId,
     string OneDriveDriveId,
+    string OneDriveSourceFolderId,
+    string OneDriveSourceFolderPath,
     string SharePointSiteId,
     string SharePointDriveId,
+    string SharePointDestFolderId,
+    string SharePointDestFolderPath,
     string MigrationRoute,
     string DestinationProvider);
 
@@ -61,8 +65,12 @@ public sealed record DiscoveryConfigDto(
 public sealed record DiscoveryConfigUpdateDto(
     string? OneDriveUserId = null,
     string? OneDriveDriveId = null,
+    string? OneDriveSourceFolderId = null,
+    string? OneDriveSourceFolderPath = null,
     string? SharePointSiteId = null,
     string? SharePointDriveId = null,
+    string? SharePointDestFolderId = null,
+    string? SharePointDestFolderPath = null,
     string? MigrationRoute = null,
     string? DestinationProvider = null);
 
@@ -243,28 +251,32 @@ public sealed class ConfigurationService : IConfigurationService
     public async Task<DiscoveryConfigDto> GetDiscoveryConfigAsync(CancellationToken ct = default)
     {
         if (!File.Exists(_configFilePath))
-            return new DiscoveryConfigDto(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, "sharepoint");
+            return new DiscoveryConfigDto(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, "sharepoint");
 
         var json = await File.ReadAllTextAsync(_configFilePath, ct).ConfigureAwait(false);
         try
         {
             using var doc = JsonDocument.Parse(json);
             if (!doc.RootElement.TryGetProperty("migrator", out var m) || m.ValueKind != JsonValueKind.Object)
-                return new DiscoveryConfigDto(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, "sharepoint");
+                return new DiscoveryConfigDto(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, "sharepoint");
 
             var hasGraphObject = m.TryGetProperty("graph", out var gProp) && gProp.ValueKind == JsonValueKind.Object;
             var oneDriveUserId = hasGraphObject ? GetString(gProp, "oneDriveUserId", string.Empty) : string.Empty;
             var oneDriveDriveId = hasGraphObject ? GetString(gProp, "oneDriveDriveId", string.Empty) : string.Empty;
+            var oneDriveSourceFolderId = hasGraphObject ? GetString(gProp, "oneDriveSourceFolderId", string.Empty) : string.Empty;
+            var oneDriveSourceFolderPath = hasGraphObject ? GetString(gProp, "oneDriveSourceFolderPath", string.Empty) : string.Empty;
             var sharePointSiteId = hasGraphObject ? GetString(gProp, "sharePointSiteId", string.Empty) : string.Empty;
             var sharePointDriveId = hasGraphObject ? GetString(gProp, "sharePointDriveId", string.Empty) : string.Empty;
+            var sharePointDestFolderId = hasGraphObject ? GetString(gProp, "sharePointDestFolderId", string.Empty) : string.Empty;
+            var sharePointDestFolderPath = hasGraphObject ? GetString(gProp, "sharePointDestFolderPath", string.Empty) : string.Empty;
             var migrationRoute = GetString(m, "migrationRoute", string.Empty);
             var destinationProvider = GetString(m, "destinationProvider", "sharepoint");
 
-            return new DiscoveryConfigDto(oneDriveUserId, oneDriveDriveId, sharePointSiteId, sharePointDriveId, migrationRoute, destinationProvider);
+            return new DiscoveryConfigDto(oneDriveUserId, oneDriveDriveId, oneDriveSourceFolderId, oneDriveSourceFolderPath, sharePointSiteId, sharePointDriveId, sharePointDestFolderId, sharePointDestFolderPath, migrationRoute, destinationProvider);
         }
         catch (JsonException)
         {
-            return new DiscoveryConfigDto(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, "sharepoint");
+            return new DiscoveryConfigDto(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, "sharepoint");
         }
     }
 
@@ -295,8 +307,12 @@ public sealed class ConfigurationService : IConfigurationService
 
             if (update.OneDriveUserId is not null) g["oneDriveUserId"] = update.OneDriveUserId;
             if (update.OneDriveDriveId is not null) g["oneDriveDriveId"] = update.OneDriveDriveId;
+            if (update.OneDriveSourceFolderId is not null) g["oneDriveSourceFolderId"] = update.OneDriveSourceFolderId;
+            if (update.OneDriveSourceFolderPath is not null) g["oneDriveSourceFolderPath"] = update.OneDriveSourceFolderPath;
             if (update.SharePointSiteId is not null) g["sharePointSiteId"] = update.SharePointSiteId;
             if (update.SharePointDriveId is not null) g["sharePointDriveId"] = update.SharePointDriveId;
+            if (update.SharePointDestFolderId is not null) g["sharePointDestFolderId"] = update.SharePointDestFolderId;
+            if (update.SharePointDestFolderPath is not null) g["sharePointDestFolderPath"] = update.SharePointDestFolderPath;
             if (update.MigrationRoute is not null) m["migrationRoute"] = update.MigrationRoute;
             if (update.DestinationProvider is not null) m["destinationProvider"] = update.DestinationProvider;
 

--- a/src/CloudMigrator.Core/Wizard/WizardState.cs
+++ b/src/CloudMigrator.Core/Wizard/WizardState.cs
@@ -26,6 +26,10 @@ public sealed class WizardState
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public WizardStepState Step2aOneDriveDiscovery { get; set; } = WizardStepState.NotStarted;
 
+    /// <summary>Step 2b: SharePoint Discovery — Site / Drive 選択（OneDrive→SharePoint 路線）。</summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public WizardStepState Step2bSharePointDiscovery { get; set; } = WizardStepState.NotStarted;
+
     /// <summary>Step 3: Dropbox OAuth 連携（OneDrive→Dropbox 路線）。</summary>
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public WizardStepState Step3DropboxOAuth { get; set; } = WizardStepState.NotStarted;
@@ -54,6 +58,7 @@ public sealed class WizardState
             Step0RouteSelection = Safe(Step0RouteSelection),
             Step1AzureAuth = Safe(Step1AzureAuth),
             Step2aOneDriveDiscovery = Safe(Step2aOneDriveDiscovery),
+            Step2bSharePointDiscovery = Safe(Step2bSharePointDiscovery),
             Step3DropboxOAuth = Safe(Step3DropboxOAuth),
             Step4ConnectionTest = Safe(Step4ConnectionTest),
             IsCompleted = IsCompleted,

--- a/src/CloudMigrator.Dashboard/App.xaml.cs
+++ b/src/CloudMigrator.Dashboard/App.xaml.cs
@@ -124,6 +124,7 @@ public partial class App : Application
         services.AddSingleton<IDropboxVerifyService, DropboxVerifyService>();
         services.AddSingleton<IAzureAuthVerifyService, AzureAuthVerifyService>();
         services.AddSingleton<IGraphDiscoveryService, GraphDiscoveryService>();
+        services.AddSingleton<ISharePointVerifyService, SharePointVerifyService>();
 
         // ── HTTP ─────────────────────────────────────────────────────────────
         services.AddHttpClient();

--- a/src/CloudMigrator.Dashboard/Components/DashboardApp.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardApp.razor
@@ -6,6 +6,7 @@
 @inject IConfigurationService ConfigurationService
 
 <MudThemeProvider Theme="_theme" />
+<MudPopoverProvider />
 <MudDialogProvider />
 <MudSnackbarProvider />
 

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -2,7 +2,13 @@
 @inject ITransferJobService JobService
 @implements IDisposable
 
-<MudText Typo="Typo.h5" Class="mb-4">転送ダッシュボード</MudText>
+<MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-4" Spacing="2">
+    <MudText Typo="Typo.h5">転送ダッシュボード</MudText>
+    @if (!string.IsNullOrEmpty(PhaseLabel))
+    {
+        <MudChip T="string" Color="@PhaseColor" Size="Size.Small">@PhaseLabel</MudChip>
+    }
+</MudStack>
 
 @if (_summary is null)
 {
@@ -11,59 +17,137 @@
 else
 {
     <MudGrid>
-        <!-- ステータスカード -->
-        <MudItem xs="12" sm="6" md="3">
+        <!-- ステータスカード: 完了 / 処理中 / 待機 / 失敗 / 永久失敗 / 合計 -->
+        <MudItem xs="6" sm="4" md="2">
             <MudCard Elevation="2">
                 <MudCardContent>
-                    <MudText Typo="Typo.overline" Color="Color.Default">完了</MudText>
-                    <MudText Typo="Typo.h4" Color="Color.Success">@_summary.Done</MudText>
-                    <MudText Typo="Typo.caption">/ @_summary.Total 件</MudText>
+                    <MudText Typo="Typo.overline">完了</MudText>
+                    <MudText Typo="Typo.h4" Color="Color.Success">@_summary.Done.ToString("N0")</MudText>
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+        <MudItem xs="6" sm="4" md="2">
+            <MudCard Elevation="2">
+                <MudCardContent>
+                    <MudText Typo="Typo.overline">処理中</MudText>
+                    <MudText Typo="Typo.h4" Color="Color.Info">@_summary.Processing.ToString("N0")</MudText>
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+        <MudItem xs="6" sm="4" md="2">
+            <MudCard Elevation="2">
+                <MudCardContent>
+                    <MudText Typo="Typo.overline">待機中</MudText>
+                    <MudText Typo="Typo.h4" Color="Color.Warning">@_summary.Pending.ToString("N0")</MudText>
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+        <MudItem xs="6" sm="4" md="2">
+            <MudCard Elevation="2">
+                <MudCardContent>
+                    <MudText Typo="Typo.overline">失敗</MudText>
+                    <MudText Typo="Typo.h4" Color="Color.Error">@_summary.Failed.ToString("N0")</MudText>
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+        <MudItem xs="6" sm="4" md="2">
+            <MudCard Elevation="2">
+                <MudCardContent>
+                    <MudText Typo="Typo.overline">永久失敗</MudText>
+                    <MudText Typo="Typo.h4" Color="Color.Error">@_summary.PermanentFailed.ToString("N0")</MudText>
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+        <MudItem xs="6" sm="4" md="2">
+            <MudCard Elevation="2">
+                <MudCardContent>
+                    <MudText Typo="Typo.overline">合計</MudText>
+                    <MudText Typo="Typo.h4">@Denominator.ToString("N0")</MudText>
+                    @if (!_summary.CrawlComplete)
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Warning">※クロール中(推定)</MudText>
+                    }
                 </MudCardContent>
             </MudCard>
         </MudItem>
 
-        <MudItem xs="12" sm="6" md="3">
-            <MudCard Elevation="2">
-                <MudCardContent>
-                    <MudText Typo="Typo.overline" Color="Color.Default">処理中</MudText>
-                    <MudText Typo="Typo.h4" Color="Color.Info">@_summary.Processing</MudText>
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
-
-        <MudItem xs="12" sm="6" md="3">
-            <MudCard Elevation="2">
-                <MudCardContent>
-                    <MudText Typo="Typo.overline" Color="Color.Default">待機中</MudText>
-                    <MudText Typo="Typo.h4" Color="Color.Warning">@_summary.Pending</MudText>
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
-
-        <MudItem xs="12" sm="6" md="3">
-            <MudCard Elevation="2">
-                <MudCardContent>
-                    <MudText Typo="Typo.overline" Color="Color.Default">失敗</MudText>
-                    <MudText Typo="Typo.h4" Color="Color.Error">@(_summary.Failed + _summary.PermanentFailed)</MudText>
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
-
-        <!-- 完了率プログレスバー -->
+        <!-- メインプログレスバー -->
         <MudItem xs="12">
             <MudCard Elevation="2">
                 <MudCardContent>
-                    <MudText Typo="Typo.subtitle1" Class="mb-2">完了率: @_summary.CompletionRate.ToString("F1")%</MudText>
-                    <MudProgressLinear Value="@_summary.CompletionRate" Max="100" Color="Color.Success" Size="Size.Large" Rounded="true" />
-                    <MudText Typo="Typo.caption" Class="mt-1">
-                        転送済みサイズ: @FormatBytes(_summary.TotalDoneSizeBytes)
-                    </MudText>
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-2">
+                        <MudText Typo="Typo.subtitle1">完了率: @CompletionRate.ToString("F1")%</MudText>
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">
+                            @_summary.Done.ToString("N0") / @Denominator.ToString("N0") 件
+                            @(!_summary.CrawlComplete ? "（クロール中のため推定）" : "")
+                        </MudText>
+                    </MudStack>
+                    <MudProgressLinear Value="@CompletionRate" Max="100" Color="Color.Success" Size="Size.Large" Rounded="true" />
                 </MudCardContent>
             </MudCard>
         </MudItem>
 
+        <!-- 2次ステータス: 経過 / ETA / 並列数 / リトライ / エラー率 / 転送量 -->
+        <MudItem xs="12">
+            <MudCard Elevation="2">
+                <MudCardContent>
+                    <MudGrid Spacing="1">
+                        <MudItem xs="6" sm="4" md="2">
+                            <MudText Typo="Typo.overline" Color="Color.Secondary">実稼働時間</MudText>
+                            <MudText Typo="Typo.body1"><b>@_workingElapsed</b></MudText>
+                        </MudItem>
+                        <MudItem xs="6" sm="4" md="2">
+                            <MudText Typo="Typo.overline" Color="Color.Secondary">総経過（壁時計）</MudText>
+                            <MudText Typo="Typo.body1" Color="Color.Secondary"><b>@_elapsed</b></MudText>
+                        </MudItem>
+                        <MudItem xs="6" sm="4" md="2">
+                            <MudText Typo="Typo.overline" Color="Color.Secondary">残り予測 (ETA)</MudText>
+                            <MudText Typo="Typo.body1"><b>@_eta</b></MudText>
+                        </MudItem>
+                        <MudItem xs="6" sm="4" md="2">
+                            <MudText Typo="Typo.overline" Color="Color.Secondary">現在並列数</MudText>
+                            <MudText Typo="Typo.body1"><b>@_currentParallelism</b></MudText>
+                        </MudItem>
+                        <MudItem xs="6" sm="4" md="2">
+                            <MudText Typo="Typo.overline" Color="Color.Secondary">リトライ総数</MudText>
+                            <MudText Typo="Typo.body1"><b>@_summary.TotalRetries.ToString("N0")</b></MudText>
+                        </MudItem>
+                        <MudItem xs="6" sm="4" md="2">
+                            <MudText Typo="Typo.overline" Color="Color.Secondary">エラー率</MudText>
+                            <MudText Typo="Typo.body1" Color="@(ErrorRate > 0 ? Color.Error : Color.Success)">
+                                <b>@ErrorRate.ToString("F1")%</b>
+                            </MudText>
+                        </MudItem>
+                        <MudItem xs="6" sm="4" md="2">
+                            <MudText Typo="Typo.overline" Color="Color.Secondary">転送済みデータ</MudText>
+                            <MudText Typo="Typo.body1"><b>@FormatBytes(_summary.TotalDoneSizeBytes)</b></MudText>
+                        </MudItem>
+                    </MudGrid>
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+
+        <!-- フォルダ作成進捗（folder_creation フェーズ、または transferring で folderTotal > 0） -->
+        @if ((_phase == "folder_creation" || _phase == "transferring") && _folderTotal > 0)
+        {
+            <MudItem xs="12">
+                <MudCard Elevation="2">
+                    <MudCardContent>
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-2">
+                            <MudText Typo="Typo.subtitle2">フォルダ作成進捗</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                @_folderDone.ToString("N0") / @_folderTotal.ToString("N0") 件
+                                (@(_phase == "folder_creation" ? "実行中" : "完了"))
+                            </MudText>
+                        </MudStack>
+                        <MudProgressLinear Value="@FolderRate" Max="100" Color="Color.Warning" Size="Size.Medium" Rounded="true" />
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+        }
+
         <!-- ジョブ操作 -->
-        <MudItem xs="12" md="6">
+        <MudItem xs="12" md="4">
             <MudCard Elevation="2">
                 <MudCardHeader>
                     <CardHeaderContent>
@@ -97,9 +181,140 @@ else
                                OnClick="StartJobAsync">
                         転送開始
                     </MudButton>
+                    <MudButton Variant="Variant.Outlined"
+                               Color="Color.Error"
+                               StartIcon="@Icons.Material.Filled.Stop"
+                               Disabled="@(!_isJobRunning)"
+                               OnClick="StopJob">
+                        停止
+                    </MudButton>
                 </MudCardActions>
             </MudCard>
         </MudItem>
+
+        <!-- 移行完了サマリー -->
+        @if (_phase == "completed" && _completedAt.HasValue)
+        {
+            <MudItem xs="12" md="8">
+                <MudCard Elevation="2">
+                    <MudCardHeader>
+                        <CardHeaderContent>
+                            <MudText Typo="Typo.h6" Color="Color.Success">移行完了サマリー</MudText>
+                        </CardHeaderContent>
+                    </MudCardHeader>
+                    <MudCardContent>
+                        <MudGrid Spacing="2">
+                            <MudItem xs="6" sm="3">
+                                <MudText Typo="Typo.overline">完了時刻</MudText>
+                                <MudText Typo="Typo.body2">@_completedAt.Value.LocalDateTime.ToString("MM/dd HH:mm:ss")</MudText>
+                            </MudItem>
+                            <MudItem xs="6" sm="3">
+                                <MudText Typo="Typo.overline">実稼働時間</MudText>
+                                <MudText Typo="Typo.body2">@_workingElapsed</MudText>
+                            </MudItem>
+                            <MudItem xs="6" sm="3">
+                                <MudText Typo="Typo.overline">総経過（壁時計）</MudText>
+                                <MudText Typo="Typo.body2" Color="Color.Secondary">@_elapsed</MudText>
+                            </MudItem>
+                            <MudItem xs="6" sm="3">
+                                <MudText Typo="Typo.overline">転送データ量</MudText>
+                                <MudText Typo="Typo.body2">@FormatBytes(_summary.TotalDoneSizeBytes)</MudText>
+                            </MudItem>
+                            <MudItem xs="6" sm="3">
+                                <MudText Typo="Typo.overline">平均ファイルサイズ</MudText>
+                                <MudText Typo="Typo.body2">@(_summary.Done > 0 ? FormatBytes(_summary.TotalDoneSizeBytes / _summary.Done) : "—")</MudText>
+                            </MudItem>
+                            <MudItem xs="6" sm="3">
+                                <MudText Typo="Typo.overline">ピーク (files/min)</MudText>
+                                <MudText Typo="Typo.body2">@(_peakFilesPerMin > 0 ? _peakFilesPerMin.ToString("F1") + " f/m" : "—")</MudText>
+                            </MudItem>
+                            <MudItem xs="6" sm="3">
+                                <MudText Typo="Typo.overline">ピーク (bytes/sec)</MudText>
+                                <MudText Typo="Typo.body2">@(_peakBytesPerSec > 0 ? FormatBytesPerSec(_peakBytesPerSec) : "—")</MudText>
+                            </MudItem>
+                            <MudItem xs="6" sm="3">
+                                <MudText Typo="Typo.overline">リトライ総数</MudText>
+                                <MudText Typo="Typo.body2">@_summary.TotalRetries.ToString("N0")</MudText>
+                            </MudItem>
+                            <MudItem xs="6" sm="3">
+                                <MudText Typo="Typo.overline">エラー率</MudText>
+                                <MudText Typo="Typo.body2" Color="@(ErrorRate > 5 ? Color.Error : ErrorRate > 0 ? Color.Warning : Color.Success)">@ErrorRate.ToString("F2")%</MudText>
+                            </MudItem>
+                        </MudGrid>
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+        }
+
+        <!-- メトリクスグラフ（データが蓄積されたら表示） -->
+        @if (_filesSeries.Count > 0)
+        {
+            <MudItem xs="12" md="6">
+                <MudCard Elevation="2">
+                    <MudCardHeader>
+                        <CardHeaderContent><MudText Typo="Typo.subtitle2">スループット (files/min)</MudText></CardHeaderContent>
+                    </MudCardHeader>
+                    <MudCardContent>
+                        <MudChart ChartType="ChartType.Line"
+                                  ChartSeries="@_filesSeries"
+                                  XAxisLabels="@_filesLabels"
+                                  Width="100%" Height="180px"
+                                  ChartOptions="@_chartOptions" />
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+        }
+        @if (_bytesSeries.Count > 0)
+        {
+            <MudItem xs="12" md="6">
+                <MudCard Elevation="2">
+                    <MudCardHeader>
+                        <CardHeaderContent><MudText Typo="Typo.subtitle2">スループット (bytes/sec)</MudText></CardHeaderContent>
+                    </MudCardHeader>
+                    <MudCardContent>
+                        <MudChart ChartType="ChartType.Line"
+                                  ChartSeries="@_bytesSeries"
+                                  XAxisLabels="@_bytesLabels"
+                                  Width="100%" Height="180px"
+                                  ChartOptions="@_chartOptions" />
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+        }
+        @if (_rateLimitSeries.Count > 0)
+        {
+            <MudItem xs="12" md="6">
+                <MudCard Elevation="2">
+                    <MudCardHeader>
+                        <CardHeaderContent><MudText Typo="Typo.subtitle2">レートリミット率 (%)</MudText></CardHeaderContent>
+                    </MudCardHeader>
+                    <MudCardContent>
+                        <MudChart ChartType="ChartType.Line"
+                                  ChartSeries="@_rateLimitSeries"
+                                  XAxisLabels="@_rateLimitLabels"
+                                  Width="100%" Height="180px"
+                                  ChartOptions="@_chartOptions" />
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+        }
+        @if (_parallelSeries.Count > 0)
+        {
+            <MudItem xs="12" md="6">
+                <MudCard Elevation="2">
+                    <MudCardHeader>
+                        <CardHeaderContent><MudText Typo="Typo.subtitle2">並列実行数</MudText></CardHeaderContent>
+                    </MudCardHeader>
+                    <MudCardContent>
+                        <MudChart ChartType="ChartType.Line"
+                                  ChartSeries="@_parallelSeries"
+                                  XAxisLabels="@_parallelLabels"
+                                  Width="100%" Height="180px"
+                                  ChartOptions="@_chartOptions" />
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+        }
 
         <!-- 最近の失敗 -->
         @if (_summary.RecentFailed.Count > 0)
@@ -132,16 +347,78 @@ else
 }
 
 @code {
+    // ── サマリー & ジョブ ──────────────────────────────────────────────────────
     private TransferDbSummary? _summary;
     private TransferJobInfo? _currentJob;
     private bool _isJobRunning;
-    // 自動更新ループ用と転送ジョブ用で CTS を分離する
+
+    // ── フェーズ: idle / crawling / folder_creation / transferring / completed ─
+    private string _phase = "";
+    private int _folderTotal;
+    private int _folderDone;
+
+    // ── 計算プロパティ ─────────────────────────────────────────────────────────
+    // crawlTotal が確定している場合はそれを分母にする（クロール中は total が増加するため）
+    private int Denominator =>
+        _summary is null ? 0
+        : (_summary.CrawlComplete && (_summary.CrawlTotal ?? 0) > 0) ? _summary.CrawlTotal!.Value
+        : _summary.Total;
+
+    private double CompletionRate =>
+        Denominator > 0 ? (double)(_summary?.Done ?? 0) / Denominator * 100.0 : 0;
+
+    private double ErrorRate =>
+        _summary is null || _summary.Total == 0 ? 0
+        : (double)(_summary.Failed + _summary.PermanentFailed) / _summary.Total * 100;
+
+    private double FolderRate =>
+        _folderTotal > 0 ? (double)_folderDone / _folderTotal * 100 : 0;
+
+    private string PhaseLabel => _phase switch
+    {
+        "crawling"        => "クロール中",
+        "folder_creation" => "フォルダ作成中",
+        "transferring"    => "転送中",
+        "completed"       => "移行完了",
+        _                 => ""
+    };
+
+    private Color PhaseColor => _phase switch
+    {
+        "crawling"        => Color.Info,
+        "folder_creation" => Color.Warning,
+        "transferring"    => Color.Primary,
+        "completed"       => Color.Success,
+        _                 => Color.Default
+    };
+
+    // ── 2次ステータス ──────────────────────────────────────────────────────────
+    private int _currentParallelism;
+    private double _latestFilesPerMin;
+    private string _elapsed = "—";        // 総経過時間（壁時計時間）
+    private string _workingElapsed = "—"; // 実稼働時間（DB記録の累積秒数）
+    private string _eta = "—";
+    private DateTimeOffset? _completedAt;
+
+    // ── メトリクスグラフ ───────────────────────────────────────────────────────
+    private double _peakFilesPerMin;
+    private double _peakBytesPerSec;
+    private List<ChartSeries> _filesSeries = [];
+    private string[] _filesLabels = [];
+    private List<ChartSeries> _bytesSeries = [];
+    private string[] _bytesLabels = [];
+    private List<ChartSeries> _rateLimitSeries = [];
+    private string[] _rateLimitLabels = [];
+    private List<ChartSeries> _parallelSeries = [];
+    private string[] _parallelLabels = [];
+    private readonly ChartOptions _chartOptions = new() { LineStrokeWidth = 1.5, YAxisTicks = 4, MaxNumYAxisTicks = 6 };
+
+    // ── タイマー ────────────────────────────────────────────────────────────────
     private CancellationTokenSource? _refreshCts;
-    private CancellationTokenSource? _jobCts;
 
     protected override async Task OnInitializedAsync()
     {
-        await RefreshAsync(CancellationToken.None);
+        await RefreshAllAsync(CancellationToken.None);
         _refreshCts = new CancellationTokenSource();
         var token = _refreshCts.Token;
         // 5 秒ごとに自動更新（PeriodicTimer で再入防止）
@@ -152,7 +429,7 @@ else
             {
                 while (await timer.WaitForNextTickAsync(token))
                 {
-                    await RefreshAsync(token);
+                    await RefreshAllAsync(token);
                     await InvokeAsync(StateHasChanged);
                 }
             }
@@ -160,60 +437,199 @@ else
         }, token);
     }
 
-    private async Task RefreshAsync(CancellationToken cancellationToken)
+    private async Task RefreshAllAsync(CancellationToken ct)
     {
-        try
+        try { _summary = await TransferStateDb.GetSummaryAsync(ct); }
+        catch { _summary ??= new TransferDbSummary(); }
+        if (_summary is null) return;
+
+        // ジョブ状態を追従（セマフォで常に最新の実行状態を取得する）
+        _isJobRunning = JobService.IsRunning;
+        // 起動後にタブを切り替えた場合も CurrentJob から再アタッチする
+        _currentJob ??= JobService.CurrentJob;
+        if (_currentJob is not null)
+            _currentJob = JobService.GetJob(_currentJob.JobId) ?? _currentJob;
+
+        await RefreshPhaseAsync(ct);
+        await UpdateElapsedAndEtaAsync(ct);
+        await RefreshFolderProgressAsync(ct);
+        await RefreshMetricsAsync(ct);
+    }
+
+    private async Task RefreshPhaseAsync(CancellationToken ct)
+    {
+        if (_summary is null) return;
+
+        // 完了判定: pending/processing がゼロかつ done が 1 件以上
+        if (_summary.Pending == 0 && _summary.Processing == 0 && _summary.Done > 0)
         {
-            _summary = await TransferStateDb.GetSummaryAsync(cancellationToken);
-        }
-        catch
-        {
-            // DB が存在しない場合は空のサマリーを使用
-            _summary = new TransferDbSummary();
+            if (_phase != "completed")
+            {
+                _phase = "completed";
+                _completedAt ??= _summary.LastUpdatedAt ?? DateTimeOffset.UtcNow;
+            }
+            return;
         }
 
-        // ジョブの最新状態を追従させる（TryStartAsync の戻り値はスナップショットのため自動更新が必要）
-        if (_currentJob is not null)
+        // ジョブが動いていなければ未完了フェーズのバッジは表示しない
+        if (!_isJobRunning)
         {
-            _currentJob = JobService.GetJob(_currentJob.JobId) ?? _currentJob;
-            _isJobRunning = _currentJob.Status is JobStatus.Pending or JobStatus.Running;
+            _phase = "";
+            return;
         }
+
+        if (!_summary.CrawlComplete)
+        {
+            _phase = "crawling";
+            return;
+        }
+
+        var folderCreationDone = await TransferStateDb.GetCheckpointAsync("folder_creation_complete", ct);
+        _phase = folderCreationDone == "true" ? "transferring" : "folder_creation";
+    }
+
+    private async Task RefreshFolderProgressAsync(CancellationToken ct)
+    {
+        var totalStr = await TransferStateDb.GetCheckpointAsync("folder_total", ct);
+        if (int.TryParse(totalStr, out var total)) _folderTotal = total;
+
+        if (_folderTotal > 0)
+        {
+            var metrics = await TransferStateDb.GetMetricsAsync("sp_folder_done", 120, ct);
+            if (metrics.Count > 0) _folderDone = (int)metrics[^1].Value;
+        }
+    }
+
+    private async Task UpdateElapsedAndEtaAsync(CancellationToken ct)
+    {
+        if (_summary is null) return;
+
+        // 実稼働時間: DBに累積保存された秒数（停止中の時間を含まない）
+        var workingSecondsStr = await TransferStateDb.GetCheckpointAsync("pipeline_working_seconds", ct);
+        if (double.TryParse(workingSecondsStr, out var workingSeconds) && workingSeconds > 0)
+        {
+            // ジョブ実行中は現在のセッション分も加算する
+            var additional = _isJobRunning
+                ? (_summary.LastUpdatedAt.HasValue ? (DateTimeOffset.UtcNow - _summary.LastUpdatedAt.Value).TotalSeconds : 0)
+                : 0;
+            _workingElapsed = FormatDuration(workingSeconds + Math.Max(0, additional));
+        }
+
+        // 総経過（壁時計）: PipelineStartedAt から現在/完了まで
+        var startedAt = _summary.PipelineStartedAt ?? _summary.FirstUpdatedAt;
+        if (startedAt.HasValue)
+        {
+            var end = _completedAt ?? DateTimeOffset.UtcNow;
+            _elapsed = FormatDuration((end - startedAt.Value).TotalSeconds);
+        }
+
+        var remaining = _summary.Pending + _summary.Processing + _summary.Failed;
+        _eta = (_latestFilesPerMin > 0 && remaining > 0)
+            ? FormatDuration(remaining / _latestFilesPerMin * 60)
+            : (remaining == 0 ? "完了" : "—");
+    }
+
+    private async Task RefreshMetricsAsync(CancellationToken ct)
+    {
+        if (_summary is null) return;
+        var startedAt = _summary.PipelineStartedAt ?? _summary.FirstUpdatedAt;
+        var minutes = startedAt.HasValue
+            ? Math.Max(60, (int)(DateTimeOffset.UtcNow - startedAt.Value).TotalMinutes + 10)
+            : 60;
+
+        var filesData = await TransferStateDb.GetMetricsAsync("throughput_files_per_min", minutes, ct);
+        var bytesData = await TransferStateDb.GetMetricsAsync("throughput_bytes_per_sec", minutes, ct);
+        var rlData    = await TransferStateDb.GetMetricsAsync("rate_limit_pct",            minutes, ct);
+        var parData   = await TransferStateDb.GetMetricsAsync("current_parallelism",       minutes, ct);
+
+        if (filesData.Count > 0)
+        {
+            _latestFilesPerMin = filesData[^1].Value;
+            _peakFilesPerMin   = Math.Max(_peakFilesPerMin, filesData.Max(p => p.Value));
+            (_filesSeries, _filesLabels) = BuildChartData(filesData, "files/min");
+        }
+        if (bytesData.Count > 0)
+        {
+            _peakBytesPerSec = Math.Max(_peakBytesPerSec, bytesData.Max(p => p.Value));
+            (_bytesSeries, _bytesLabels) = BuildChartData(bytesData, "bytes/sec");
+        }
+        if (rlData.Count > 0)
+            (_rateLimitSeries, _rateLimitLabels) = BuildChartData(rlData, "rate_limit %");
+        if (parData.Count > 0)
+        {
+            _currentParallelism = (int)parData[^1].Value;
+            (_parallelSeries, _parallelLabels) = BuildChartData(parData, "並列数");
+        }
+    }
+
+    private static (List<ChartSeries> series, string[] labels) BuildChartData(
+        IReadOnlyList<MetricPoint> points, string seriesName)
+    {
+        const int maxPoints = 60;
+        const int maxLabels = 8;
+        int dataStep = Math.Max(1, points.Count / maxPoints);
+
+        List<double> data = [];
+        List<string> baseLabels = [];
+        for (int i = 0; i < points.Count; i += dataStep)
+        {
+            data.Add(points[i].Value);
+            baseLabels.Add(points[i].Timestamp.LocalDateTime.ToString("HH:mm"));
+        }
+
+        int labelStep = Math.Max(1, baseLabels.Count / maxLabels);
+        var displayLabels = baseLabels
+            .Select((l, i) => i % labelStep == 0 ? l : "")
+            .ToArray();
+
+        return ([new ChartSeries { Name = seriesName, Data = [.. data] }], displayLabels);
     }
 
     private async Task StartJobAsync()
     {
         if (_isJobRunning) return;
-        _jobCts = new CancellationTokenSource();
-        _currentJob = await JobService.TryStartAsync(_jobCts.Token);
+        _currentJob = await JobService.TryStartAsync();
         _isJobRunning = _currentJob?.Status is JobStatus.Pending or JobStatus.Running;
     }
 
+    private void StopJob() => JobService.Cancel();
+
     private static Color JobStatusColor(JobStatus status) => status switch
     {
-        JobStatus.Pending => Color.Warning,
-        JobStatus.Running => Color.Info,
+        JobStatus.Pending   => Color.Warning,
+        JobStatus.Running   => Color.Info,
         JobStatus.Completed => Color.Success,
-        JobStatus.Failed => Color.Error,
+        JobStatus.Failed    => Color.Error,
         JobStatus.Cancelled => Color.Default,
-        _ => Color.Default,
+        _                   => Color.Default,
     };
 
-    private static string FormatBytes(long bytes)
+    private static string FormatDuration(double seconds)
     {
-        return bytes switch
-        {
-            >= 1_073_741_824 => $"{bytes / 1_073_741_824.0:F1} GB",
-            >= 1_048_576 => $"{bytes / 1_048_576.0:F1} MB",
-            >= 1_024 => $"{bytes / 1_024.0:F1} KB",
-            _ => $"{bytes} B",
-        };
+        var sec = (int)Math.Round(Math.Abs(seconds));
+        if (sec < 60) return $"{sec}秒";
+        if (sec < 3600) return $"{sec / 60}m{sec % 60:D2}s";
+        return $"{sec / 3600}h{sec % 3600 / 60:D2}m";
     }
+
+    private static string FormatBytes(long bytes) => bytes switch
+    {
+        >= 1_073_741_824 => $"{bytes / 1_073_741_824.0:F1} GB",
+        >= 1_048_576     => $"{bytes / 1_048_576.0:F1} MB",
+        >= 1_024         => $"{bytes / 1_024.0:F1} KB",
+        _                => $"{bytes} B",
+    };
+
+    private static string FormatBytesPerSec(double v) => v switch
+    {
+        >= 1_048_576 => $"{v / 1_048_576:F1} MB/s",
+        >= 1_024     => $"{v / 1_024:F1} KB/s",
+        _            => $"{v:F0} B/s",
+    };
 
     public void Dispose()
     {
         _refreshCts?.Cancel();
         _refreshCts?.Dispose();
-        _jobCts?.Cancel();
-        _jobCts?.Dispose();
     }
 }

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -452,17 +452,18 @@ else
             _currentJob = JobService.GetJob(_currentJob.JobId) ?? _currentJob;
 
         await RefreshPhaseAsync(ct);
+        await RefreshMetricsAsync(ct);
         await UpdateElapsedAndEtaAsync(ct);
         await RefreshFolderProgressAsync(ct);
-        await RefreshMetricsAsync(ct);
     }
 
     private async Task RefreshPhaseAsync(CancellationToken ct)
     {
         if (_summary is null) return;
 
-        // 完了判定: pending/processing がゼロかつ done が 1 件以上
-        if (_summary.Pending == 0 && _summary.Processing == 0 && _summary.Done > 0)
+        // 完了判定: ジョブが Completed 状態、または pending/processing がゼロかつ done が 1 件以上
+        var jobCompleted = _currentJob?.Status == CloudMigrator.Core.Transfer.JobStatus.Completed;
+        if (jobCompleted || (_summary.Pending == 0 && _summary.Processing == 0 && _summary.Done > 0))
         {
             if (_phase != "completed")
             {

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -1,5 +1,6 @@
 @inject ITransferStateDb TransferStateDb
 @inject ITransferJobService JobService
+@inject ILogger<DashboardPage> Logger
 @implements IDisposable
 
 <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-4" Spacing="2">
@@ -440,7 +441,7 @@ else
     private async Task RefreshAllAsync(CancellationToken ct)
     {
         try { _summary = await TransferStateDb.GetSummaryAsync(ct); }
-        catch { _summary ??= new TransferDbSummary(); }
+        catch (Exception ex) { Logger.LogError(ex, "RefreshAllAsync: GetSummaryAsync 失敗"); _summary ??= new TransferDbSummary(); }
         if (_summary is null) return;
 
         // ジョブ状態を追従（セマフォで常に最新の実行状態を取得する）
@@ -492,6 +493,7 @@ else
     {
         var totalStr = await TransferStateDb.GetCheckpointAsync("folder_total", ct);
         if (int.TryParse(totalStr, out var total)) _folderTotal = total;
+        else { _folderTotal = 0; _folderDone = 0; }
 
         if (_folderTotal > 0)
         {
@@ -534,7 +536,7 @@ else
         if (_summary is null) return;
         var startedAt = _summary.PipelineStartedAt ?? _summary.FirstUpdatedAt;
         var minutes = startedAt.HasValue
-            ? Math.Max(60, (int)(DateTimeOffset.UtcNow - startedAt.Value).TotalMinutes + 10)
+            ? Math.Clamp((int)(DateTimeOffset.UtcNow - startedAt.Value).TotalMinutes + 10, 60, 120)
             : 60;
 
         var filesData = await TransferStateDb.GetMetricsAsync("throughput_files_per_min", minutes, ct);

--- a/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
@@ -1,5 +1,9 @@
 @inject IConfigurationService ConfigService
+@inject ITransferStateDb TransferStateDb
+@inject ITransferJobService JobService
+@inject IDialogService DialogService
 @inject ISnackbar Snackbar
+@inject ILogger<SettingsPage> Logger
 
 <MudText Typo="Typo.h5" Class="mb-4">設定</MudText>
 
@@ -79,10 +83,53 @@ else
             </MudButton>
         </MudCardActions>
     </MudCard>
+
+    <!-- 危険な操作 -->
+    <MudCard Elevation="2" Style="max-width: 600px;" Class="mt-6">
+        <MudCardHeader>
+            <CardHeaderContent>
+                <MudText Typo="Typo.h6" Color="Color.Error">危険な操作</MudText>
+            </CardHeaderContent>
+        </MudCardHeader>
+        <MudCardContent>
+            <MudAlert Severity="Severity.Warning" Dense="true" Class="mb-3">
+                以下の操作は転送状態・メトリクス・チェックポイントをすべて削除します。
+                元に戻すことはできません。転送をやり直したい場合にのみ使用してください。
+            </MudAlert>
+            <MudText Typo="Typo.body2" Class="mb-1">
+                <b>フルリビルド</b>とは以下を実行します:
+            </MudText>
+            <MudList T="string" Dense="true" Class="mb-2">
+                <MudListItem Icon="@Icons.Material.Filled.DeleteForever" IconColor="Color.Error">SQLite DB の全データ削除（transfer_records / checkpoints / metrics）</MudListItem>
+                <MudListItem Icon="@Icons.Material.Filled.DeleteForever" IconColor="Color.Error">キャッシュファイル削除（OneDrive・SharePoint・Dropbox キャッシュ、skip_list）</MudListItem>
+                <MudListItem Icon="@Icons.Material.Filled.Info" IconColor="Color.Info">次回の転送開始ボタン押下でクロールから全フェーズを再実行</MudListItem>
+            </MudList>
+        </MudCardContent>
+        <MudCardActions>
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Error"
+                       StartIcon="@Icons.Material.Filled.RestartAlt"
+                       Disabled="@_isRebuilding"
+                       OnClick="FullRebuildAsync">
+                @(_isRebuilding ? "実行中..." : "フルリビルド")
+            </MudButton>
+        </MudCardActions>
+    </MudCard>
 }
 
+<!-- 確認ダイアログ -->
+<MudMessageBox @ref="_confirmBox" Title="フルリビルドの確認" CancelText="キャンセル" YesText="実行する">
+    <MessageContent>
+        <MudText>
+            転送状態・メトリクス・チェックポイント・キャッシュファイルをすべて削除します。<br />
+            この操作は<b>元に戻せません</b>。本当に実行しますか？
+        </MudText>
+    </MessageContent>
+</MudMessageBox>
 @code {
     private ConfigDto? _config;
+    private bool _isRebuilding;
+    private MudMessageBox? _confirmBox;
 
     // 編集用フィールド
     private int _editMaxParallelTransfers;
@@ -189,5 +236,43 @@ else
         if (_config is not null)
             CopyToEditFields(_config);
         await Task.CompletedTask;
+    }
+
+    private async Task FullRebuildAsync()
+    {
+        // 1. 確認ダイアログ
+        var confirmed = await _confirmBox!.ShowAsync();
+        if (confirmed is not true) return;
+
+        // 2. ジョブ実行中ならブロック
+        if (JobService.IsRunning)
+        {
+            Snackbar.Add("転送ジョブが実行中です。ダッシュボードで停止してから再試行してください。", Severity.Error);
+            return;
+        }
+
+        _isRebuilding = true;
+        try
+        {
+            // 3. DB 全データ削除
+            await TransferStateDb.ResetAllAsync(CancellationToken.None);
+
+            // 4. キャッシュファイル削除（PathOptions はデフォルト値 = AppDataPaths.LogFile(...) と一致するため new() で十分）
+            var opts = new MigratorOptions();
+            ConfigHashChecker.ClearAll(opts.Paths, Logger);
+
+            Snackbar.Add("フルリビルドが完了しました。転送を再開するにはダッシュボードの「転送開始」ボタンを押してください。", Severity.Success, cfg =>
+            {
+                cfg.VisibleStateDuration = 6000;
+            });
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"フルリビルドに失敗しました: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _isRebuilding = false;
+        }
     }
 }

--- a/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
@@ -1,7 +1,6 @@
 @inject IConfigurationService ConfigService
 @inject ITransferStateDb TransferStateDb
 @inject ITransferJobService JobService
-@inject IDialogService DialogService
 @inject ISnackbar Snackbar
 @inject ILogger<SettingsPage> Logger
 

--- a/src/CloudMigrator.Dashboard/Components/Wizard/AzureSetupPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/AzureSetupPage.razor
@@ -110,12 +110,13 @@
                       ValueChanged="@(v => { _clientSecret = v; _isVerified = false; })"
                       Label="クライアントシークレット（値）"
                       Variant="Variant.Outlined"
+                      Placeholder="@(_hasExistingSecret ? "（保存済み – 変更する場合のみ入力）" : "")"
                       InputType="@(_showSecret ? InputType.Text : InputType.Password)"
                       Disabled="@_isBusy"
                       Adornment="Adornment.End"
                       AdornmentIcon="@(_showSecret ? Icons.Material.Filled.VisibilityOff : Icons.Material.Filled.Visibility)"
                       OnAdornmentClick="@(() => _showSecret = !_showSecret)"
-                      HelperText="「証明書とシークレット」で作成したシークレットの「値」を貼り付けてください。" />
+                      HelperText="@(_hasExistingSecret ? "保存済み。変更しない場合は空のままで次へ進めます。" : "「証明書とシークレット」で作成したシークレットの「値」を貼り付けてください。")" />
 
         @* シークレット有効期限選択 *@
         <MudSelect T="string"
@@ -143,7 +144,7 @@
                         </MudText>
                         <MudIconButton Icon="@Icons.Material.Filled.ContentCopy"
                                        Size="Size.Small"
-                                       Title="URL をコピー"
+                                       aria-label="URL をコピー"
                                        OnClick="CopyAdminConsentUrlAsync" />
                     </MudStack>
                 </MudStack>
@@ -163,7 +164,9 @@
         @if (_isVerified)
         {
             <MudAlert Severity="Severity.Success" Dense="true">
-                認証に成功しました。クレデンシャルは「保存して次へ」をクリックすると Credential Manager に保存されます。
+                @(_hasExistingSecret && string.IsNullOrWhiteSpace(_clientSecret)
+                    ? "保存済みの認証情報を利用します。そのまま「次へ」をクリックしてください。"
+                    : "認証に成功しました。「保存して次へ」をクリックすると Credential Manager に保存されます。")
             </MudAlert>
         }
 
@@ -190,7 +193,7 @@
                        EndIcon="@Icons.Material.Filled.ArrowForward"
                        Disabled="@(!_isVerified || _isBusy)"
                        OnClick="SaveAndNextAsync">
-                保存して次へ
+                @(_hasExistingSecret && string.IsNullOrWhiteSpace(_clientSecret) ? "次へ" : "保存して次へ")
             </MudButton>
         </MudStack>
 
@@ -219,6 +222,7 @@
     private bool _showSecret;
     private bool _isBusy;
     private bool _isVerified;
+    private bool _hasExistingSecret;
     private string? _verifyError;
 
     private bool CanVerify =>
@@ -240,8 +244,8 @@
 
         // 既にシークレットが Credential Manager に保存されていれば Verified 済みとして扱う
         // ClientId ・ TenantId 両方が存在する場合のみ Verified にする
-        var hasSecret = await CredentialStore.ExistsAsync(CredentialKeys.AzureClientSecret);
-        if (hasSecret && !string.IsNullOrEmpty(graphConfig.ClientId) && !string.IsNullOrEmpty(graphConfig.TenantId))
+        _hasExistingSecret = await CredentialStore.ExistsAsync(CredentialKeys.AzureClientSecret);
+        if (_hasExistingSecret && !string.IsNullOrEmpty(graphConfig.ClientId) && !string.IsNullOrEmpty(graphConfig.TenantId))
             _isVerified = true;
     }
 
@@ -278,8 +282,11 @@
         _isBusy = true;
         try
         {
-            // Credential Manager に保存
-            await CredentialStore.SaveAsync(CredentialKeys.AzureClientSecret, _clientSecret.Trim());
+            // シークレットが入力されている場合のみ上書き保存（空のまま保存すると既存が消える）
+            if (!string.IsNullOrWhiteSpace(_clientSecret))
+            {
+                await CredentialStore.SaveAsync(CredentialKeys.AzureClientSecret, _clientSecret.Trim());
+            }
 
             // config.json に ClientId / TenantId / ClientSecretExpiry を保存（シークレット本体は含めない）
             var expiryDate = DateTimeOffset.UtcNow.AddMonths(int.Parse(_secretExpiryMonths));

--- a/src/CloudMigrator.Dashboard/Components/Wizard/ConnectionTestPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/ConnectionTestPage.razor
@@ -1,6 +1,8 @@
 @using CloudMigrator.Core.Wizard
 @using CloudMigrator.Providers.Dropbox.Auth
-@inject IDropboxVerifyService VerifyService
+@using CloudMigrator.Providers.Graph.Auth
+@inject IDropboxVerifyService DropboxVerifyService
+@inject ISharePointVerifyService SharePointVerifyService
 
 @* Step 4: 接続テスト & 完了 *@
 <MudContainer MaxWidth="MaxWidth.Small" Class="py-8">
@@ -12,7 +14,7 @@
             </MudText>
         </div>
 
-        @if (_result is null && !_isRunning)
+        @if (_dropboxResult is null && _sharePointResult is null && !_isRunning)
         {
             <MudText Typo="Typo.body2" Color="Color.Secondary">
                 「テストを実行」ボタンをクリックして接続を確認してください。
@@ -25,14 +27,15 @@
             <MudText Typo="Typo.body2" Align="Align.Center" Color="Color.Secondary">接続確認中...</MudText>
         }
 
-        @if (_result is not null)
+        @* Dropbox 路線の結果 *@
+        @if (_dropboxResult is not null)
         {
-            <MudAlert Severity="@(_result.IsSuccess ? Severity.Success : Severity.Error)" Dense="true">
-                @(_result.IsSuccess ? "すべてのチェックが完了しました。" : "接続テストに失敗しました。")
+            <MudAlert Severity="@(_dropboxResult.IsSuccess ? Severity.Success : Severity.Error)" Dense="true">
+                @(_dropboxResult.IsSuccess ? "すべてのチェックが完了しました。" : "接続テストに失敗しました。")
             </MudAlert>
 
             <MudList T="DropboxVerifyCheck" Dense="true">
-                @foreach (var check in _result.Checks)
+                @foreach (var check in _dropboxResult.Checks)
                 {
                     <MudListItem>
                         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
@@ -40,7 +43,35 @@
                                      Color="@(check.IsSuccess ? Color.Success : (check.Detail?.Contains("スキップ") == true ? Color.Default : Color.Error))"
                                      Size="Size.Small" />
                             <div>
-                                <MudText Typo="Typo.body2"><strong>@LayerLabel(check.Layer)</strong></MudText>
+                                <MudText Typo="Typo.body2"><strong>@DropboxLayerLabel(check.Layer)</strong></MudText>
+                                @if (!string.IsNullOrEmpty(check.Detail))
+                                {
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@check.Detail</MudText>
+                                }
+                            </div>
+                        </MudStack>
+                    </MudListItem>
+                }
+            </MudList>
+        }
+
+        @* SharePoint 路線の結果 *@
+        @if (_sharePointResult is not null)
+        {
+            <MudAlert Severity="@(_sharePointResult.IsSuccess ? Severity.Success : Severity.Error)" Dense="true">
+                @(_sharePointResult.IsSuccess ? "すべてのチェックが完了しました。" : "接続テストに失敗しました。")
+            </MudAlert>
+
+            <MudList T="SharePointVerifyCheck" Dense="true">
+                @foreach (var check in _sharePointResult.Checks)
+                {
+                    <MudListItem>
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                            <MudIcon Icon="@(check.IsSuccess ? Icons.Material.Filled.CheckCircle : Icons.Material.Filled.Cancel)"
+                                     Color="@(check.IsSuccess ? Color.Success : (check.Detail?.Contains("スキップ") == true ? Color.Default : Color.Error))"
+                                     Size="Size.Small" />
+                            <div>
+                                <MudText Typo="Typo.body2"><strong>@SharePointLayerLabel(check.Layer)</strong></MudText>
                                 @if (!string.IsNullOrEmpty(check.Detail))
                                 {
                                     <MudText Typo="Typo.caption" Color="Color.Secondary">@check.Detail</MudText>
@@ -61,7 +92,7 @@
                 テストを実行
             </MudButton>
 
-            @if (_result?.IsSuccess == true)
+            @if (IsCurrentResultSuccess)
             {
                 <MudButton Variant="Variant.Filled"
                            Color="Color.Success"
@@ -77,7 +108,7 @@
                    StartIcon="@Icons.Material.Filled.ArrowBack"
                    Disabled="@_isRunning"
                    OnClick="OnBackClick">
-            Dropbox 連携に戻る
+            @BackButtonLabel
         </MudButton>
     </MudStack>
 </MudContainer>
@@ -88,18 +119,58 @@
     /// <summary>接続テストが全層成功し、完了ボタンが押されたときのコールバック。</summary>
     [Parameter] public EventCallback OnCompleteClick { get; set; }
 
-    private DropboxVerifyResult? _result;
+    /// <summary>
+    /// Credential 層の失敗を前のステップに通知するコールバック。
+    /// 期限切れ・無効なトークンの検出に使用する。
+    /// </summary>
+    [Parameter] public EventCallback OnCredentialFailed { get; set; }
+
+    /// <summary>現在の移行路線。</summary>
+    [Parameter] public WizardRoute Route { get; set; }
+
+    private DropboxVerifyResult? _dropboxResult;
+    private SharePointVerifyResult? _sharePointResult;
     private bool _isRunning;
+
+    private bool IsCurrentResultSuccess =>
+        Route == WizardRoute.OneDriveToDropbox
+            ? _dropboxResult?.IsSuccess == true
+            : _sharePointResult?.IsSuccess == true;
+
+    private string BackButtonLabel =>
+        Route == WizardRoute.OneDriveToDropbox ? "Dropbox 連携に戻る" : "SharePoint Discovery に戻る";
 
     private async Task RunVerifyAsync()
     {
         _isRunning = true;
-        _result = null;
+        _dropboxResult = null;
+        _sharePointResult = null;
         StateHasChanged();
 
         try
         {
-            _result = await VerifyService.VerifyAsync();
+            if (Route == WizardRoute.OneDriveToDropbox)
+            {
+                _dropboxResult = await DropboxVerifyService.VerifyAsync();
+
+                // Credential 層が失敗した場合は前のステップを Failed として通知
+                if (!_dropboxResult.IsSuccess &&
+                    _dropboxResult.Checks.Any(c => c.Layer == DropboxVerifyLayer.Credential && !c.IsSuccess))
+                {
+                    await OnCredentialFailed.InvokeAsync();
+                }
+            }
+            else
+            {
+                _sharePointResult = await SharePointVerifyService.VerifyAsync();
+
+                // Credential 層が失敗した場合は前のステップを Failed として通知
+                if (!_sharePointResult.IsSuccess &&
+                    _sharePointResult.Checks.Any(c => c.Layer == SharePointVerifyLayer.Credential && !c.IsSuccess))
+                {
+                    await OnCredentialFailed.InvokeAsync();
+                }
+            }
         }
         finally
         {
@@ -107,11 +178,19 @@
         }
     }
 
-    private static string LayerLabel(DropboxVerifyLayer layer) => layer switch
+    private static string DropboxLayerLabel(DropboxVerifyLayer layer) => layer switch
     {
         DropboxVerifyLayer.Credential => "Credential Verify（クレデンシャル確認）",
         DropboxVerifyLayer.Discovery  => "Discovery Verify（API 到達確認）",
         DropboxVerifyLayer.Preflight  => "Migration Preflight（読み書き権限確認）",
+        _ => layer.ToString(),
+    };
+
+    private static string SharePointLayerLabel(SharePointVerifyLayer layer) => layer switch
+    {
+        SharePointVerifyLayer.Credential => "Credential Verify（クレデンシャル・認証確認）",
+        SharePointVerifyLayer.Discovery  => "Discovery Verify（SharePoint Drive 到達確認）",
+        SharePointVerifyLayer.Preflight  => "Migration Preflight（読み書き権限確認）",
         _ => layer.ToString(),
     };
 }

--- a/src/CloudMigrator.Dashboard/Components/Wizard/DriveDiscoveryPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/DriveDiscoveryPage.razor
@@ -74,7 +74,7 @@
             <div>
                 <MudText Typo="Typo.subtitle2" Class="mb-1">移行元フォルダ</MudText>
                 <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-2">
-                    OneDrive 内のドのフォルダから移行するか選択します。選択しない場合はドライブ全体を移行します。
+                    OneDrive 内のどのフォルダから移行するか選択します。選択しない場合はドライブ全体を移行します。
                 </MudText>
                 <DriveFolderPicker @ref="_sourceFolderPicker"
                                    DriveId="@(_discoveryResult.DriveId ?? string.Empty)"

--- a/src/CloudMigrator.Dashboard/Components/Wizard/DriveDiscoveryPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/DriveDiscoveryPage.razor
@@ -69,6 +69,22 @@
                     </MudText>
                 </MudStack>
             </MudPaper>
+
+            @* 移行元フォルダ選択 *@
+            <div>
+                <MudText Typo="Typo.subtitle2" Class="mb-1">移行元フォルダ</MudText>
+                <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-2">
+                    OneDrive 内のドのフォルダから移行するか選択します。選択しない場合はドライブ全体を移行します。
+                </MudText>
+                <DriveFolderPicker @ref="_sourceFolderPicker"
+                                   DriveId="@(_discoveryResult.DriveId ?? string.Empty)"
+                                   ClientId="@_clientId"
+                                   TenantId="@_tenantId"
+                                   ClientSecret="@_clientSecret"
+                                   InitialFolderId="@_initialSourceFolderId"
+                                   InitialFolderPath="@_initialSourceFolderPath"
+                                   Disabled="@_isBusy" />
+            </div>
         }
 
         @if (_discoveryResult is { Success: false })
@@ -113,15 +129,29 @@
     [Parameter] public EventCallback OnDiscoveryCompleted { get; set; }
 
     private string _userId = string.Empty;
+    private string _clientId = string.Empty;
+    private string _tenantId = string.Empty;
+    private string _clientSecret = string.Empty;
     private OneDriveDiscoveryResult? _discoveryResult;
     private bool _isBusy;
     private bool _isAdminConsentError;
+    private DriveFolderPicker? _sourceFolderPicker;
+    private string _initialSourceFolderId = string.Empty;
+    private string _initialSourceFolderPath = string.Empty;
 
     protected override async Task OnInitializedAsync()
     {
-        // 既存の設定から UPN をプリロードする
+        // 既存の設定からプリロードする
         var config = await ConfigurationService.GetDiscoveryConfigAsync();
         _userId = config.OneDriveUserId;
+        _initialSourceFolderId = config.OneDriveSourceFolderId;
+        _initialSourceFolderPath = config.OneDriveSourceFolderPath;
+
+        // 認証情報もプリロード（フォルダピッカー渡し用）
+        var graphConfig = await ConfigurationService.GetGraphConfigAsync();
+        _clientId = graphConfig.ClientId;
+        _tenantId = graphConfig.TenantId;
+        _clientSecret = await CredentialStore.GetAsync(CredentialKeys.AzureClientSecret) ?? string.Empty;
     }
 
     private async Task FetchDriveIdAsync()
@@ -155,6 +185,13 @@
             {
                 _isAdminConsentError = _discoveryResult.ErrorMessage?.Contains("管理者の同意") == true;
             }
+            else
+            {
+                // 認証情報をフォルダピッカー用に保持
+                _clientId = clientId;
+                _tenantId = tenantId;
+                _clientSecret = clientSecret;
+            }
         }
         catch (Exception ex)
         {
@@ -176,9 +213,14 @@
         try
         {
             // Discovery 結果を config.json に保存する
+            var folderId = _sourceFolderPicker?.SelectedFolderId ?? string.Empty;
+            var folderPath = _sourceFolderPicker?.SelectedFolderPath ?? string.Empty;
+
             await ConfigurationService.UpdateDiscoveryConfigAsync(new DiscoveryConfigUpdateDto(
                 OneDriveUserId: _userId.Trim(),
-                OneDriveDriveId: driveId));
+                OneDriveDriveId: driveId,
+                OneDriveSourceFolderId: folderId,
+                OneDriveSourceFolderPath: folderPath));
 
             Snackbar.Add("OneDrive の Drive ID を保存しました。", Severity.Success);
             await OnDiscoveryCompleted.InvokeAsync();

--- a/src/CloudMigrator.Dashboard/Components/Wizard/DriveFolderPicker.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/DriveFolderPicker.razor
@@ -156,17 +156,35 @@
     // パンくず表示用（名前のみ）
     private List<string> _breadcrumbs = [];
     private bool _initialized;
+    private string? _previousDriveId;
 
     private string CurrentPathDisplay =>
         string.Join("/", _navStack.Select(n => n.DisplayName));
 
     protected override void OnParametersSet()
     {
-        if (_initialized) return;
-        _initialized = true;
-        // 初期値をプロパティに反映（ページのプリロード対応）
-        SelectedFolderId = InitialFolderId ?? string.Empty;
-        SelectedFolderPath = InitialFolderPath ?? string.Empty;
+        var driveChanged = _initialized && !string.Equals(_previousDriveId, DriveId, StringComparison.Ordinal);
+
+        if (!_initialized || driveChanged)
+        {
+            if (driveChanged)
+            {
+                _isOpen = false;
+                _isBusy = false;
+                _error = null;
+                _navStack.Clear();
+                _currentFolders.Clear();
+                _breadcrumbs.Clear();
+                SelectedFolderId = string.Empty;
+                SelectedFolderPath = string.Empty;
+            }
+
+            _initialized = true;
+            _previousDriveId = DriveId;
+            // 初期値をプロパティに反映（ページのプリロード対応）
+            SelectedFolderId = InitialFolderId ?? string.Empty;
+            SelectedFolderPath = InitialFolderPath ?? string.Empty;
+        }
     }
 
     private async Task OpenPicker()

--- a/src/CloudMigrator.Dashboard/Components/Wizard/DriveFolderPicker.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/DriveFolderPicker.razor
@@ -155,12 +155,15 @@
 
     // パンくず表示用（名前のみ）
     private List<string> _breadcrumbs = [];
+    private bool _initialized;
 
     private string CurrentPathDisplay =>
         string.Join("/", _navStack.Select(n => n.DisplayName));
 
     protected override void OnParametersSet()
     {
+        if (_initialized) return;
+        _initialized = true;
         // 初期値をプロパティに反映（ページのプリロード対応）
         SelectedFolderId = InitialFolderId ?? string.Empty;
         SelectedFolderPath = InitialFolderPath ?? string.Empty;
@@ -225,7 +228,9 @@
     private async Task SelectCurrentFolder()
     {
         var folderId = _navStack.Last().FolderId;
-        var folderPath = CurrentPathDisplay == "ルート" ? string.Empty : CurrentPathDisplay;
+        var folderPath = _navStack.Count <= 1
+            ? string.Empty
+            : string.Join("/", _navStack.Skip(1).Select(n => n.DisplayName));
 
         SelectedFolderId = folderId;
         SelectedFolderPath = folderPath;

--- a/src/CloudMigrator.Dashboard/Components/Wizard/DriveFolderPicker.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/DriveFolderPicker.razor
@@ -1,0 +1,241 @@
+@using CloudMigrator.Providers.Graph.Auth
+@inject IGraphDiscoveryService DiscoveryService
+
+@* ドライブ内のフォルダを階層ナビゲーションで選択するインラインコンポーネント *@
+
+<MudStack Spacing="2">
+
+    @* ── 現在の選択表示 ── *@
+    @if (!_isOpen)
+    {
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudIcon Icon="@Icons.Material.Filled.Folder" Size="Size.Small" Color="Color.Primary" />
+            <MudText Typo="Typo.body2">
+                @(string.IsNullOrEmpty(SelectedFolderPath)
+                    ? "（ルート — ドライブ全体）"
+                    : SelectedFolderPath)
+            </MudText>
+            <MudButton Variant="Variant.Text"
+                       Color="Color.Primary"
+                       Size="Size.Small"
+                       StartIcon="@Icons.Material.Filled.Edit"
+                       Disabled="@Disabled"
+                       OnClick="OpenPicker">
+                変更
+            </MudButton>
+        </MudStack>
+    }
+
+    @* ── フォルダブラウザ（展開時） ── *@
+    @if (_isOpen)
+    {
+        <MudPaper Elevation="2" Class="pa-3">
+            <MudStack Spacing="2">
+
+                @* パンくずナビ *@
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Wrap="Wrap.Wrap">
+                    @for (var i = 0; i < _breadcrumbs.Count; i++)
+                    {
+                        var depth = i;
+                        var name = _breadcrumbs[i];
+                        @if (i > 0)
+                        {
+                            <MudText Color="Color.Secondary"> › </MudText>
+                        }
+                        @if (i < _breadcrumbs.Count - 1)
+                        {
+                            <MudLink OnClick="@(() => NavigateToBreadcrumbDepth(depth))"
+                                     Style="cursor: pointer;">
+                                @name
+                            </MudLink>
+                        }
+                        else
+                        {
+                            <MudText><strong>@name</strong></MudText>
+                        }
+                    }
+                </MudStack>
+
+                @* フォルダ一覧 *@
+                @if (_isBusy)
+                {
+                    <MudStack AlignItems="AlignItems.Center" Spacing="1" Class="py-2">
+                        <MudProgressCircular Indeterminate="true" Size="Size.Small" />
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">取得中...</MudText>
+                    </MudStack>
+                }
+                else if (_error is not null)
+                {
+                    <MudAlert Severity="Severity.Error" Dense="true">@_error</MudAlert>
+                }
+                else if (_currentFolders.Count == 0)
+                {
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">
+                        このフォルダにはサブフォルダがありません。
+                    </MudText>
+                }
+                else
+                {
+                    <MudList T="DriveFolderEntry" Dense="true" Style="max-height: 240px; overflow-y: auto;">
+                        @foreach (var folder in _currentFolders)
+                        {
+                            <MudListItem OnClick="@(() => NavigateIntoAsync(folder))">
+                                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                                    <MudIcon Icon="@Icons.Material.Filled.Folder"
+                                             Size="Size.Small"
+                                             Color="Color.Warning" />
+                                    <MudText Typo="Typo.body2">@folder.DisplayName</MudText>
+                                    <MudIcon Icon="@Icons.Material.Filled.ChevronRight"
+                                             Size="Size.Small"
+                                             Color="Color.Secondary" />
+                                </MudStack>
+                            </MudListItem>
+                        }
+                    </MudList>
+                }
+
+                @* アクションボタン *@
+                <MudStack Row="true" Spacing="2">
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Primary"
+                               Size="Size.Small"
+                               StartIcon="@Icons.Material.Filled.CheckCircle"
+                               Disabled="@_isBusy"
+                               OnClick="SelectCurrentFolder">
+                        @(CurrentPathDisplay == string.Empty
+                            ? "ルートを選択"
+                            : $"「{_breadcrumbs.Last()}」を選択")
+                    </MudButton>
+                    <MudButton Variant="Variant.Text"
+                               Size="Size.Small"
+                               Disabled="@_isBusy"
+                               OnClick="Cancel">
+                        キャンセル
+                    </MudButton>
+                </MudStack>
+
+            </MudStack>
+        </MudPaper>
+    }
+
+</MudStack>
+
+@code {
+    /// <summary>対象 Drive の ID。</summary>
+    [Parameter, EditorRequired] public string DriveId { get; set; } = string.Empty;
+
+    /// <summary>Graph 認証情報。</summary>
+    [Parameter, EditorRequired] public string ClientId { get; set; } = string.Empty;
+    [Parameter, EditorRequired] public string TenantId { get; set; } = string.Empty;
+    [Parameter, EditorRequired] public string ClientSecret { get; set; } = string.Empty;
+
+    /// <summary>初期選択フォルダ ID（null = ルート）。</summary>
+    [Parameter] public string? InitialFolderId { get; set; }
+
+    /// <summary>初期選択フォルダパス（表示用）。</summary>
+    [Parameter] public string? InitialFolderPath { get; set; }
+
+    /// <summary>フォルダが選択されたときのコールバック。(FolderId="", FolderPath="") がルートを意味する。</summary>
+    [Parameter] public EventCallback<(string FolderId, string FolderPath)> OnFolderSelected { get; set; }
+
+    [Parameter] public bool Disabled { get; set; }
+
+    // ── 公開プロパティ（親が読む） ──
+    public string SelectedFolderId { get; private set; } = string.Empty;
+    public string SelectedFolderPath { get; private set; } = string.Empty;
+
+    // ── 内部状態 ──
+    private bool _isOpen;
+    private bool _isBusy;
+    private string? _error;
+
+    // ナビゲーションスタック用
+    private readonly List<(string FolderId, string DisplayName)> _navStack = [];
+    private List<DriveFolderEntry> _currentFolders = [];
+
+    // パンくず表示用（名前のみ）
+    private List<string> _breadcrumbs = [];
+
+    private string CurrentPathDisplay =>
+        string.Join("/", _navStack.Select(n => n.DisplayName));
+
+    protected override void OnParametersSet()
+    {
+        // 初期値をプロパティに反映（ページのプリロード対応）
+        SelectedFolderId = InitialFolderId ?? string.Empty;
+        SelectedFolderPath = InitialFolderPath ?? string.Empty;
+    }
+
+    private async Task OpenPicker()
+    {
+        _isOpen = true;
+        _navStack.Clear();
+        _navStack.Add((string.Empty, "ルート"));
+        RebuildBreadcrumbs();
+        await LoadCurrentFoldersAsync();
+    }
+
+    private void Cancel()
+    {
+        _isOpen = false;
+        _error = null;
+    }
+
+    private async Task NavigateIntoAsync(DriveFolderEntry folder)
+    {
+        _navStack.Add((folder.FolderId, folder.DisplayName));
+        RebuildBreadcrumbs();
+        await LoadCurrentFoldersAsync();
+    }
+
+    private async Task NavigateToBreadcrumbDepth(int depth)
+    {
+        while (_navStack.Count > depth + 1)
+            _navStack.RemoveAt(_navStack.Count - 1);
+        RebuildBreadcrumbs();
+        await LoadCurrentFoldersAsync();
+    }
+
+    private async Task LoadCurrentFoldersAsync()
+    {
+        _isBusy = true;
+        _error = null;
+        _currentFolders = [];
+        StateHasChanged();
+
+        try
+        {
+            var currentFolderId = _navStack.Last().FolderId;
+            var result = await DiscoveryService.ListDriveFoldersAsync(
+                ClientId, TenantId, ClientSecret,
+                DriveId,
+                folderId: string.IsNullOrEmpty(currentFolderId) ? null : currentFolderId);
+
+            if (result.Success)
+                _currentFolders = result.Folders?.ToList() ?? [];
+            else
+                _error = result.ErrorMessage;
+        }
+        finally
+        {
+            _isBusy = false;
+        }
+    }
+
+    private async Task SelectCurrentFolder()
+    {
+        var folderId = _navStack.Last().FolderId;
+        var folderPath = CurrentPathDisplay == "ルート" ? string.Empty : CurrentPathDisplay;
+
+        SelectedFolderId = folderId;
+        SelectedFolderPath = folderPath;
+        _isOpen = false;
+
+        await OnFolderSelected.InvokeAsync((folderId, folderPath));
+    }
+
+    private void RebuildBreadcrumbs()
+    {
+        _breadcrumbs = _navStack.Select(n => n.DisplayName).ToList();
+    }
+}

--- a/src/CloudMigrator.Dashboard/Components/Wizard/SharePointDiscoveryPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/SharePointDiscoveryPage.razor
@@ -1,0 +1,445 @@
+@using CloudMigrator.Core.Configuration
+@using CloudMigrator.Core.Credentials
+@using CloudMigrator.Providers.Graph.Auth
+@inject IGraphDiscoveryService DiscoveryService
+@inject ICredentialStore CredentialStore
+@inject IConfigurationService ConfigurationService
+@inject ISnackbar Snackbar
+
+@* Step 2b: SharePoint Discovery — サイト候補一覧 → Library 選択 *@
+<MudContainer MaxWidth="MaxWidth.Small" Class="py-8">
+    <MudStack Spacing="6">
+
+        <div>
+            <MudText Typo="Typo.h5">保存先を選択してください</MudText>
+            <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mt-1">
+                移行先の SharePoint サイトと Document Library を選択します。
+            </MudText>
+        </div>
+
+        @* ── サイト候補一覧 ─────────────────────────────────────────── *@
+        @if (_isBusy && _phase is BusyPhase.SiteList)
+        {
+            <MudStack AlignItems="AlignItems.Center" Spacing="2" Class="py-4">
+                <MudProgressCircular Indeterminate="true" Size="Size.Small" />
+                <MudText Typo="Typo.body2" Color="Color.Secondary">サイト一覧を取得しています...</MudText>
+            </MudStack>
+        }
+
+        @if (_siteSearchResult is { Success: false })
+        {
+            <MudAlert Severity="Severity.Error" Class="mb-2">
+                <MudText Style="white-space: pre-line;">@_siteSearchResult.ErrorMessage</MudText>
+            </MudAlert>
+            <MudButton Variant="Variant.Outlined"
+                       StartIcon="@Icons.Material.Filled.Refresh"
+                       Disabled="@_isBusy"
+                       OnClick="LoadAllSitesAsync">
+                再試行
+            </MudButton>
+        }
+
+        @if (_siteSearchResult is { Success: true })
+        {
+            var displaySites = _showAll
+                ? _siteSearchResult.Sites!
+                : _siteSearchResult.Sites!.Take(DisplayLimit).ToList();
+            var hiddenCount = _siteSearchResult.Sites!.Count - DisplayLimit;
+
+            @if (_siteSearchResult.Sites!.Count == 0)
+            {
+                <MudAlert Severity="Severity.Warning" Dense="true">
+                    アクセス可能なサイトが見つかりませんでした。
+                    下の「名前で検索」または「URL で指定」からお試しください。
+                </MudAlert>
+            }
+            else
+            {
+                <MudText Typo="Typo.body2" Color="Color.Secondary">
+                    移行先のサイトを選択してください。
+                </MudText>
+                <MudList T="SharePointSiteEntry" Dense="true">
+                    @foreach (var site in displaySites)
+                    {
+                        <MudListItem OnClick="@(() => SelectSiteAsync(site))"
+                                     Class="@(_selectedSite?.SiteId == site.SiteId ? "mud-selected-item" : "")">
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                                <MudIcon Icon="@Icons.Material.Filled.Web" Size="Size.Small" />
+                                <MudText Typo="Typo.body2"><strong>@site.DisplayName</strong></MudText>
+                            </MudStack>
+                        </MudListItem>
+                    }
+                </MudList>
+
+                @if (!_showAll && hiddenCount > 0)
+                {
+                    <MudButton Variant="Variant.Text"
+                               Color="Color.Primary"
+                               Size="Size.Small"
+                               StartIcon="@Icons.Material.Filled.ExpandMore"
+                               OnClick="@(() => _showAll = true)">
+                        他にもあります（+@hiddenCount 件）
+                    </MudButton>
+                }
+            }
+        }
+
+        @* ── 名前で検索（任意・折りたたみ） ──────────────────────────── *@
+        <MudExpansionPanels Elevation="0">
+            <MudExpansionPanel Text="🔍 名前で検索する（任意）" Dense="true">
+                <MudStack Spacing="3" Class="pt-2">
+                    <MudTextField T="string"
+                                  Value="_keyword"
+                                  ValueChanged="@(v => _keyword = v)"
+                                  Label="サイト名キーワード"
+                                  Variant="Variant.Outlined"
+                                  Placeholder="例: Marketing, 社内ポータル"
+                                  Disabled="@_isBusy" />
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Primary"
+                               StartIcon="@Icons.Material.Filled.Search"
+                               Disabled="@(_isBusy || string.IsNullOrWhiteSpace(_keyword))"
+                               OnClick="SearchSitesAsync">
+                        @(_isBusy && _phase == BusyPhase.SiteSearch ? "検索中..." : "検索")
+                    </MudButton>
+                </MudStack>
+            </MudExpansionPanel>
+
+            @* ── URL で直接指定（任意・折りたたみ） ──────────────── *@
+            <MudExpansionPanel Text="🔗 URL で直接指定する（任意）" Dense="true">
+                <MudStack Spacing="3" Class="pt-2">
+                    <MudTextField T="string"
+                                  @bind-Value="_directUrl"
+                                  Label="サイト URL"
+                                  Variant="Variant.Outlined"
+                                  Placeholder="例: https://contoso.sharepoint.com/sites/MyTeam"
+                                  Disabled="@_isBusy"
+                                  HelperText="ブラウザでサイトを開いた際のアドレスバーの URL を貼り付けてください。" />
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Primary"
+                               StartIcon="@Icons.Material.Filled.Link"
+                               Disabled="@(_isBusy || string.IsNullOrWhiteSpace(_directUrl))"
+                               OnClick="GetSiteByUrlAsync">
+                        @(_isBusy && _phase == BusyPhase.SiteByUrl ? "取得中..." : "このサイトを使う")
+                    </MudButton>
+                </MudStack>
+            </MudExpansionPanel>
+        </MudExpansionPanels>
+
+        @* ── Document Library 選択 ──────────────────────────────────── *@
+        @if (_selectedSite is not null)
+        {
+            <MudDivider />
+            <MudText Typo="Typo.subtitle1">
+                <strong>保存先フォルダー（Document Library）</strong>
+            </MudText>
+            <MudText Typo="Typo.body2" Color="Color.Secondary">
+                選択中のサイト: <strong>@_selectedSite.DisplayName</strong>
+            </MudText>
+
+            @if (_isBusy && _phase == BusyPhase.DriveList)
+            {
+                <MudProgressLinear Indeterminate="true" />
+            }
+
+            @if (_driveListResult is { Success: false })
+            {
+                <MudAlert Severity="Severity.Error">@_driveListResult.ErrorMessage</MudAlert>
+            }
+
+            @if (_driveListResult is { Success: true, Drives: { Count: > 0 } })
+            {
+                <MudList T="SharePointDriveEntry" Dense="true">
+                    @foreach (var drive in _driveListResult.Drives!)
+                    {
+                        <MudListItem OnClick="@(() => _selectedDrive = drive)"
+                                     Class="@(_selectedDrive?.DriveId == drive.DriveId ? "mud-selected-item" : "")">
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                                <MudIcon Icon="@Icons.Material.Filled.Folder" Size="Size.Small" />
+                                <MudText Typo="Typo.body2"><strong>@drive.DisplayName</strong></MudText>
+                            </MudStack>
+                        </MudListItem>
+                    }
+                </MudList>
+            }
+
+            @if (_driveListResult is { Success: true, Drives.Count: 0 })
+            {
+                <MudAlert Severity="Severity.Warning" Dense="true">
+                    このサイトに Document Library が見つかりませんでした。
+                </MudAlert>
+            }
+        }
+
+        @* 選択確認パネル *@
+        @if (_selectedSite is not null && _selectedDrive is not null)
+        {
+            <MudPaper Elevation="2" Class="pa-4">
+                <MudStack Spacing="1">
+                    <MudText Typo="Typo.subtitle2" Color="Color.Success">
+                        <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Size="Size.Small" Class="mr-1" />
+                        選択済み
+                    </MudText>
+                    <MudText Typo="Typo.body2">
+                        <strong>@_selectedSite.DisplayName</strong> › @_selectedDrive.DisplayName
+                    </MudText>
+                </MudStack>
+            </MudPaper>
+
+            @* 移行先フォルダ選択 *@
+            <div>
+                <MudText Typo="Typo.subtitle2" Class="mb-1">移行先フォルダ</MudText>
+                <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-2">
+                    Library 内のどのフォルダに保存するか選択します。選択しない場合は Library ルートに保存します。
+                </MudText>
+                <DriveFolderPicker @ref="_destFolderPicker"
+                                   DriveId="@_selectedDrive.DriveId"
+                                   ClientId="@_cachedClientId"
+                                   TenantId="@_cachedTenantId"
+                                   ClientSecret="@_cachedClientSecret"
+                                   InitialFolderId="@_initialDestFolderId"
+                                   InitialFolderPath="@_initialDestFolderPath"
+                                   Disabled="@_isBusy" />
+            </div>
+        }
+
+        @* ナビゲーションボタン *@
+        <MudStack Row="true" Justify="Justify.SpaceBetween" Class="mt-4">
+            <MudButton Variant="Variant.Outlined"
+                       StartIcon="@Icons.Material.Filled.ArrowBack"
+                       OnClick="@(() => OnBackClick.InvokeAsync())"
+                       Disabled="@_isBusy">
+                戻る
+            </MudButton>
+
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       EndIcon="@Icons.Material.Filled.ArrowForward"
+                       Disabled="@(_isBusy || _selectedSite is null || _selectedDrive is null)"
+                       OnClick="SaveAndContinueAsync">
+                次へ
+            </MudButton>
+        </MudStack>
+
+    </MudStack>
+</MudContainer>
+
+@code {
+    private const int DisplayLimit = 15;
+
+    [Parameter] public EventCallback OnBackClick { get; set; }
+    [Parameter] public EventCallback OnDiscoveryCompleted { get; set; }
+
+    private enum BusyPhase { None, SiteSearch, SiteList, SiteByUrl, DriveList }
+
+    private string _keyword = string.Empty;
+    private string _directUrl = string.Empty;
+    private SharePointSiteSearchResult? _siteSearchResult;
+    private SharePointSiteEntry? _selectedSite;
+    private SharePointDriveListResult? _driveListResult;
+    private SharePointDriveEntry? _selectedDrive;
+    private bool _isBusy;
+    private BusyPhase _phase = BusyPhase.None;
+    private bool _showAll;
+    private DriveFolderPicker? _destFolderPicker;
+    private string _cachedClientId = string.Empty;
+    private string _cachedTenantId = string.Empty;
+    private string _cachedClientSecret = string.Empty;
+    private string _initialDestFolderId = string.Empty;
+    private string _initialDestFolderPath = string.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var config = await ConfigurationService.GetDiscoveryConfigAsync();
+        _initialDestFolderId = config.SharePointDestFolderId;
+        _initialDestFolderPath = config.SharePointDestFolderPath;
+
+        await LoadAllSitesAsync();
+    }
+
+    private async Task<(string ClientId, string TenantId, string ClientSecret)?> GetGraphCredentialsAsync()
+    {
+        var graphConfig = await ConfigurationService.GetGraphConfigAsync();
+        var clientSecret = await CredentialStore.GetAsync(CredentialKeys.AzureClientSecret);
+
+        if (string.IsNullOrWhiteSpace(graphConfig.ClientId) ||
+            string.IsNullOrWhiteSpace(graphConfig.TenantId) ||
+            string.IsNullOrWhiteSpace(clientSecret))
+        {
+            Snackbar.Add("Azure 認証情報が保存されていません。Step 1 に戻って再設定してください。", Severity.Error);
+            return null;
+        }
+        _cachedClientId = graphConfig.ClientId;
+        _cachedTenantId = graphConfig.TenantId;
+        _cachedClientSecret = clientSecret;
+        return (graphConfig.ClientId, graphConfig.TenantId, clientSecret);
+    }
+
+    private async Task LoadAllSitesAsync()
+    {
+        var creds = await GetGraphCredentialsAsync();
+        if (creds is null) return;
+
+        _isBusy = true;
+        _phase = BusyPhase.SiteList;
+        _siteSearchResult = null;
+        _selectedSite = null;
+        _driveListResult = null;
+        _selectedDrive = null;
+        _showAll = false;
+        StateHasChanged();
+
+        try
+        {
+            _siteSearchResult = await DiscoveryService.ListAllSharePointSitesAsync(
+                creds.Value.ClientId, creds.Value.TenantId, creds.Value.ClientSecret);
+        }
+        catch (Exception ex)
+        {
+            _siteSearchResult = new SharePointSiteSearchResult(false, ErrorMessage: $"予期しないエラーが発生しました: {ex.Message}");
+        }
+        finally
+        {
+            _isBusy = false;
+            _phase = BusyPhase.None;
+        }
+    }
+
+    private async Task SearchSitesAsync()
+    {
+        var creds = await GetGraphCredentialsAsync();
+        if (creds is null) return;
+
+        _isBusy = true;
+        _phase = BusyPhase.SiteSearch;
+        _siteSearchResult = null;
+        _selectedSite = null;
+        _driveListResult = null;
+        _selectedDrive = null;
+        _showAll = true;
+        StateHasChanged();
+
+        try
+        {
+            _siteSearchResult = await DiscoveryService.SearchSharePointSitesAsync(
+                creds.Value.ClientId, creds.Value.TenantId, creds.Value.ClientSecret, _keyword.Trim());
+        }
+        catch (Exception ex)
+        {
+            _siteSearchResult = new SharePointSiteSearchResult(false, ErrorMessage: $"予期しないエラーが発生しました: {ex.Message}");
+        }
+        finally
+        {
+            _isBusy = false;
+            _phase = BusyPhase.None;
+        }
+    }
+
+    private async Task GetSiteByUrlAsync()
+    {
+        var creds = await GetGraphCredentialsAsync();
+        if (creds is null) return;
+
+        _isBusy = true;
+        _phase = BusyPhase.SiteByUrl;
+        _siteSearchResult = null;
+        _selectedSite = null;
+        _driveListResult = null;
+        _selectedDrive = null;
+        StateHasChanged();
+
+        try
+        {
+            var result = await DiscoveryService.GetSharePointSiteByUrlAsync(
+                creds.Value.ClientId, creds.Value.TenantId, creds.Value.ClientSecret, _directUrl.Trim());
+
+            if (result.Success && result.Sites?.Count > 0)
+            {
+                _siteSearchResult = result;
+                await SelectSiteAsync(result.Sites[0]);
+            }
+            else
+            {
+                _siteSearchResult = result;
+            }
+        }
+        catch (Exception ex)
+        {
+            _siteSearchResult = new SharePointSiteSearchResult(false, ErrorMessage: $"予期しないエラーが発生しました: {ex.Message}");
+        }
+        finally
+        {
+            _isBusy = false;
+            _phase = BusyPhase.None;
+        }
+    }
+
+    private async Task SelectSiteAsync(SharePointSiteEntry site)
+    {
+        _selectedSite = site;
+        _driveListResult = null;
+        _selectedDrive = null;
+        await LoadDrivesAsync();
+    }
+
+    private async Task LoadDrivesAsync()
+    {
+        if (_selectedSite is null) return;
+
+        var creds = await GetGraphCredentialsAsync();
+        if (creds is null) return;
+
+        _isBusy = true;
+        _phase = BusyPhase.DriveList;
+        _driveListResult = null;
+        _selectedDrive = null;
+        StateHasChanged();
+
+        try
+        {
+            _driveListResult = await DiscoveryService.GetSharePointDrivesAsync(
+                creds.Value.ClientId, creds.Value.TenantId, creds.Value.ClientSecret, _selectedSite.SiteId);
+        }
+        catch (Exception ex)
+        {
+            _driveListResult = new SharePointDriveListResult(false, ErrorMessage: $"予期しないエラーが発生しました: {ex.Message}");
+        }
+        finally
+        {
+            _isBusy = false;
+            _phase = BusyPhase.None;
+        }
+    }
+
+    private async Task SaveAndContinueAsync()
+    {
+        if (_selectedSite is null || _selectedDrive is null) return;
+
+        _isBusy = true;
+        try
+        {
+            var folderId = _destFolderPicker?.SelectedFolderId ?? string.Empty;
+            var folderPath = _destFolderPicker?.SelectedFolderPath ?? string.Empty;
+
+            await ConfigurationService.UpdateDiscoveryConfigAsync(new DiscoveryConfigUpdateDto(
+                SharePointSiteId: _selectedSite.SiteId,
+                SharePointDriveId: _selectedDrive.DriveId,
+                SharePointDestFolderId: folderId,
+                SharePointDestFolderPath: folderPath,
+                MigrationRoute: "OneDriveToSharePoint",
+                DestinationProvider: "Graph"));
+
+            Snackbar.Add("SharePoint の接続先を保存しました。", Severity.Success);
+            await OnDiscoveryCompleted.InvokeAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"保存中にエラーが発生しました: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _isBusy = false;
+        }
+    }
+}
+

--- a/src/CloudMigrator.Dashboard/Components/Wizard/SharePointDiscoveryPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/SharePointDiscoveryPage.razor
@@ -427,7 +427,7 @@
                 SharePointDestFolderId: folderId,
                 SharePointDestFolderPath: folderPath,
                 MigrationRoute: "OneDriveToSharePoint",
-                DestinationProvider: "Graph"));
+                DestinationProvider: "sharepoint"));
 
             Snackbar.Add("SharePoint の接続先を保存しました。", Severity.Success);
             await OnDiscoveryCompleted.InvokeAsync();

--- a/src/CloudMigrator.Dashboard/Components/Wizard/WizardApp.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/WizardApp.razor
@@ -35,18 +35,21 @@
                                     OnDiscoveryCompleted="GoToPostDiscoveryStep" />
                 break;
 
-            case WizardStep.SharePointPlaceholder:
-                <SharePointPlaceholderPage OnBackClick="GoToAzureAuth" />
+            case WizardStep.SharePointDiscovery:
+                <SharePointDiscoveryPage OnBackClick="GoToDriveDiscovery"
+                                         OnDiscoveryCompleted="GoToSharePointConnectionTest" />
                 break;
 
             case WizardStep.DropboxOAuth:
                 <DropboxOAuthPage OnBackClick="GoToAzureAuth"
-                                  OnAuthCompleted="GoToConnectionTest" />
+                                  OnAuthCompleted="GoToDropboxConnectionTest" />
                 break;
 
             case WizardStep.ConnectionTest:
-                <ConnectionTestPage OnBackClick="GoToDropboxOAuth"
-                                    OnCompleteClick="CompleteWizardAsync" />
+                <ConnectionTestPage Route="_state.SelectedRoute"
+                                    OnBackClick="GoToPreConnectionTestStep"
+                                    OnCompleteClick="CompleteWizardAsync"
+                                    OnCredentialFailed="OnCredentialFailedAsync" />
                 break;
         }
     </MudMainContent>
@@ -65,7 +68,7 @@
         RouteSelection,
         AzureAuth,
         DriveDiscovery,
-        SharePointPlaceholder,
+        SharePointDiscovery,
         DropboxOAuth,
         ConnectionTest,
     }
@@ -129,8 +132,22 @@
         }
         else
         {
-            _currentStep = WizardStep.SharePointPlaceholder;
+            GoToSharePointDiscovery();
         }
+    }
+
+    private void GoToSharePointDiscovery()
+    {
+        _state.Step2bSharePointDiscovery = WizardStepState.InProgress;
+        _currentStep = WizardStep.SharePointDiscovery;
+    }
+
+    private async Task GoToSharePointConnectionTest()
+    {
+        _state.Step2bSharePointDiscovery = WizardStepState.Verified;
+        _state.Step4ConnectionTest = WizardStepState.InProgress;
+        await WizardStateService.SaveAsync(_state);
+        _currentStep = WizardStep.ConnectionTest;
     }
 
     private void GoToDropboxOAuth()
@@ -139,12 +156,35 @@
         _currentStep = WizardStep.DropboxOAuth;
     }
 
-    private async Task GoToConnectionTest()
+    private async Task GoToDropboxConnectionTest()
     {
         _state.Step3DropboxOAuth = WizardStepState.Verified;
         _state.Step4ConnectionTest = WizardStepState.InProgress;
         _currentStep = WizardStep.ConnectionTest;
         await WizardStateService.SaveAsync(_state);
+    }
+
+    private void GoToPreConnectionTestStep()
+    {
+        // 「戻る」ボタン: 路線に応じて direct back
+        if (_state.SelectedRoute == WizardRoute.OneDriveToDropbox)
+        {
+            GoToDropboxOAuth();
+        }
+        else
+        {
+            GoToSharePointDiscovery();
+        }
+    }
+
+    private async Task OnCredentialFailedAsync()
+    {
+        // Credential 失敗を検出 → Step 1 を Failed にして Step 1 に戻す
+        _state.Step1AzureAuth = WizardStepState.Failed;
+        await WizardStateService.SaveAsync(_state);
+
+        Snackbar.Add("認証情報が無効または期限切れです。Step 1 に戻って再設定してください。", Severity.Warning);
+        GoToAzureAuth();
     }
 
     private async Task CompleteWizardAsync()
@@ -179,32 +219,32 @@
         if (state.Step2aOneDriveDiscovery != WizardStepState.Verified)
             return WizardStep.DriveDiscovery;
 
+        // SharePoint 路線: Step 2b が未完了
+        if (state.SelectedRoute == WizardRoute.OneDriveToSharePoint &&
+            state.Step2bSharePointDiscovery != WizardStepState.Verified)
+            return WizardStep.SharePointDiscovery;
+
         // Dropbox 路線: Step 3 が未完了
         if (state.SelectedRoute == WizardRoute.OneDriveToDropbox &&
             state.Step3DropboxOAuth != WizardStepState.Verified)
             return WizardStep.DropboxOAuth;
 
-        // Dropbox 路線: Step 4 が未完了
-        if (state.SelectedRoute == WizardRoute.OneDriveToDropbox &&
-            state.Step4ConnectionTest != WizardStepState.Verified)
+        // Step 4 が未完了（両路線共通）
+        if (state.Step4ConnectionTest != WizardStepState.Verified)
             return WizardStep.ConnectionTest;
-
-        // SharePoint 路線（#113残ステップで実装予定）
-        if (state.SelectedRoute == WizardRoute.OneDriveToSharePoint)
-            return WizardStep.SharePointPlaceholder;
 
         return WizardStep.Welcome;
     }
 
     private static string StepLabel(WizardStep step) => step switch
     {
-        WizardStep.Welcome               => "ようこそ",
-        WizardStep.RouteSelection        => "Step 0: 移行路線の選択",
-        WizardStep.AzureAuth             => "Step 1: Azure 認証設定",
-        WizardStep.DriveDiscovery        => "Step 2a: OneDrive Drive ID 取得",
-        WizardStep.SharePointPlaceholder => "SharePoint 路線（準備中）",
-        WizardStep.DropboxOAuth          => "Step 3: Dropbox 連携",
-        WizardStep.ConnectionTest        => "Step 4: 接続テスト",
-        _                                => string.Empty,
+        WizardStep.Welcome              => "ようこそ",
+        WizardStep.RouteSelection       => "Step 0: 移行路線の選択",
+        WizardStep.AzureAuth            => "Step 1: Azure 認証設定",
+        WizardStep.DriveDiscovery       => "Step 2a: OneDrive Drive ID 取得",
+        WizardStep.SharePointDiscovery  => "Step 2b: SharePoint 接続先設定",
+        WizardStep.DropboxOAuth         => "Step 3: Dropbox 連携",
+        WizardStep.ConnectionTest       => "Step 4: 接続テスト",
+        _                               => string.Empty,
     };
 }

--- a/src/CloudMigrator.Dashboard/Components/Wizard/WizardApp.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/WizardApp.razor
@@ -179,11 +179,21 @@
 
     private async Task OnCredentialFailedAsync()
     {
-        // Credential 失敗を検出 → Step 1 を Failed にして Step 1 に戻す
+        // Credential 失敗を検出 → 路線に応じて該当ステップを Failed にして戻す
+        if (_state.SelectedRoute == WizardRoute.OneDriveToDropbox)
+        {
+            _state.Step3DropboxOAuth = WizardStepState.Failed;
+            await WizardStateService.SaveAsync(_state);
+
+            Snackbar.Add("Dropbox の認証情報が無効または期限切れです。Dropbox OAuth に戻って再設定してください。", Severity.Warning);
+            GoToDropboxOAuth();
+            return;
+        }
+
         _state.Step1AzureAuth = WizardStepState.Failed;
         await WizardStateService.SaveAsync(_state);
 
-        Snackbar.Add("認証情報が無効または期限切れです。Step 1 に戻って再設定してください。", Severity.Warning);
+        Snackbar.Add("Azure の認証情報が無効または期限切れです。Step 1 に戻って再設定してください。", Severity.Warning);
         GoToAzureAuth();
     }
 

--- a/src/CloudMigrator.Dashboard/_Imports.razor
+++ b/src/CloudMigrator.Dashboard/_Imports.razor
@@ -6,6 +6,7 @@
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.Extensions.DependencyInjection
+@using Microsoft.Extensions.Logging
 @using Microsoft.JSInterop
 @using MudBlazor
 @using CloudMigrator.Core.Configuration

--- a/src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs
+++ b/src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs
@@ -332,6 +332,130 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
 
     // ── プライベートヘルパー ────────────────────────────────────────────────
 
+    /// <inheritdoc/>
+    public async Task<DriveFolderListResult> ListDriveFoldersAsync(
+        string clientId,
+        string tenantId,
+        string clientSecret,
+        string driveId,
+        string? folderId = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(driveId))
+            return new DriveFolderListResult(false, ErrorMessage: "Drive ID が指定されていません。");
+
+        try
+        {
+            var client = ClientFactory(clientId, tenantId, clientSecret);
+
+            Microsoft.Graph.Models.DriveItemCollectionResponse? response;
+            if (string.IsNullOrEmpty(folderId))
+            {
+                response = await client.Drives[driveId].Items["root"].Children
+                    .GetAsync(r => r.QueryParameters.Select = ["id", "name", "folder"],
+                        cancellationToken: ct)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                response = await client.Drives[driveId].Items[folderId].Children
+                    .GetAsync(r => r.QueryParameters.Select = ["id", "name", "folder"],
+                        cancellationToken: ct)
+                    .ConfigureAwait(false);
+            }
+
+            var folders = response?.Value?
+                .Where(item => item.Folder is not null && item.Id is not null)
+                .Select(item => new DriveFolderEntry(item.Id!, item.Name ?? item.Id!))
+                .ToList() ?? [];
+
+            return new DriveFolderListResult(Success: true, Folders: folders);
+        }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
+        {
+            return new DriveFolderListResult(false,
+                ErrorMessage: BuildAdminConsentError(ex.Error?.Code));
+        }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 404)
+        {
+            return new DriveFolderListResult(false,
+                ErrorMessage: "指定されたフォルダが見つかりませんでした。");
+        }
+        catch (ODataError ex)
+        {
+            return new DriveFolderListResult(false,
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
+        catch (ApiException ex)
+        {
+            return new DriveFolderListResult(false,
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode})");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return new DriveFolderListResult(false, ErrorMessage: $"接続エラー: {ex.Message}");
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<SharePointSiteSearchResult> ListAllSharePointSitesAsync(
+        string clientId,
+        string tenantId,
+        string clientSecret,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var client = ClientFactory(clientId, tenantId, clientSecret);
+            var sitesResponse = await client.Sites
+                .GetAsync(r => r.QueryParameters.Search = "*", ct)
+                .ConfigureAwait(false);
+
+            var sites = sitesResponse?.Value?
+                .Where(s => s.Id is not null)
+                .Select(s => new SharePointSiteEntry(
+                    SiteId: s.Id!,
+                    DisplayName: s.DisplayName ?? s.Name ?? s.Id!,
+                    WebUrl: s.WebUrl ?? string.Empty))
+                .ToList() ?? [];
+
+            return new SharePointSiteSearchResult(Success: true, Sites: sites);
+        }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: BuildAdminConsentError(ex.Error?.Code));
+        }
+        catch (ODataError ex)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
+        catch (ApiException ex) when (ex.ResponseStatusCode == 403)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: BuildAdminConsentError(null));
+        }
+        catch (ApiException ex)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode})");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: $"接続エラー: {ex.Message}");
+        }
+    }
+
     private static GraphServiceClient CreateClient(string clientId, string tenantId, string clientSecret)
     {
         var authenticator = new GraphAuthenticator(clientId, tenantId, clientSecret);

--- a/src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs
+++ b/src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs
@@ -348,26 +348,23 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         {
             var client = ClientFactory(clientId, tenantId, clientSecret);
 
-            Microsoft.Graph.Models.DriveItemCollectionResponse? response;
+            List<DriveFolderEntry> folders;
             if (string.IsNullOrEmpty(folderId))
             {
-                response = await client.Drives[driveId].Items["root"].Children
-                    .GetAsync(r => r.QueryParameters.Select = ["id", "name", "folder"],
-                        cancellationToken: ct)
-                    .ConfigureAwait(false);
+                var builder = client.Drives[driveId].Items["root"].Children;
+                folders = await CollectFolderPagedAsync(
+                    () => builder.GetAsync(r => r.QueryParameters.Select = ["id", "name", "folder"], cancellationToken: ct),
+                    nextLink => builder.WithUrl(nextLink).GetAsync(cancellationToken: ct),
+                    ct).ConfigureAwait(false);
             }
             else
             {
-                response = await client.Drives[driveId].Items[folderId].Children
-                    .GetAsync(r => r.QueryParameters.Select = ["id", "name", "folder"],
-                        cancellationToken: ct)
-                    .ConfigureAwait(false);
+                var builder = client.Drives[driveId].Items[folderId].Children;
+                folders = await CollectFolderPagedAsync(
+                    () => builder.GetAsync(r => r.QueryParameters.Select = ["id", "name", "folder"], cancellationToken: ct),
+                    nextLink => builder.WithUrl(nextLink).GetAsync(cancellationToken: ct),
+                    ct).ConfigureAwait(false);
             }
-
-            var folders = response?.Value?
-                .Where(item => item.Folder is not null && item.Id is not null)
-                .Select(item => new DriveFolderEntry(item.Id!, item.Name ?? item.Id!))
-                .ToList() ?? [];
 
             return new DriveFolderListResult(Success: true, Folders: folders);
         }
@@ -411,17 +408,34 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         try
         {
             var client = ClientFactory(clientId, tenantId, clientSecret);
+
+            var allSites = new List<Microsoft.Graph.Models.Site>();
             var sitesResponse = await client.Sites
                 .GetAsync(r => r.QueryParameters.Search = "*", ct)
                 .ConfigureAwait(false);
+            if (sitesResponse?.Value is not null)
+                allSites.AddRange(sitesResponse.Value);
 
-            var sites = sitesResponse?.Value?
+            var nextLink = sitesResponse?.OdataNextLink;
+            while (!string.IsNullOrWhiteSpace(nextLink))
+            {
+                ct.ThrowIfCancellationRequested();
+                var nextPage = await client.Sites.WithUrl(nextLink)
+                    .GetAsync(cancellationToken: ct).ConfigureAwait(false);
+                if (nextPage?.Value is not null)
+                    allSites.AddRange(nextPage.Value);
+                nextLink = nextPage?.OdataNextLink;
+            }
+
+            var sites = allSites
                 .Where(s => s.Id is not null)
+                .GroupBy(s => s.Id!)
+                .Select(g => g.First())
                 .Select(s => new SharePointSiteEntry(
                     SiteId: s.Id!,
                     DisplayName: s.DisplayName ?? s.Name ?? s.Id!,
                     WebUrl: s.WebUrl ?? string.Empty))
-                .ToList() ?? [];
+                .ToList();
 
             return new SharePointSiteSearchResult(Success: true, Sites: sites);
         }
@@ -454,6 +468,26 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
             return new SharePointSiteSearchResult(false,
                 ErrorMessage: $"接続エラー: {ex.Message}");
         }
+    }
+
+    private static async Task<List<DriveFolderEntry>> CollectFolderPagedAsync(
+        Func<Task<Microsoft.Graph.Models.DriveItemCollectionResponse?>> getFirstPage,
+        Func<string, Task<Microsoft.Graph.Models.DriveItemCollectionResponse?>> getNextPage,
+        CancellationToken ct)
+    {
+        var result = new List<DriveFolderEntry>();
+        var response = await getFirstPage().ConfigureAwait(false);
+        while (response is not null)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (response.Value is not null)
+                result.AddRange(response.Value
+                    .Where(item => item.Folder is not null && item.Id is not null)
+                    .Select(item => new DriveFolderEntry(item.Id!, item.Name ?? item.Id!)));
+            if (string.IsNullOrWhiteSpace(response.OdataNextLink)) break;
+            response = await getNextPage(response.OdataNextLink).ConfigureAwait(false);
+        }
+        return result;
     }
 
     private static GraphServiceClient CreateClient(string clientId, string tenantId, string clientSecret)

--- a/src/CloudMigrator.Providers.Graph/Auth/IGraphDiscoveryService.cs
+++ b/src/CloudMigrator.Providers.Graph/Auth/IGraphDiscoveryService.cs
@@ -57,7 +57,43 @@ public interface IGraphDiscoveryService
         string clientSecret,
         string driveId,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// 指定 Drive の直下または指定フォルダ配下のサブフォルダ一覧を取得する（<c>GET /drives/{driveId}/items/{folderId}/children</c>）。
+    /// <paramref name="folderId"/> が null の場合はルート直下を対象とする。
+    /// </summary>
+    Task<DriveFolderListResult> ListDriveFoldersAsync(
+        string clientId,
+        string tenantId,
+        string clientSecret,
+        string driveId,
+        string? folderId = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// テナント内のすべての SharePoint サイトを取得する（<c>GET /sites?search=*</c>）。
+    /// ページングを考慮した全件取得。
+    /// </summary>
+    Task<SharePointSiteSearchResult> ListAllSharePointSitesAsync(
+        string clientId,
+        string tenantId,
+        string clientSecret,
+        CancellationToken ct = default);
 }
+
+/// <summary>Drive 内フォルダの一覧エントリ。</summary>
+/// <param name="FolderId">アイテム ID。</param>
+/// <param name="DisplayName">表示名。</param>
+public sealed record DriveFolderEntry(string FolderId, string DisplayName);
+
+/// <summary><see cref="IGraphDiscoveryService.ListDriveFoldersAsync"/> の結果。</summary>
+/// <param name="Success">成功かどうか。</param>
+/// <param name="Folders">フォルダ一覧。失敗時は null。</param>
+/// <param name="ErrorMessage">エラー詳細。成功時は null。</param>
+public sealed record DriveFolderListResult(
+    bool Success,
+    IReadOnlyList<DriveFolderEntry>? Folders = null,
+    string? ErrorMessage = null);
 
 /// <summary>OneDrive Drive ID 取得結果。</summary>
 public sealed record OneDriveDiscoveryResult(

--- a/src/CloudMigrator.Providers.Graph/Auth/ISharePointVerifyService.cs
+++ b/src/CloudMigrator.Providers.Graph/Auth/ISharePointVerifyService.cs
@@ -1,0 +1,43 @@
+namespace CloudMigrator.Providers.Graph.Auth;
+
+/// <summary>
+/// SharePoint 接続検証の層。
+/// </summary>
+public enum SharePointVerifyLayer
+{
+    /// <summary>クレデンシャルの存在確認と App-only 認証確認。</summary>
+    Credential,
+
+    /// <summary>SharePoint Drive ID の API 到達確認。</summary>
+    Discovery,
+
+    /// <summary>小ファイル書き込み・削除による読み書き権限確認。</summary>
+    Preflight,
+}
+
+/// <summary>
+/// SharePoint 接続検証の各層の結果。
+/// </summary>
+/// <param name="Layer">検証層。</param>
+/// <param name="IsSuccess">成功かどうか。</param>
+/// <param name="Detail">補足情報またはエラー詳細。</param>
+public sealed record SharePointVerifyCheck(SharePointVerifyLayer Layer, bool IsSuccess, string? Detail);
+
+/// <summary>
+/// SharePoint 接続検証の全体結果。
+/// </summary>
+/// <param name="IsSuccess">全層が成功した場合 true。</param>
+/// <param name="Checks">各層の検証結果。</param>
+public sealed record SharePointVerifyResult(bool IsSuccess, IReadOnlyList<SharePointVerifyCheck> Checks);
+
+/// <summary>
+/// SharePoint 接続を Credential / Discovery / Preflight の 3 層で検証するサービス抽象。
+/// </summary>
+public interface ISharePointVerifyService
+{
+    /// <summary>
+    /// Credential Verify → Discovery Verify → Migration Preflight の順で検証を実行する。
+    /// いずれかの層で失敗した場合、後続の層はスキップされる。
+    /// </summary>
+    Task<SharePointVerifyResult> VerifyAsync(CancellationToken cancellationToken = default);
+}

--- a/src/CloudMigrator.Providers.Graph/Auth/SharePointVerifyService.cs
+++ b/src/CloudMigrator.Providers.Graph/Auth/SharePointVerifyService.cs
@@ -1,0 +1,243 @@
+using CloudMigrator.Core.Configuration;
+using CloudMigrator.Core.Credentials;
+using CloudMigrator.Providers.Graph.Http;
+using Microsoft.Graph;
+using Microsoft.Graph.Models.ODataErrors;
+using Microsoft.Kiota.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace CloudMigrator.Providers.Graph.Auth;
+
+/// <summary>
+/// SharePoint 接続を Credential / Discovery / Preflight の 3 層で検証する
+/// <see cref="ISharePointVerifyService"/> 実装。
+/// <list type="bullet">
+///   <item><description>Credential: Azure クレデンシャルの存在確認 + App-only 認証疎通確認。</description></item>
+///   <item><description>Discovery: <c>GET /drives/{driveId}</c> で SharePoint Drive への到達確認。</description></item>
+///   <item><description>Preflight: テストファイルの書き込み・削除による読み書き権限確認。</description></item>
+/// </list>
+/// </summary>
+public sealed class SharePointVerifyService : ISharePointVerifyService
+{
+    private const string PreflightFileName = ".cloudmigrator-preflight-check.tmp";
+    private const string PreflightContent = "cloudmigrator-preflight\n";
+
+    private readonly ICredentialStore _credentialStore;
+    private readonly IConfigurationService _configurationService;
+    private readonly IAzureAuthVerifyService _azureAuthVerifyService;
+    private readonly IGraphDiscoveryService _discoveryService;
+    private readonly ILogger<SharePointVerifyService> _logger;
+
+    public SharePointVerifyService(
+        ICredentialStore credentialStore,
+        IConfigurationService configurationService,
+        IAzureAuthVerifyService azureAuthVerifyService,
+        IGraphDiscoveryService discoveryService,
+        ILogger<SharePointVerifyService> logger)
+    {
+        _credentialStore = credentialStore;
+        _configurationService = configurationService;
+        _azureAuthVerifyService = azureAuthVerifyService;
+        _discoveryService = discoveryService;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<SharePointVerifyResult> VerifyAsync(CancellationToken cancellationToken = default)
+    {
+        var checks = new List<SharePointVerifyCheck>();
+
+        // ── Credential Verify ────────────────────────────────────────────────
+        var (credCheck, clientId, tenantId, clientSecret) =
+            await VerifyCredentialAsync(cancellationToken).ConfigureAwait(false);
+        checks.Add(credCheck);
+
+        if (!credCheck.IsSuccess)
+        {
+            checks.Add(new SharePointVerifyCheck(SharePointVerifyLayer.Discovery, false, "クレデンシャル不足のためスキップ"));
+            checks.Add(new SharePointVerifyCheck(SharePointVerifyLayer.Preflight, false, "クレデンシャル不足のためスキップ"));
+            return new SharePointVerifyResult(false, checks);
+        }
+
+        // ── Discovery Verify ────────────────────────────────────────────────
+        var (discoveryCheck, driveId) =
+            await VerifyDiscoveryAsync(clientId!, tenantId!, clientSecret!, cancellationToken)
+                .ConfigureAwait(false);
+        checks.Add(discoveryCheck);
+
+        if (!discoveryCheck.IsSuccess)
+        {
+            checks.Add(new SharePointVerifyCheck(SharePointVerifyLayer.Preflight, false, "Discovery 失敗のためスキップ"));
+            return new SharePointVerifyResult(false, checks);
+        }
+
+        // ── Preflight ────────────────────────────────────────────────────────
+        var preflightCheck = await VerifyPreflightAsync(clientId!, tenantId!, clientSecret!, driveId!, cancellationToken)
+            .ConfigureAwait(false);
+        checks.Add(preflightCheck);
+
+        var isSuccess = checks.All(c => c.IsSuccess);
+        return new SharePointVerifyResult(isSuccess, checks);
+    }
+
+    // ── 各検証ヘルパー ────────────────────────────────────────────────────
+
+    private async Task<(SharePointVerifyCheck Check, string? ClientId, string? TenantId, string? ClientSecret)>
+        VerifyCredentialAsync(CancellationToken ct)
+    {
+        try
+        {
+            // ClientId / TenantId は config.json から取得（secret 以外は Credential Manager には保存しない）
+            var graphConfig = await _configurationService.GetGraphConfigAsync(ct).ConfigureAwait(false);
+            var clientId = graphConfig.ClientId;
+            var tenantId = graphConfig.TenantId;
+            var clientSecret = await _credentialStore.GetAsync(CredentialKeys.AzureClientSecret, ct).ConfigureAwait(false);
+
+            if (string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(tenantId))
+            {
+                return (new SharePointVerifyCheck(SharePointVerifyLayer.Credential, false,
+                    "Azure 認証情報（ClientId / TenantId）が保存されていません。Step 1 に戻って再設定してください。"),
+                    null, null, null);
+            }
+
+            if (string.IsNullOrWhiteSpace(clientSecret))
+            {
+                return (new SharePointVerifyCheck(SharePointVerifyLayer.Credential, false,
+                    "クライアントシークレットが見つかりません。Step 1 に戻って再設定してください。"),
+                    null, null, null);
+            }
+
+            // App-only 認証の疎通確認
+            var authResult = await _azureAuthVerifyService
+                .VerifyAsync(clientId, tenantId, clientSecret, ct)
+                .ConfigureAwait(false);
+
+            if (!authResult.IsSuccess)
+            {
+                return (new SharePointVerifyCheck(SharePointVerifyLayer.Credential, false,
+                    authResult.ErrorMessage ?? "App-only 認証に失敗しました。"),
+                    null, null, null);
+            }
+
+            return (new SharePointVerifyCheck(SharePointVerifyLayer.Credential, true, "クレデンシャルと認証を確認しました。"),
+                clientId, tenantId, clientSecret);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Credential Verify 中にエラーが発生しました。");
+            return (new SharePointVerifyCheck(SharePointVerifyLayer.Credential, false,
+                $"確認中にエラーが発生しました: {ex.Message}"),
+                null, null, null);
+        }
+    }
+
+    private async Task<(SharePointVerifyCheck Check, string? DriveId)> VerifyDiscoveryAsync(
+        string clientId, string tenantId, string clientSecret, CancellationToken ct)
+    {
+        try
+        {
+            var discoveryConfig = await _configurationService.GetDiscoveryConfigAsync(ct).ConfigureAwait(false);
+            var driveId = discoveryConfig.SharePointDriveId;
+
+            if (string.IsNullOrWhiteSpace(driveId))
+            {
+                return (new SharePointVerifyCheck(SharePointVerifyLayer.Discovery, false,
+                    "SharePoint Drive ID が保存されていません。Step 2b に戻って再設定してください。"),
+                    null);
+            }
+
+            var verifyResult = await _discoveryService
+                .VerifyDriveAsync(clientId, tenantId, clientSecret, driveId, ct)
+                .ConfigureAwait(false);
+
+            if (!verifyResult.Success)
+            {
+                return (new SharePointVerifyCheck(SharePointVerifyLayer.Discovery, false,
+                    verifyResult.ErrorMessage ?? "SharePoint Drive への到達確認に失敗しました。"),
+                    null);
+            }
+
+            return (new SharePointVerifyCheck(SharePointVerifyLayer.Discovery, true,
+                "SharePoint Drive への到達を確認しました。"), driveId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Discovery Verify 中にエラーが発生しました。");
+            return (new SharePointVerifyCheck(SharePointVerifyLayer.Discovery, false,
+                $"確認中にエラーが発生しました: {ex.Message}"),
+                null);
+        }
+    }
+
+    private async Task<SharePointVerifyCheck> VerifyPreflightAsync(
+        string clientId, string tenantId, string clientSecret, string driveId, CancellationToken ct)
+    {
+        try
+        {
+            var authenticator = new GraphAuthenticator(clientId, tenantId, clientSecret);
+            var graphClient = Http.GraphClientFactory.Create(authenticator);
+
+            // テストファイルをアップロード
+            var contentBytes = System.Text.Encoding.UTF8.GetBytes(PreflightContent);
+            using var contentStream = new MemoryStream(contentBytes);
+
+            var uploadedItem = await graphClient.Drives[driveId]
+                .Root
+                .ItemWithPath(PreflightFileName)
+                .Content
+                .PutAsync(contentStream, cancellationToken: ct)
+                .ConfigureAwait(false);
+
+            if (uploadedItem?.Id is null)
+            {
+                return new SharePointVerifyCheck(SharePointVerifyLayer.Preflight, false,
+                    "テストファイルのアップロードに失敗しました。書き込み権限を確認してください。");
+            }
+
+            // テストファイルを削除
+            try
+            {
+                await graphClient.Drives[driveId]
+                    .Items[uploadedItem.Id]
+                    .DeleteAsync(cancellationToken: ct)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception deleteEx)
+            {
+                _logger.LogWarning(deleteEx, "Preflight テストファイルの削除に失敗しました。driveId={DriveId}", driveId);
+                // 削除失敗はソフトエラー（アップロード成功で書き込み権限確認済み）
+                return new SharePointVerifyCheck(SharePointVerifyLayer.Preflight, true,
+                    "書き込み権限を確認しました。（テストファイルの削除に失敗しました）");
+            }
+
+            return new SharePointVerifyCheck(SharePointVerifyLayer.Preflight, true, "読み書き権限を確認しました。");
+        }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
+        {
+            return new SharePointVerifyCheck(SharePointVerifyLayer.Preflight, false,
+                "書き込み権限がありません。Azure アプリの権限設定を確認してください。");
+        }
+        catch (ODataError ex)
+        {
+            _logger.LogError(ex, "Preflight Verify 中に Graph API エラーが発生しました。driveId={DriveId}", driveId);
+            return new SharePointVerifyCheck(SharePointVerifyLayer.Preflight, false,
+                $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
+        catch (ApiException ex)
+        {
+            _logger.LogError(ex, "Preflight Verify 中に API エラーが発生しました。driveId={DriveId}", driveId);
+            return new SharePointVerifyCheck(SharePointVerifyLayer.Preflight, false,
+                $"API エラー ({ex.ResponseStatusCode})");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Preflight Verify 中にエラーが発生しました。driveId={DriveId}", driveId);
+            return new SharePointVerifyCheck(SharePointVerifyLayer.Preflight, false,
+                $"確認中にエラーが発生しました: {ex.Message}");
+        }
+    }
+}

--- a/src/CloudMigrator.Providers.Graph/Auth/SharePointVerifyService.cs
+++ b/src/CloudMigrator.Providers.Graph/Auth/SharePointVerifyService.cs
@@ -42,6 +42,14 @@ public sealed class SharePointVerifyService : ISharePointVerifyService
         _logger = logger;
     }
 
+    /// <summary>テスト時に差し替え可能な GraphServiceClient ファクトリー。</summary>
+    internal Func<string, string, string, GraphServiceClient> ClientFactory { get; set; } =
+        (clientId, tenantId, clientSecret) =>
+        {
+            var authenticator = new GraphAuthenticator(clientId, tenantId, clientSecret);
+            return Http.GraphClientFactory.Create(authenticator);
+        };
+
     /// <inheritdoc/>
     public async Task<SharePointVerifyResult> VerifyAsync(CancellationToken cancellationToken = default)
     {
@@ -182,8 +190,7 @@ public sealed class SharePointVerifyService : ISharePointVerifyService
     {
         try
         {
-            var authenticator = new GraphAuthenticator(clientId, tenantId, clientSecret);
-            var graphClient = Http.GraphClientFactory.Create(authenticator);
+            var graphClient = ClientFactory(clientId, tenantId, clientSecret);
 
             // テストファイルをアップロード
             var contentBytes = System.Text.Encoding.UTF8.GetBytes(PreflightContent);

--- a/src/CloudMigrator.Providers.Graph/Auth/SharePointVerifyService.cs
+++ b/src/CloudMigrator.Providers.Graph/Auth/SharePointVerifyService.cs
@@ -122,6 +122,10 @@ public sealed class SharePointVerifyService : ISharePointVerifyService
             return (new SharePointVerifyCheck(SharePointVerifyLayer.Credential, true, "クレデンシャルと認証を確認しました。"),
                 clientId, tenantId, clientSecret);
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Credential Verify 中にエラーが発生しました。");
@@ -159,6 +163,10 @@ public sealed class SharePointVerifyService : ISharePointVerifyService
 
             return (new SharePointVerifyCheck(SharePointVerifyLayer.Discovery, true,
                 "SharePoint Drive への到達を確認しました。"), driveId);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/tests/unit/GraphDiscoveryServiceTests.cs
+++ b/tests/unit/GraphDiscoveryServiceTests.cs
@@ -588,4 +588,155 @@ public sealed class GraphDiscoveryServiceTests
 
         await act.Should().ThrowAsync<OperationCanceledException>();
     }
+
+    // ── ListDriveFoldersAsync 入力バリデーション ───────────────────────
+
+    [Fact]
+    public async Task ListDriveFoldersAsync_WhenDriveIdIsEmpty_ReturnsFailure()
+    {
+        // 検証対象: ListDriveFoldersAsync  目的: Drive ID 未入力時に失敗結果が返されること
+        var result = await _sut.ListDriveFoldersAsync(
+            clientId: "client-id",
+            tenantId: "tenant-id",
+            clientSecret: "secret",
+            driveId: string.Empty);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().NotBeNullOrEmpty();
+        result.Folders.Should().BeNull();
+    }
+
+    // ── ListDriveFoldersAsync 例外ハンドリング ─────────────────────────
+
+    [Fact]
+    public async Task ListDriveFoldersAsync_When403ODataError_ReturnsAdminConsentMessage()
+    {
+        // 検証対象: ListDriveFoldersAsync  目的: 403 で管理者同意メッセージが返されること
+        var result = await CreateSutThrowing(MakeODataError(403, "Authorization_RequestDenied"))
+            .ListDriveFoldersAsync("c", "t", "s", "drive-id");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("管理者の同意");
+    }
+
+    [Fact]
+    public async Task ListDriveFoldersAsync_When404ODataError_ReturnsFolderNotFound()
+    {
+        // 検証対象: ListDriveFoldersAsync  目的: 404 でフォルダ未発見メッセージが返されること
+        var result = await CreateSutThrowing(MakeODataError(404))
+            .ListDriveFoldersAsync("c", "t", "s", "drive-id");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("見つかりませんでした");
+    }
+
+    [Fact]
+    public async Task ListDriveFoldersAsync_WhenGenericODataError_ReturnsGraphApiError()
+    {
+        // 検証対象: ListDriveFoldersAsync  目的: 汎用 ODataError で Graph API エラーメッセージが返されること
+        var result = await CreateSutThrowing(MakeODataError(500, message: "error"))
+            .ListDriveFoldersAsync("c", "t", "s", "drive-id");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Graph API エラー");
+    }
+
+    [Fact]
+    public async Task ListDriveFoldersAsync_WhenApiException_ReturnsGraphApiError()
+    {
+        // 検証対象: ListDriveFoldersAsync  目的: ApiException で Graph API エラーメッセージが返されること
+        var result = await CreateSutThrowing(new ApiException { ResponseStatusCode = 500 })
+            .ListDriveFoldersAsync("c", "t", "s", "drive-id");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Graph API エラー");
+    }
+
+    [Fact]
+    public async Task ListDriveFoldersAsync_WhenNetworkError_ReturnsConnectionError()
+    {
+        // 検証対象: ListDriveFoldersAsync  目的: ネットワークエラーで接続エラーメッセージが返されること
+        var result = await CreateSutThrowing(new HttpRequestException("Network error"))
+            .ListDriveFoldersAsync("c", "t", "s", "drive-id");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("接続エラー");
+    }
+
+    [Fact]
+    public async Task ListDriveFoldersAsync_WhenCanceled_ThrowsOperationCanceledException()
+    {
+        // 検証対象: ListDriveFoldersAsync  目的: キャンセル時に OperationCanceledException が握り潰されず再スローされること
+        var act = async () => await CreateSutThrowing(new OperationCanceledException())
+            .ListDriveFoldersAsync("c", "t", "s", "drive-id");
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    // ── ListAllSharePointSitesAsync 例外ハンドリング ───────────────────
+
+    [Fact]
+    public async Task ListAllSharePointSitesAsync_When403ODataError_ReturnsAdminConsentMessage()
+    {
+        // 検証対象: ListAllSharePointSitesAsync  目的: 403 で管理者同意メッセージが返されること
+        var result = await CreateSutThrowing(MakeODataError(403, "Authorization_RequestDenied"))
+            .ListAllSharePointSitesAsync("c", "t", "s");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("管理者の同意");
+    }
+
+    [Fact]
+    public async Task ListAllSharePointSitesAsync_WhenGenericODataError_ReturnsGraphApiError()
+    {
+        // 検証対象: ListAllSharePointSitesAsync  目的: 汎用 ODataError で Graph API エラーメッセージが返されること
+        var result = await CreateSutThrowing(MakeODataError(500, message: "error"))
+            .ListAllSharePointSitesAsync("c", "t", "s");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Graph API エラー");
+    }
+
+    [Fact]
+    public async Task ListAllSharePointSitesAsync_WhenApiException403_ReturnsAdminConsentMessage()
+    {
+        // 検証対象: ListAllSharePointSitesAsync  目的: 非-OData ApiException 403 でも管理者同意メッセージが返されること
+        var result = await CreateSutThrowing(new ApiException { ResponseStatusCode = 403 })
+            .ListAllSharePointSitesAsync("c", "t", "s");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("アクセスが拒否");
+    }
+
+    [Fact]
+    public async Task ListAllSharePointSitesAsync_WhenGenericApiException_ReturnsGraphApiError()
+    {
+        // 検証対象: ListAllSharePointSitesAsync  目的: 汎用 ApiException で Graph API エラーメッセージが返されること
+        var result = await CreateSutThrowing(new ApiException { ResponseStatusCode = 500 })
+            .ListAllSharePointSitesAsync("c", "t", "s");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Graph API エラー");
+    }
+
+    [Fact]
+    public async Task ListAllSharePointSitesAsync_WhenNetworkError_ReturnsConnectionError()
+    {
+        // 検証対象: ListAllSharePointSitesAsync  目的: ネットワークエラーで接続エラーメッセージが返されること
+        var result = await CreateSutThrowing(new HttpRequestException("Network error"))
+            .ListAllSharePointSitesAsync("c", "t", "s");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("接続エラー");
+    }
+
+    [Fact]
+    public async Task ListAllSharePointSitesAsync_WhenCanceled_ThrowsOperationCanceledException()
+    {
+        // 検証対象: ListAllSharePointSitesAsync  目的: キャンセル時に OperationCanceledException が握り潰されず再スローされること
+        var act = async () => await CreateSutThrowing(new OperationCanceledException())
+            .ListAllSharePointSitesAsync("c", "t", "s");
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
 }

--- a/tests/unit/SharePointVerifyServiceTests.cs
+++ b/tests/unit/SharePointVerifyServiceTests.cs
@@ -1,0 +1,280 @@
+using CloudMigrator.Core.Configuration;
+using CloudMigrator.Core.Credentials;
+using CloudMigrator.Providers.Graph.Auth;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace CloudMigrator.Tests.Unit;
+
+/// <summary>
+/// 検証対象: SharePointVerifyService
+/// 目的: Credential / Discovery / Preflight の 3 層検証が、
+///       各レイヤーの成否に応じて正しく動作すること（後続スキップ・エラー伝播・呼び出し制御）を確認する。
+/// Preflight 層は GraphClient を直接生成するため E2E カテゴリで別途確認する。
+/// </summary>
+public sealed class SharePointVerifyServiceTests
+{
+    // ── ヘルパーファクトリ ─────────────────────────────────────────────────
+
+    private static (
+        SharePointVerifyService Sut,
+        Mock<ICredentialStore> CredStore,
+        Mock<IConfigurationService> ConfigSvc,
+        Mock<IAzureAuthVerifyService> AuthSvc,
+        Mock<IGraphDiscoveryService> DiscSvc) Build(
+        string clientId = "test-client",
+        string tenantId = "test-tenant",
+        string? clientSecret = "test-secret",
+        AzureAuthVerifyResult? authResult = null,
+        DiscoveryVerifyResult? driveResult = null,
+        string sharePointDriveId = "drive-id")
+    {
+        authResult ??= new AzureAuthVerifyResult(true);
+        driveResult ??= new DiscoveryVerifyResult(true);
+
+        var credStore = new Mock<ICredentialStore>();
+        credStore
+            .Setup(c => c.GetAsync(CredentialKeys.AzureClientSecret, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(clientSecret);
+
+        var configSvc = new Mock<IConfigurationService>();
+        configSvc
+            .Setup(c => c.GetGraphConfigAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GraphConfigDto(clientId, tenantId, string.Empty));
+        configSvc
+            .Setup(c => c.GetDiscoveryConfigAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DiscoveryConfigDto(
+                string.Empty, string.Empty, string.Empty, string.Empty,
+                string.Empty, sharePointDriveId, string.Empty, string.Empty,
+                string.Empty, "sharepoint"));
+
+        var authSvc = new Mock<IAzureAuthVerifyService>();
+        authSvc
+            .Setup(a => a.VerifyAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(authResult);
+
+        var discSvc = new Mock<IGraphDiscoveryService>();
+        discSvc
+            .Setup(d => d.VerifyDriveAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(driveResult);
+
+        var sut = new SharePointVerifyService(
+            credStore.Object,
+            configSvc.Object,
+            authSvc.Object,
+            discSvc.Object,
+            NullLogger<SharePointVerifyService>.Instance);
+
+        return (sut, credStore, configSvc, authSvc, discSvc);
+    }
+
+    // ── Credential 層: バリデーション ─────────────────────────────────────
+
+    [Fact]
+    public async Task VerifyAsync_WhenClientIdIsEmpty_CredentialFailsAndDiscoveryPreflightSkipped()
+    {
+        // 検証対象: VerifyAsync (Credential 層)  目的: ClientId が空の場合に Credential 失敗、後続の Discovery / Preflight がスキップされること
+        var (sut, _, _, _, _) = Build(clientId: string.Empty);
+
+        var result = await sut.VerifyAsync();
+
+        result.IsSuccess.Should().BeFalse();
+        result.Checks.Should().HaveCount(3);
+        result.Checks[0].Layer.Should().Be(SharePointVerifyLayer.Credential);
+        result.Checks[0].IsSuccess.Should().BeFalse();
+        result.Checks[0].Detail.Should().NotBeNullOrEmpty();
+        result.Checks[1].Layer.Should().Be(SharePointVerifyLayer.Discovery);
+        result.Checks[1].IsSuccess.Should().BeFalse();
+        result.Checks[1].Detail.Should().Contain("スキップ");
+        result.Checks[2].Layer.Should().Be(SharePointVerifyLayer.Preflight);
+        result.Checks[2].IsSuccess.Should().BeFalse();
+        result.Checks[2].Detail.Should().Contain("スキップ");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WhenTenantIdIsEmpty_CredentialFailsAndDiscoveryPreflightSkipped()
+    {
+        // 検証対象: VerifyAsync (Credential 層)  目的: TenantId が空の場合に Credential 失敗、後続がスキップされること
+        var (sut, _, _, _, _) = Build(tenantId: string.Empty);
+
+        var result = await sut.VerifyAsync();
+
+        result.IsSuccess.Should().BeFalse();
+        result.Checks[0].Layer.Should().Be(SharePointVerifyLayer.Credential);
+        result.Checks[0].IsSuccess.Should().BeFalse();
+        result.Checks[1].Detail.Should().Contain("スキップ");
+        result.Checks[2].Detail.Should().Contain("スキップ");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WhenClientSecretIsNull_CredentialFailsWithMessage()
+    {
+        // 検証対象: VerifyAsync (Credential 層)  目的: ClientSecret が未保存（null）の場合に Credential 失敗となること
+        var (sut, _, _, _, _) = Build(clientSecret: null);
+
+        var result = await sut.VerifyAsync();
+
+        result.IsSuccess.Should().BeFalse();
+        result.Checks[0].Layer.Should().Be(SharePointVerifyLayer.Credential);
+        result.Checks[0].IsSuccess.Should().BeFalse();
+        result.Checks[0].Detail.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WhenClientSecretIsWhitespace_CredentialFails()
+    {
+        // 検証対象: VerifyAsync (Credential 層)  目的: ClientSecret が空白文字のみの場合に Credential 失敗となること
+        var (sut, _, _, _, _) = Build(clientSecret: "   ");
+
+        var result = await sut.VerifyAsync();
+
+        result.IsSuccess.Should().BeFalse();
+        result.Checks[0].IsSuccess.Should().BeFalse();
+    }
+
+    // ── Credential 層: Azure 認証失敗 ────────────────────────────────────
+
+    [Fact]
+    public async Task VerifyAsync_WhenAzureAuthFails_CredentialFailsWithErrorMessage()
+    {
+        // 検証対象: VerifyAsync (Credential 層)  目的: Azure 認証失敗時にエラーメッセージが Detail に伝播すること
+        var (sut, _, _, _, _) = Build(
+            authResult: new AzureAuthVerifyResult(false, "認証トークン取得エラー"));
+
+        var result = await sut.VerifyAsync();
+
+        result.IsSuccess.Should().BeFalse();
+        result.Checks[0].IsSuccess.Should().BeFalse();
+        result.Checks[0].Detail.Should().Be("認証トークン取得エラー");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WhenAzureAuthFailsWithNullMessage_CredentialFailsWithDefaultMessage()
+    {
+        // 検証対象: VerifyAsync (Credential 層)  目的: Azure 認証失敗かつ ErrorMessage が null の場合にデフォルトメッセージが返ること
+        var (sut, _, _, _, _) = Build(
+            authResult: new AzureAuthVerifyResult(false, null));
+
+        var result = await sut.VerifyAsync();
+
+        result.IsSuccess.Should().BeFalse();
+        result.Checks[0].IsSuccess.Should().BeFalse();
+        result.Checks[0].Detail.Should().NotBeNullOrEmpty();
+    }
+
+    // ── Discovery 層 ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task VerifyAsync_WhenSharePointDriveIdIsEmpty_DiscoveryFailsAndPreflightSkipped()
+    {
+        // 検証対象: VerifyAsync (Discovery 層)  目的: SharePoint Drive ID が空の場合に Discovery 失敗、Preflight がスキップされること
+        var (sut, _, _, _, _) = Build(sharePointDriveId: string.Empty);
+
+        var result = await sut.VerifyAsync();
+
+        result.IsSuccess.Should().BeFalse();
+        result.Checks.Should().HaveCount(3);
+        result.Checks[0].IsSuccess.Should().BeTrue();
+        result.Checks[1].Layer.Should().Be(SharePointVerifyLayer.Discovery);
+        result.Checks[1].IsSuccess.Should().BeFalse();
+        result.Checks[1].Detail.Should().NotBeNullOrEmpty();
+        result.Checks[2].Layer.Should().Be(SharePointVerifyLayer.Preflight);
+        result.Checks[2].IsSuccess.Should().BeFalse();
+        result.Checks[2].Detail.Should().Contain("スキップ");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WhenVerifyDriveFails_DiscoveryFailsWithMessageAndPreflightSkipped()
+    {
+        // 検証対象: VerifyAsync (Discovery 層)  目的: VerifyDriveAsync 失敗時にエラーメッセージが伝播し Preflight がスキップされること
+        var (sut, _, _, _, _) = Build(
+            driveResult: new DiscoveryVerifyResult(false, "Drive が見つかりません"));
+
+        var result = await sut.VerifyAsync();
+
+        result.IsSuccess.Should().BeFalse();
+        result.Checks[1].IsSuccess.Should().BeFalse();
+        result.Checks[1].Detail.Should().Be("Drive が見つかりません");
+        result.Checks[2].Detail.Should().Contain("スキップ");
+    }
+
+    // ── 呼び出し制御の検証 ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task VerifyAsync_WhenCredentialAndDiscoverySucceed_VerifyDriveCalledWithCorrectArgs()
+    {
+        // 検証対象: VerifyAsync  目的: Credential / Discovery 成功時に VerifyDriveAsync が正しい引数で 1 回だけ呼ばれること
+        var (sut, _, _, _, discSvc) = Build();
+
+        await sut.VerifyAsync();
+
+        discSvc.Verify(d => d.VerifyDriveAsync(
+            "test-client", "test-tenant", "test-secret", "drive-id",
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WhenCredentialFails_VerifyDriveNeverCalled()
+    {
+        // 検証対象: VerifyAsync  目的: Credential 失敗時に VerifyDriveAsync が呼ばれないこと（余分なネットワーク呼び出しがないこと）
+        var (sut, _, _, _, discSvc) = Build(clientId: string.Empty);
+
+        await sut.VerifyAsync();
+
+        discSvc.Verify(d => d.VerifyDriveAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WhenCredentialFails_AzureAuthVerifyNeverCalled()
+    {
+        // 検証対象: VerifyAsync  目的: ClientId/TenantId 不足でクレデンシャル検証失敗時に Azure 認証 API が呼ばれないこと
+        var (sut, _, _, authSvc, _) = Build(clientId: string.Empty);
+
+        await sut.VerifyAsync();
+
+        authSvc.Verify(a => a.VerifyAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── キャンセル ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task VerifyAsync_WhenCancelled_ThrowsOperationCanceledException()
+    {
+        // 検証対象: VerifyAsync  目的: キャンセルトークンが発動した場合に OperationCanceledException がスローされること
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var credStore = new Mock<ICredentialStore>();
+        credStore
+            .Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var configSvc = new Mock<IConfigurationService>();
+        configSvc
+            .Setup(c => c.GetGraphConfigAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GraphConfigDto("cid", "tid", string.Empty));
+
+        var sut = new SharePointVerifyService(
+            credStore.Object,
+            configSvc.Object,
+            Mock.Of<IAzureAuthVerifyService>(),
+            Mock.Of<IGraphDiscoveryService>(),
+            NullLogger<SharePointVerifyService>.Instance);
+
+        var act = async () => await sut.VerifyAsync(cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/tests/unit/SharePointVerifyServiceTests.cs
+++ b/tests/unit/SharePointVerifyServiceTests.cs
@@ -3,6 +3,8 @@ using CloudMigrator.Core.Credentials;
 using CloudMigrator.Providers.Graph.Auth;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Graph.Models.ODataErrors;
+using Microsoft.Kiota.Abstractions;
 using Moq;
 
 namespace CloudMigrator.Tests.Unit;
@@ -247,8 +249,6 @@ public sealed class SharePointVerifyServiceTests
             Times.Never);
     }
 
-    // ── キャンセル ────────────────────────────────────────────────────────
-
     [Fact]
     public async Task VerifyAsync_WhenCancelled_ThrowsOperationCanceledException()
     {
@@ -274,6 +274,93 @@ public sealed class SharePointVerifyServiceTests
             NullLogger<SharePointVerifyService>.Instance);
 
         var act = async () => await sut.VerifyAsync(cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    // ── Preflight 層（ClientFactory 注入による例外分岐テスト）─────────────
+
+    private static ODataError MakeSPODataError(int statusCode, string? code = null, string? message = null) =>
+        new() { ResponseStatusCode = statusCode, Error = new MainError { Code = code, Message = message } };
+
+    [Fact]
+    public async Task VerifyAsync_WhenPreflight403WithAuthorizationRequestDenied_PreflightFailsWithPermissionError()
+    {
+        // 検証対象: VerifyAsync (Preflight 層)  目的: ClientFactory が Authorization_RequestDenied 403 をスローした場合に Preflight 失敗となること
+        var (sut, _, _, _, _) = Build();
+        sut.ClientFactory = (_, _, _) => throw MakeSPODataError(403, "Authorization_RequestDenied");
+
+        var result = await sut.VerifyAsync();
+
+        result.IsSuccess.Should().BeFalse();
+        result.Checks.Should().HaveCount(3);
+        result.Checks[0].IsSuccess.Should().BeTrue();
+        result.Checks[1].IsSuccess.Should().BeTrue();
+        result.Checks[2].Layer.Should().Be(SharePointVerifyLayer.Preflight);
+        result.Checks[2].IsSuccess.Should().BeFalse();
+        result.Checks[2].Detail.Should().Contain("権限");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WhenPreflight403UnknownCode_PreflightFails()
+    {
+        // 検証対象: VerifyAsync (Preflight 層)  目的: ClientFactory が 403（未知コード）をスローした場合に Preflight 失敗となること
+        var (sut, _, _, _, _) = Build();
+        sut.ClientFactory = (_, _, _) => throw MakeSPODataError(403, "Forbidden_Other");
+
+        var result = await sut.VerifyAsync();
+
+        result.Checks[2].IsSuccess.Should().BeFalse();
+        result.Checks[2].Detail.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WhenPreflightGenericODataError_PreflightFailsWithStatusCode()
+    {
+        // 検証対象: VerifyAsync (Preflight 層)  目的: ClientFactory が汎用 ODataError をスローした場合に Preflight 失敗となること
+        var (sut, _, _, _, _) = Build();
+        sut.ClientFactory = (_, _, _) => throw MakeSPODataError(500, message: "Internal Server Error");
+
+        var result = await sut.VerifyAsync();
+
+        result.Checks[2].IsSuccess.Should().BeFalse();
+        result.Checks[2].Detail.Should().Contain("500");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WhenPreflightApiException_PreflightFails()
+    {
+        // 検証対象: VerifyAsync (Preflight 層)  目的: ClientFactory が ApiException をスローした場合に Preflight 失敗となること
+        var (sut, _, _, _, _) = Build();
+        sut.ClientFactory = (_, _, _) => throw new ApiException { ResponseStatusCode = 403 };
+
+        var result = await sut.VerifyAsync();
+
+        result.Checks[2].IsSuccess.Should().BeFalse();
+        result.Checks[2].Detail.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WhenPreflightNetworkError_PreflightFailsWithMessage()
+    {
+        // 検証対象: VerifyAsync (Preflight 層)  目的: ClientFactory が汎用例外をスローした場合に Preflight 失敗となること
+        var (sut, _, _, _, _) = Build();
+        sut.ClientFactory = (_, _, _) => throw new HttpRequestException("Network unreachable");
+
+        var result = await sut.VerifyAsync();
+
+        result.Checks[2].IsSuccess.Should().BeFalse();
+        result.Checks[2].Detail.Should().Contain("Network unreachable");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WhenPreflightCancelled_ThrowsOperationCanceledException()
+    {
+        // 検証対象: VerifyAsync (Preflight 層)  目的: ClientFactory が OperationCanceledException をスローした場合に握り潰されず再スローされること
+        var (sut, _, _, _, _) = Build();
+        sut.ClientFactory = (_, _, _) => throw new OperationCanceledException();
+
+        var act = async () => await sut.VerifyAsync();
 
         await act.Should().ThrowAsync<OperationCanceledException>();
     }


### PR DESCRIPTION
## 概要
ダッシュボード UI を全面再実装し、フェーズバッジ・ETA・グラフ等の視覚情報を追加します。ウィザードページも改善し、フルリビルド機能を追加します。

## 変更内容

### DashboardPage.razor（全面再実装）
- ステータスカード6枚（クロール数・フォルダ作成数・転送数・スキップ数・エラー数・経過時間）
- 完了率プログレスバー・ETA（推定完了時刻）表示
- フェーズバッジ（crawling / folder_creation / transferring / completed）
- ジョブ停止中はフェーズバッジ非表示のガード追加
- `JobService.Cancel()` / `JobService.CurrentJob` への移行（`_jobCts` フィールド除去）
- タブ復帰時の再アタッチ（`_currentJob ??= JobService.CurrentJob`）
- グラフ4本（転送速度・エラー率・スループット・進捗）
- 完了サマリー表示

### SettingsPage.razor
- 「危険な操作」カード追加
- `FullRebuildAsync()`: 確認ダイアログ・実行中ジョブブロック・DB全削除・キャッシュ削除

### 新規ファイル
- `DriveFolderPicker.razor`: フォルダ選択 UI コンポーネント
- `SharePointDiscoveryPage.razor`: SharePoint サイト探索ウィザードページ

### その他
- `WizardApp.razor` / `AzureSetupPage.razor` / `ConnectionTestPage.razor` / `DriveDiscoveryPage.razor`: ウィザード UI 改善
- `_Imports.razor`: `Microsoft.Extensions.Logging` using 追加
- `WizardState.cs`: 状態プロパティ追加
- `DashboardApp.razor`: マイナー修正

## 依存 PR
- base: `feature/fix-transfer-job-service` (#126) — `Cancel()` / `CurrentJob` の依存があります