### PR TITLE
fix: プロバイダー正規化・クロール状態修正・RateLimit ログ追加・GraphDiscovery 追加

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,5 +5,6 @@
       リリースビルドは GitHub Actions でタグから -p:Version=x.y.z を渡して上書きする。
     -->
     <Version>0.3.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/src/CloudMigrator.Cli/CliServices.cs
+++ b/src/CloudMigrator.Cli/CliServices.cs
@@ -201,7 +201,8 @@ internal sealed class CliServices : IDisposable
             timeoutSec: options.TimeoutSec,
             maxRetry: options.RetryCount,
             onRateLimit: onRateLimit,
-            copyLocationCapture: copyCapture);
+            copyLocationCapture: copyCapture,
+            rateLimitLogger: loggerFactory.CreateLogger<CliServices>());
 
         var storageOptions = new GraphStorageOptions
         {

--- a/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
@@ -180,7 +180,7 @@ public sealed class ConfigurationService : IConfigurationService
 
     /// <summary>
     /// プロバイダー文字列を正規化する。大文字小文字を吸収し、旧表記エイリアスをマップする。
-    /// 未知の値はそのまま返す（将来プロバイダー追加時に対応可能）。
+    /// 未知の値も小文字化したうえで返す（将来プロバイダー追加時に比較しやすくするため）。
     /// </summary>
     private static string NormalizeProvider(string value) => value.ToLowerInvariant() switch
     {

--- a/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
@@ -129,7 +129,7 @@ public sealed class ConfigurationService : IConfigurationService
             RetryCount: GetInt(m, "retryCount", 3),
             TimeoutSec: GetInt(m, "timeoutSec", 300),
             DestinationRoot: GetString(m, "destinationRoot", string.Empty),
-            DestinationProvider: GetString(m, "destinationProvider", "sharepoint"));
+            DestinationProvider: NormalizeProvider(GetString(m, "destinationProvider", "sharepoint")));
     }
 
     /// <inheritdoc />
@@ -177,6 +177,17 @@ public sealed class ConfigurationService : IConfigurationService
         => element.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.String
             ? prop.GetString() ?? defaultValue
             : defaultValue;
+
+    /// <summary>
+    /// プロバイダー文字列を正規化する。大文字小文字を吸収し、旧表記エイリアスをマップする。
+    /// 未知の値はそのまま返す（将来プロバイダー追加時に対応可能）。
+    /// </summary>
+    private static string NormalizeProvider(string value) => value.ToLowerInvariant() switch
+    {
+        "sharepoint" or "graph" => "sharepoint",  // "Graph" は旧表記エイリアス
+        "dropbox" => "dropbox",
+        var v => v  // 未知のプロバイダーはそのまま保持
+    };
 
     /// <inheritdoc />
     public async Task<GraphConfigDto> GetGraphConfigAsync(CancellationToken ct = default)
@@ -251,14 +262,16 @@ public sealed class ConfigurationService : IConfigurationService
     public async Task<DiscoveryConfigDto> GetDiscoveryConfigAsync(CancellationToken ct = default)
     {
         if (!File.Exists(_configFilePath))
-            return new DiscoveryConfigDto(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, "sharepoint");
+            return new DiscoveryConfigDto(string.Empty, string.Empty, string.Empty, string.Empty,
+                string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, "sharepoint");
 
         var json = await File.ReadAllTextAsync(_configFilePath, ct).ConfigureAwait(false);
         try
         {
             using var doc = JsonDocument.Parse(json);
             if (!doc.RootElement.TryGetProperty("migrator", out var m) || m.ValueKind != JsonValueKind.Object)
-                return new DiscoveryConfigDto(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, "sharepoint");
+                return new DiscoveryConfigDto(string.Empty, string.Empty, string.Empty, string.Empty,
+                    string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, "sharepoint");
 
             var hasGraphObject = m.TryGetProperty("graph", out var gProp) && gProp.ValueKind == JsonValueKind.Object;
             var oneDriveUserId = hasGraphObject ? GetString(gProp, "oneDriveUserId", string.Empty) : string.Empty;
@@ -272,11 +285,15 @@ public sealed class ConfigurationService : IConfigurationService
             var migrationRoute = GetString(m, "migrationRoute", string.Empty);
             var destinationProvider = GetString(m, "destinationProvider", "sharepoint");
 
-            return new DiscoveryConfigDto(oneDriveUserId, oneDriveDriveId, oneDriveSourceFolderId, oneDriveSourceFolderPath, sharePointSiteId, sharePointDriveId, sharePointDestFolderId, sharePointDestFolderPath, migrationRoute, destinationProvider);
+            return new DiscoveryConfigDto(
+                oneDriveUserId, oneDriveDriveId, oneDriveSourceFolderId, oneDriveSourceFolderPath,
+                sharePointSiteId, sharePointDriveId, sharePointDestFolderId, sharePointDestFolderPath,
+                migrationRoute, destinationProvider);
         }
         catch (JsonException)
         {
-            return new DiscoveryConfigDto(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, "sharepoint");
+            return new DiscoveryConfigDto(string.Empty, string.Empty, string.Empty, string.Empty,
+                string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, "sharepoint");
         }
     }
 

--- a/src/CloudMigrator.Core/Migration/DropboxMigrationPipeline.cs
+++ b/src/CloudMigrator.Core/Migration/DropboxMigrationPipeline.cs
@@ -74,13 +74,27 @@ public sealed class DropboxMigrationPipeline : IMigrationPipeline
         if (existingStartedAt is null)
             await _stateDb.SaveCheckpointAsync("pipeline_started_at", _pipelineStartTime.ToString("O"), ct).ConfigureAwait(false);
 
+        // 前回までの累積実稼働秒数を読み込む（再起動をまたいだ合計実稼働時間のため）
+        var prevWorkingSecondsStr = await _stateDb.GetCheckpointAsync("pipeline_working_seconds", ct).ConfigureAwait(false);
+        double prevWorkingSeconds = double.TryParse(prevWorkingSecondsStr, out var parsed) ? parsed : 0;
+
         // Phase A + Phase B: クロールを完了まで先行実行（SQLite に登録し Channel には書かない）
         await PhasesABAsync(ct).ConfigureAwait(false);
 
         // Phase D: SQLite の pending/processing/failed を全件ストリームで転送
-        var (success, failed) = await PhaseDAsync(ct).ConfigureAwait(false);
-
-        sw.Stop();
+        int success, failed;
+        try
+        {
+            (success, failed) = await PhaseDAsync(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            sw.Stop();
+            var saveToken = ct.IsCancellationRequested ? CancellationToken.None : ct;
+            var totalWorking = prevWorkingSeconds + sw.Elapsed.TotalSeconds;
+            await _stateDb.SaveCheckpointAsync("pipeline_working_seconds", totalWorking.ToString("F3"), saveToken)
+                          .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+        }
 
         var totalRlCount = _concurrencyController is not null
             ? _concurrencyController.RateLimitCount

--- a/src/CloudMigrator.Core/Migration/DropboxMigrationPipeline.cs
+++ b/src/CloudMigrator.Core/Migration/DropboxMigrationPipeline.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Threading.Channels;
 using CloudMigrator.Core.Configuration;
 using CloudMigrator.Core.State;
@@ -76,7 +77,7 @@ public sealed class DropboxMigrationPipeline : IMigrationPipeline
 
         // 前回までの累積実稼働秒数を読み込む（再起動をまたいだ合計実稼働時間のため）
         var prevWorkingSecondsStr = await _stateDb.GetCheckpointAsync("pipeline_working_seconds", ct).ConfigureAwait(false);
-        double prevWorkingSeconds = double.TryParse(prevWorkingSecondsStr, out var parsed) ? parsed : 0;
+        double prevWorkingSeconds = double.TryParse(prevWorkingSecondsStr, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed) ? parsed : 0;
 
         // Phase A + Phase B: クロールを完了まで先行実行（SQLite に登録し Channel には書かない）
         await PhasesABAsync(ct).ConfigureAwait(false);
@@ -92,7 +93,7 @@ public sealed class DropboxMigrationPipeline : IMigrationPipeline
             sw.Stop();
             var saveToken = ct.IsCancellationRequested ? CancellationToken.None : ct;
             var totalWorking = prevWorkingSeconds + sw.Elapsed.TotalSeconds;
-            await _stateDb.SaveCheckpointAsync("pipeline_working_seconds", totalWorking.ToString("F3"), saveToken)
+            await _stateDb.SaveCheckpointAsync("pipeline_working_seconds", totalWorking.ToString("F3", CultureInfo.InvariantCulture), saveToken)
                           .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
         }
 

--- a/src/CloudMigrator.Core/Migration/SharePointMigrationPipeline.cs
+++ b/src/CloudMigrator.Core/Migration/SharePointMigrationPipeline.cs
@@ -71,6 +71,10 @@ public sealed class SharePointMigrationPipeline : IMigrationPipeline
         if (await _stateDb.GetCheckpointAsync("pipeline_started_at", ct).ConfigureAwait(false) is null)
             await _stateDb.SaveCheckpointAsync("pipeline_started_at", _pipelineStartTime.ToString("O"), ct).ConfigureAwait(false);
 
+        // 前回までの累積実稼働秒数を読み込む（再起動をまたいだ合計実稼働時間のため）
+        var prevWorkingSecondsStr = await _stateDb.GetCheckpointAsync("pipeline_working_seconds", ct).ConfigureAwait(false);
+        double prevWorkingSeconds = double.TryParse(prevWorkingSecondsStr, out var parsed) ? parsed : 0;
+
         // ── Phase A: クラッシュリカバリ ────────────────────────────────────────────
         await _stateDb.ResetProcessingAsync(ct).ConfigureAwait(false);
         var resetCount = await _stateDb.ResetPermanentFailedAsync(ct).ConfigureAwait(false);
@@ -79,12 +83,16 @@ public sealed class SharePointMigrationPipeline : IMigrationPipeline
         _logger.LogInformation("Phase A: クラッシュリカバリ完了（processing → pending リセット）");
 
         // ── Phase B: クロール ───────────────────────────────────────────────────────
-        if (await _stateDb.GetCheckpointAsync(CrawlCompleteKey, ct).ConfigureAwait(false) == "true")
+        var crawlCompleteVal = await _stateDb.GetCheckpointAsync(CrawlCompleteKey, ct).ConfigureAwait(false);
+        if (crawlCompleteVal == "true")
         {
             _logger.LogInformation("Phase B: クロール完了チェックポイントあり - スキップ");
         }
         else
         {
+            // フレッシュスタートまたはクロール未完了の場合は "false" を明示保存する。
+            // これによりダッシュボードが CrawlComplete=false を正しく読み取り "クロール中" を表示できる。
+            await _stateDb.SaveCheckpointAsync(CrawlCompleteKey, "false", ct).ConfigureAwait(false);
             await PhaseBCrawlAsync(ct).ConfigureAwait(false);
         }
 
@@ -122,9 +130,17 @@ public sealed class SharePointMigrationPipeline : IMigrationPipeline
             await producerTask.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
             throw;
         }
+        finally
+        {
+            sw.Stop();
+            // 中断・完了問わず今回の実稼働時間を累積保存する
+            // CancellationToken がキャンセル済みの場合は CancellationToken.None で保存する
+            var saveToken = ct.IsCancellationRequested ? CancellationToken.None : ct;
+            var totalWorking = prevWorkingSeconds + sw.Elapsed.TotalSeconds;
+            await _stateDb.SaveCheckpointAsync("pipeline_working_seconds", totalWorking.ToString("F3"), saveToken)
+                          .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+        }
         await producerTask.ConfigureAwait(false);
-
-        sw.Stop();
 
         var totalRlCount = _concurrencyController is not null
             ? _concurrencyController.RateLimitCount

--- a/src/CloudMigrator.Core/Migration/SharePointMigrationPipeline.cs
+++ b/src/CloudMigrator.Core/Migration/SharePointMigrationPipeline.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Threading.Channels;
 using CloudMigrator.Core.Configuration;
 using CloudMigrator.Core.State;
@@ -73,7 +74,7 @@ public sealed class SharePointMigrationPipeline : IMigrationPipeline
 
         // 前回までの累積実稼働秒数を読み込む（再起動をまたいだ合計実稼働時間のため）
         var prevWorkingSecondsStr = await _stateDb.GetCheckpointAsync("pipeline_working_seconds", ct).ConfigureAwait(false);
-        double prevWorkingSeconds = double.TryParse(prevWorkingSecondsStr, out var parsed) ? parsed : 0;
+        double prevWorkingSeconds = double.TryParse(prevWorkingSecondsStr, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed) ? parsed : 0;
 
         // ── Phase A: クラッシュリカバリ ────────────────────────────────────────────
         await _stateDb.ResetProcessingAsync(ct).ConfigureAwait(false);
@@ -137,7 +138,7 @@ public sealed class SharePointMigrationPipeline : IMigrationPipeline
             // CancellationToken がキャンセル済みの場合は CancellationToken.None で保存する
             var saveToken = ct.IsCancellationRequested ? CancellationToken.None : ct;
             var totalWorking = prevWorkingSeconds + sw.Elapsed.TotalSeconds;
-            await _stateDb.SaveCheckpointAsync("pipeline_working_seconds", totalWorking.ToString("F3"), saveToken)
+            await _stateDb.SaveCheckpointAsync("pipeline_working_seconds", totalWorking.ToString("F3", CultureInfo.InvariantCulture), saveToken)
                           .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
         }
         await producerTask.ConfigureAwait(false);

--- a/src/CloudMigrator.Core/Setup/SetupDoctorService.cs
+++ b/src/CloudMigrator.Core/Setup/SetupDoctorService.cs
@@ -211,9 +211,9 @@ public sealed class SetupDoctorService : ISetupDoctorService
 
             if (res.StatusCode == System.Net.HttpStatusCode.NotFound && !string.IsNullOrWhiteSpace(root))
             {
-                // DestinationRoot フォルダはなくても転送時に自動作成されるため Warning 扱い
-                return new DoctorCheck(CheckName, DoctorStatus.Warning,
-                    $"destinationRoot フォルダが未作成です（転送時に自動作成されます）: /{root}");
+                // GraphStorageProvider のアップロードでは親フォルダの事前存在が必要なため Fail 扱い
+                return new DoctorCheck(CheckName, DoctorStatus.Fail,
+                    $"destinationRoot フォルダが未作成です。転送前に作成してください: /{root}");
             }
 
             if (!res.IsSuccessStatusCode)

--- a/src/CloudMigrator.Core/Setup/SetupDoctorService.cs
+++ b/src/CloudMigrator.Core/Setup/SetupDoctorService.cs
@@ -211,8 +211,9 @@ public sealed class SetupDoctorService : ISetupDoctorService
 
             if (res.StatusCode == System.Net.HttpStatusCode.NotFound && !string.IsNullOrWhiteSpace(root))
             {
-                return new DoctorCheck(CheckName, DoctorStatus.Fail,
-                    $"destinationRoot が見つかりません: /{root}");
+                // DestinationRoot フォルダはなくても転送時に自動作成されるため Warning 扱い
+                return new DoctorCheck(CheckName, DoctorStatus.Warning,
+                    $"destinationRoot フォルダが未作成です（転送時に自動作成されます）: /{root}");
             }
 
             if (!res.IsSuccessStatusCode)

--- a/src/CloudMigrator.Dashboard/App.xaml.cs
+++ b/src/CloudMigrator.Dashboard/App.xaml.cs
@@ -2,15 +2,19 @@ using System.IO;
 using System.Windows;
 using CloudMigrator.Core.Configuration;
 using CloudMigrator.Core.Credentials;
+using CloudMigrator.Core.Migration;
 using CloudMigrator.Core.Setup;
 using CloudMigrator.Core.State;
 using CloudMigrator.Core.Transfer;
 using CloudMigrator.Core.Wizard;
 using CloudMigrator.Observability;
 using CloudMigrator.Providers.Dropbox.Auth;
+using CloudMigrator.Providers.Graph;
 using CloudMigrator.Providers.Graph.Auth;
+using CloudMigrator.Providers.Graph.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using MudBlazor.Services;
 
 namespace CloudMigrator.Dashboard;
@@ -71,7 +75,59 @@ public partial class App : Application
 
         // ── Application services ─────────────────────────────────────────────
         services.AddSingleton<IConfigurationService, ConfigurationService>();
-        services.AddSingleton<ITransferJobService, TransferJobService>();
+        services.AddSingleton<ITransferJobService>(sp =>
+        {
+            var loggerFactory2 = sp.GetRequiredService<ILoggerFactory>();
+            var stateDb = sp.GetRequiredService<ITransferStateDb>();
+
+            async Task MigrationWork(CancellationToken ct)
+            {
+                var configuration = AppConfiguration.Build();
+                var opts = configuration.GetSection(MigratorOptions.SectionName).Get<MigratorOptions>() ?? new MigratorOptions();
+
+                ICredentialStore credentialStore = CredentialStoreFactory.Create();
+                var clientSecret = await credentialStore.GetAsync(CredentialKeys.AzureClientSecret).ConfigureAwait(false)
+                    ?? AppConfiguration.GetGraphClientSecret();
+
+                var auth = new GraphAuthenticator(opts.Graph.ClientId, opts.Graph.TenantId, clientSecret);
+                var graphClient = GraphClientFactory.Create(
+                    auth,
+                    timeoutSec: opts.TimeoutSec,
+                    maxRetry: opts.RetryCount,
+                    onRateLimit: _ => { },  // ダッシュボードでは並列度制御なし。ロガー経由でログのみ記録
+                    rateLimitLogger: loggerFactory2.CreateLogger<GraphStorageProvider>());
+
+                var storageOptions = new GraphStorageOptions
+                {
+                    OneDriveUserId = opts.Graph.OneDriveUserId,
+                    SharePointDriveId = opts.Graph.SharePointDriveId,
+                    OneDriveSourceFolder = opts.Graph.OneDriveSourceFolder,
+                };
+
+                var sessionStore = new UploadSessionStore(Path.Combine(AppDataPaths.LogsDirectory, "upload_sessions.json"));
+
+                var storageProvider = new GraphStorageProvider(
+                    graphClient,
+                    loggerFactory2.CreateLogger<GraphStorageProvider>(),
+                    storageOptions,
+                    largeFileThresholdMb: opts.LargeFileThresholdMb,
+                    chunkSizeMb: opts.ChunkSizeMb,
+                    sessionStore: sessionStore);
+
+                var pipeline = new SharePointMigrationPipeline(
+                    storageProvider,
+                    storageProvider,
+                    stateDb,
+                    opts,
+                    loggerFactory2.CreateLogger<SharePointMigrationPipeline>());
+
+                await pipeline.RunAsync(ct).ConfigureAwait(false);
+            }
+
+            return new TransferJobService(
+                loggerFactory2.CreateLogger<TransferJobService>(),
+                MigrationWork);
+        });
 
         // SetupDoctorService: Core と同じ設定解決順序（環境変数 > config.json > デフォルト値）で資格情報を読み取る
         services.AddSingleton<ISetupDoctorService>(sp =>
@@ -87,31 +143,27 @@ public partial class App : Application
             return new SetupDoctorService(opts, sp.GetRequiredService<System.Net.Http.IHttpClientFactory>());
         });
 
-        // ITransferStateDb: --db-path 引数 > MigratorOptions デフォルトパス > NullObject
+        // ITransferStateDb: --db-path 引数 > 選択済み DB > SharePoint デフォルト（初回実行時は DB を新規作成）
         services.AddSingleton<ITransferStateDb>(sp =>
         {
             var resolvedPath = dbPath ?? ResolveDefaultDbPath();
-            if (resolvedPath is not null && File.Exists(resolvedPath))
+            var db = new SqliteTransferStateDb(resolvedPath);
+            try
             {
-                var db = new SqliteTransferStateDb(resolvedPath);
-                try
-                {
-                    db.InitializeAsync(CancellationToken.None).GetAwaiter().GetResult();
-                }
-                catch (Exception ex)
-                {
-                    // 初期化失敗: db を確実に破棄してからフォールバック（ファイルハンドルのリーク防止）
-                    db.DisposeAsync().AsTask().GetAwaiter().GetResult();
-                    MessageBox.Show(
-                        $"DB の初期化に失敗しました。DB なしモードで起動します。\n\n{ex.Message}",
-                        "警告",
-                        MessageBoxButton.OK,
-                        MessageBoxImage.Warning);
-                    return NullTransferStateDb.Instance;
-                }
-                return db;
+                db.InitializeAsync(CancellationToken.None).GetAwaiter().GetResult();
             }
-            return NullTransferStateDb.Instance;
+            catch (Exception ex)
+            {
+                // 初期化失敗: db を確実に破棄してからフォールバック（ファイルハンドルのリーク防止）
+                db.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                MessageBox.Show(
+                    $"DB の初期化に失敗しました。DB なしモードで起動します。\n\n{ex.Message}",
+                    "警告",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
+                return NullTransferStateDb.Instance;
+            }
+            return db;
         });
 
         // ── WPF Host サービス ──────────────────────────────────────────────
@@ -143,7 +195,7 @@ public partial class App : Application
     /// デフォルトの DB パスを解決する。
     /// 両方の DB が存在する場合はユーザーに選択させる。
     /// </summary>
-    private static string? ResolveDefaultDbPath()
+    private static string ResolveDefaultDbPath()
     {
         var dropboxDb = AppDataPaths.LogFile("dropbox_transfer_state.db");
         var sharePointDb = AppDataPaths.LogFile("sharepoint_transfer_state.db");
@@ -155,21 +207,16 @@ public partial class App : Application
             var result = MessageBox.Show(
                 "Dropbox 用 DB と SharePoint 用 DB の両方が見つかりました。\n" +
                 "表示する DB を選択してください。\n\n" +
-                "はい: Dropbox\nいいえ: SharePoint\nキャンセル: 選択しない",
+                "はい: Dropbox\nいいえ: SharePoint",
                 "DB の選択",
-                MessageBoxButton.YesNoCancel,
+                MessageBoxButton.YesNo,
                 MessageBoxImage.Question);
 
-            return result switch
-            {
-                MessageBoxResult.Yes => dropboxDb,
-                MessageBoxResult.No => sharePointDb,
-                _ => null,
-            };
+            return result == MessageBoxResult.Yes ? dropboxDb : sharePointDb;
         }
 
         if (hasDropbox) return dropboxDb;
-        if (hasSharePoint) return sharePointDb;
-        return null;
+        // SharePoint DB（既存または新規作成）をデフォルトとして返す
+        return sharePointDb;
     }
 }

--- a/src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs
+++ b/src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs
@@ -152,18 +152,31 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         try
         {
             var client = ClientFactory(clientId, tenantId, clientSecret);
-            // GET /sites/getAllSites — アクセス可能な全サイトを返す専用エンドポイント
+            // GET /sites/getAllSites — アクセス可能な全サイトを返す専用エンドポイント（ページング対応）
+            var sites = new List<SharePointSiteEntry>();
             var sitesResponse = await client.Sites.GetAllSites
                 .GetAsGetAllSitesGetResponseAsync(cancellationToken: ct)
                 .ConfigureAwait(false);
 
-            var sites = sitesResponse?.Value?
-                .Where(s => s.Id is not null)
-                .Select(s => new SharePointSiteEntry(
-                    SiteId: s.Id!,
-                    DisplayName: s.DisplayName ?? s.Name ?? s.Id!,
-                    WebUrl: s.WebUrl ?? string.Empty))
-                .ToList() ?? [];
+            while (sitesResponse is not null)
+            {
+                sites.AddRange(
+                    sitesResponse.Value?
+                        .Where(s => s.Id is not null)
+                        .Select(s => new SharePointSiteEntry(
+                            SiteId: s.Id!,
+                            DisplayName: s.DisplayName ?? s.Name ?? s.Id!,
+                            WebUrl: s.WebUrl ?? string.Empty))
+                    ?? []);
+
+                if (string.IsNullOrWhiteSpace(sitesResponse.OdataNextLink))
+                    break;
+
+                sitesResponse = await client.Sites.GetAllSites
+                    .WithUrl(sitesResponse.OdataNextLink)
+                    .GetAsGetAllSitesGetResponseAsync(cancellationToken: ct)
+                    .ConfigureAwait(false);
+            }
 
             return new SharePointSiteSearchResult(Success: true, Sites: sites);
         }
@@ -438,11 +451,6 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
             return new DriveFolderListResult(false,
                 ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
         }
-        catch (ApiException ex) when (ex.ResponseStatusCode == 403)
-        {
-            return new DriveFolderListResult(false,
-                ErrorMessage: BuildAdminConsentError(null));
-        }
         catch (ApiException ex)
         {
             return new DriveFolderListResult(false,
@@ -455,146 +463,6 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         catch (Exception ex)
         {
             return new DriveFolderListResult(false, ErrorMessage: $"接続エラー: {ex.Message}");
-        }
-    }
-
-    // ── プライベートヘルパー ────────────────────────────────────────────────
-
-    /// <inheritdoc/>
-    public async Task<DriveFolderListResult> ListDriveFoldersAsync(
-        string clientId,
-        string tenantId,
-        string clientSecret,
-        string driveId,
-        string? folderId = null,
-        CancellationToken ct = default)
-    {
-        if (string.IsNullOrWhiteSpace(driveId))
-            return new DriveFolderListResult(false, ErrorMessage: "Drive ID が指定されていません。");
-
-        try
-        {
-            var client = ClientFactory(clientId, tenantId, clientSecret);
-
-            List<DriveFolderEntry> folders;
-            if (string.IsNullOrEmpty(folderId))
-            {
-                var builder = client.Drives[driveId].Items["root"].Children;
-                folders = await CollectFolderPagedAsync(
-                    () => builder.GetAsync(r => r.QueryParameters.Select = ["id", "name", "folder"], cancellationToken: ct),
-                    nextLink => builder.WithUrl(nextLink).GetAsync(cancellationToken: ct),
-                    ct).ConfigureAwait(false);
-            }
-            else
-            {
-                var builder = client.Drives[driveId].Items[folderId].Children;
-                folders = await CollectFolderPagedAsync(
-                    () => builder.GetAsync(r => r.QueryParameters.Select = ["id", "name", "folder"], cancellationToken: ct),
-                    nextLink => builder.WithUrl(nextLink).GetAsync(cancellationToken: ct),
-                    ct).ConfigureAwait(false);
-            }
-
-            return new DriveFolderListResult(Success: true, Folders: folders);
-        }
-        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
-        {
-            return new DriveFolderListResult(false,
-                ErrorMessage: BuildAdminConsentError(ex.Error?.Code));
-        }
-        catch (ODataError ex) when (ex.ResponseStatusCode == 404)
-        {
-            return new DriveFolderListResult(false,
-                ErrorMessage: "指定されたフォルダが見つかりませんでした。");
-        }
-        catch (ODataError ex)
-        {
-            return new DriveFolderListResult(false,
-                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
-        }
-        catch (ApiException ex)
-        {
-            return new DriveFolderListResult(false,
-                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode})");
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            return new DriveFolderListResult(false, ErrorMessage: $"接続エラー: {ex.Message}");
-        }
-    }
-
-    /// <inheritdoc/>
-    public async Task<SharePointSiteSearchResult> ListAllSharePointSitesAsync(
-        string clientId,
-        string tenantId,
-        string clientSecret,
-        CancellationToken ct = default)
-    {
-        try
-        {
-            var client = ClientFactory(clientId, tenantId, clientSecret);
-
-            var allSites = new List<Microsoft.Graph.Models.Site>();
-            var sitesResponse = await client.Sites
-                .GetAsync(r => r.QueryParameters.Search = "*", ct)
-                .ConfigureAwait(false);
-            if (sitesResponse?.Value is not null)
-                allSites.AddRange(sitesResponse.Value);
-
-            var nextLink = sitesResponse?.OdataNextLink;
-            while (!string.IsNullOrWhiteSpace(nextLink))
-            {
-                ct.ThrowIfCancellationRequested();
-                var nextPage = await client.Sites.WithUrl(nextLink)
-                    .GetAsync(cancellationToken: ct).ConfigureAwait(false);
-                if (nextPage?.Value is not null)
-                    allSites.AddRange(nextPage.Value);
-                nextLink = nextPage?.OdataNextLink;
-            }
-
-            var sites = allSites
-                .Where(s => s.Id is not null)
-                .GroupBy(s => s.Id!)
-                .Select(g => g.First())
-                .Select(s => new SharePointSiteEntry(
-                    SiteId: s.Id!,
-                    DisplayName: s.DisplayName ?? s.Name ?? s.Id!,
-                    WebUrl: s.WebUrl ?? string.Empty))
-                .ToList();
-
-            return new SharePointSiteSearchResult(Success: true, Sites: sites);
-        }
-        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
-        {
-            return new SharePointSiteSearchResult(false,
-                ErrorMessage: BuildAdminConsentError(ex.Error?.Code));
-        }
-        catch (ODataError ex)
-        {
-            return new SharePointSiteSearchResult(false,
-                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
-        }
-        catch (ApiException ex) when (ex.ResponseStatusCode == 403)
-        {
-            return new SharePointSiteSearchResult(false,
-                ErrorMessage: BuildAdminConsentError(null));
-        }
-        catch (ApiException ex)
-        {
-            return new SharePointSiteSearchResult(false,
-                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode})");
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            return new SharePointSiteSearchResult(false,
-                ErrorMessage: $"接続エラー: {ex.Message}");
         }
     }
 

--- a/src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs
+++ b/src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs
@@ -143,6 +143,62 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
     }
 
     /// <inheritdoc/>
+    public async Task<SharePointSiteSearchResult> ListAllSharePointSitesAsync(
+        string clientId,
+        string tenantId,
+        string clientSecret,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var client = ClientFactory(clientId, tenantId, clientSecret);
+            // GET /sites/getAllSites — アクセス可能な全サイトを返す専用エンドポイント
+            var sitesResponse = await client.Sites.GetAllSites
+                .GetAsGetAllSitesGetResponseAsync(cancellationToken: ct)
+                .ConfigureAwait(false);
+
+            var sites = sitesResponse?.Value?
+                .Where(s => s.Id is not null)
+                .Select(s => new SharePointSiteEntry(
+                    SiteId: s.Id!,
+                    DisplayName: s.DisplayName ?? s.Name ?? s.Id!,
+                    WebUrl: s.WebUrl ?? string.Empty))
+                .ToList() ?? [];
+
+            return new SharePointSiteSearchResult(Success: true, Sites: sites);
+        }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: BuildAdminConsentError(ex.Error?.Code));
+        }
+        catch (ODataError ex)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
+        catch (ApiException ex) when (ex.ResponseStatusCode == 403)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: BuildAdminConsentError(null));
+        }
+        catch (ApiException ex)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode})");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return new SharePointSiteSearchResult(false,
+                ErrorMessage: $"接続エラー: {ex.Message}");
+        }
+    }
+
+    /// <inheritdoc/>
     public async Task<SharePointSiteSearchResult> GetSharePointSiteByUrlAsync(
         string clientId,
         string tenantId,
@@ -327,6 +383,78 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         catch (Exception ex)
         {
             return new DiscoveryVerifyResult(false, $"接続エラー: {ex.Message}");
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<DriveFolderListResult> ListDriveFoldersAsync(
+        string clientId,
+        string tenantId,
+        string clientSecret,
+        string driveId,
+        string? folderId = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(driveId))
+            return new DriveFolderListResult(false, ErrorMessage: "Drive ID が指定されていません。");
+
+        try
+        {
+            var client = ClientFactory(clientId, tenantId, clientSecret);
+
+            Microsoft.Graph.Models.DriveItemCollectionResponse? response;
+            if (folderId is null)
+            {
+                response = await client.Drives[driveId].Items["root"].Children
+                    .GetAsync(r => r.QueryParameters.Select = ["id", "name", "folder"], ct)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                response = await client.Drives[driveId].Items[folderId].Children
+                    .GetAsync(r => r.QueryParameters.Select = ["id", "name", "folder"], ct)
+                    .ConfigureAwait(false);
+            }
+
+            var folders = response?.Value?
+                .Where(item => item.Folder is not null && item.Id is not null)
+                .Select(item => new DriveFolderEntry(item.Id!, item.Name ?? item.Id!))
+                .ToList() ?? [];
+
+            return new DriveFolderListResult(Success: true, Folders: folders);
+        }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 403)
+        {
+            return new DriveFolderListResult(false,
+                ErrorMessage: BuildAdminConsentError(ex.Error?.Code));
+        }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 404)
+        {
+            return new DriveFolderListResult(false,
+                ErrorMessage: "指定されたフォルダが見つかりませんでした。");
+        }
+        catch (ODataError ex)
+        {
+            return new DriveFolderListResult(false,
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
+        catch (ApiException ex) when (ex.ResponseStatusCode == 403)
+        {
+            return new DriveFolderListResult(false,
+                ErrorMessage: BuildAdminConsentError(null));
+        }
+        catch (ApiException ex)
+        {
+            return new DriveFolderListResult(false,
+                ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode})");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return new DriveFolderListResult(false, ErrorMessage: $"接続エラー: {ex.Message}");
         }
     }
 

--- a/src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs
+++ b/src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs
@@ -416,7 +416,7 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
             var client = ClientFactory(clientId, tenantId, clientSecret);
 
             Microsoft.Graph.Models.DriveItemCollectionResponse? response;
-            if (folderId is null)
+            if (string.IsNullOrWhiteSpace(folderId))
             {
                 response = await client.Drives[driveId].Items["root"].Children
                     .GetAsync(r => r.QueryParameters.Select = ["id", "name", "folder"], ct)

--- a/src/CloudMigrator.Providers.Graph/Auth/IGraphDiscoveryService.cs
+++ b/src/CloudMigrator.Providers.Graph/Auth/IGraphDiscoveryService.cs
@@ -28,6 +28,16 @@ public interface IGraphDiscoveryService
         CancellationToken ct = default);
 
     /// <summary>
+    /// アクセス可能なすべての SharePoint サイトを一覧取得する（<c>GET /sites/getAllSites</c>）。
+    /// ページング（@odata.nextLink）を追って全件取得する。全サイト一覧取得には Sites.Read.All 権限が必要。
+    /// </summary>
+    Task<SharePointSiteSearchResult> ListAllSharePointSitesAsync(
+        string clientId,
+        string tenantId,
+        string clientSecret,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Site URL を直接指定してサイトを取得する（<c>GET /sites/{hostname}:/{serverRelativePath}</c>）。
     /// キーワード検索で 0 件の場合のフォールバック用。
     /// </summary>
@@ -69,31 +79,7 @@ public interface IGraphDiscoveryService
         string driveId,
         string? folderId = null,
         CancellationToken ct = default);
-
-    /// <summary>
-    /// テナント内のすべての SharePoint サイトを取得する（<c>GET /sites?search=*</c>）。
-    /// ページングを考慮した全件取得。
-    /// </summary>
-    Task<SharePointSiteSearchResult> ListAllSharePointSitesAsync(
-        string clientId,
-        string tenantId,
-        string clientSecret,
-        CancellationToken ct = default);
 }
-
-/// <summary>Drive 内フォルダの一覧エントリ。</summary>
-/// <param name="FolderId">アイテム ID。</param>
-/// <param name="DisplayName">表示名。</param>
-public sealed record DriveFolderEntry(string FolderId, string DisplayName);
-
-/// <summary><see cref="IGraphDiscoveryService.ListDriveFoldersAsync"/> の結果。</summary>
-/// <param name="Success">成功かどうか。</param>
-/// <param name="Folders">フォルダ一覧。失敗時は null。</param>
-/// <param name="ErrorMessage">エラー詳細。成功時は null。</param>
-public sealed record DriveFolderListResult(
-    bool Success,
-    IReadOnlyList<DriveFolderEntry>? Folders = null,
-    string? ErrorMessage = null);
 
 /// <summary>OneDrive Drive ID 取得結果。</summary>
 public sealed record OneDriveDiscoveryResult(
@@ -124,6 +110,20 @@ public sealed record SharePointDriveEntry(
 public sealed record SharePointDriveListResult(
     bool Success,
     IReadOnlyList<SharePointDriveEntry>? Drives = null,
+    string? ErrorMessage = null);
+
+/// <summary>Drive 内フォルダエントリ。</summary>
+/// <param name="FolderId">アイテム ID。</param>
+/// <param name="DisplayName">表示名。</param>
+public sealed record DriveFolderEntry(string FolderId, string DisplayName);
+
+/// <summary><see cref="IGraphDiscoveryService.ListDriveFoldersAsync"/> の結果。</summary>
+/// <param name="Success">成功かどうか。</param>
+/// <param name="Folders">フォルダ一覧。失敗時は null。</param>
+/// <param name="ErrorMessage">エラー詳細。成功時は null。</param>
+public sealed record DriveFolderListResult(
+    bool Success,
+    IReadOnlyList<DriveFolderEntry>? Folders = null,
     string? ErrorMessage = null);
 
 /// <summary>Discovery Verify 結果。</summary>

--- a/src/CloudMigrator.Providers.Graph/Auth/SharePointVerifyService.cs
+++ b/src/CloudMigrator.Providers.Graph/Auth/SharePointVerifyService.cs
@@ -19,7 +19,8 @@ namespace CloudMigrator.Providers.Graph.Auth;
 /// </summary>
 public sealed class SharePointVerifyService : ISharePointVerifyService
 {
-    private const string PreflightFileName = ".cloudmigrator-preflight-check.tmp";
+    private static readonly string PreflightFileName =
+        $".cloudmigrator-preflight-check-{Guid.NewGuid():N}.tmp";
     private const string PreflightContent = "cloudmigrator-preflight\n";
 
     private readonly ICredentialStore _credentialStore;

--- a/src/CloudMigrator.Providers.Graph/Http/GraphClientFactory.cs
+++ b/src/CloudMigrator.Providers.Graph/Http/GraphClientFactory.cs
@@ -1,4 +1,5 @@
 using CloudMigrator.Providers.Graph.Auth;
+using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
 using Microsoft.Kiota.Abstractions.Authentication;
 using Microsoft.Kiota.Http.HttpClientLibrary;
@@ -32,7 +33,8 @@ public static class GraphClientFactory
         int timeoutSec = 300,
         int maxRetry = 3,
         Action<TimeSpan?>? onRateLimit = null,
-        CopyLocationCaptureHandler? copyLocationCapture = null)
+        CopyLocationCaptureHandler? copyLocationCapture = null,
+        ILogger? rateLimitLogger = null)
     {
         // Kiota 標準ミドルウェアスタック（RetryHandler / RedirectHandler 等）を組み込む
         var handlers = KiotaClientFactory.CreateDefaultHandlers();
@@ -58,7 +60,7 @@ public static class GraphClientFactory
                 // RetryHandler の内側（後段）に RateLimitAwareHandler を挿入する。
                 // これにより各リトライ試行ごとの 429/503 レスポンスを傍受できる。
                 if (onRateLimit is not null)
-                    handlers.Insert(i + 1, new RateLimitAwareHandler(onRateLimit));
+                    handlers.Insert(i + 1, new RateLimitAwareHandler(onRateLimit, rateLimitLogger));
 
                 break;
             }

--- a/src/CloudMigrator.Providers.Graph/Http/RateLimitAwareHandler.cs
+++ b/src/CloudMigrator.Providers.Graph/Http/RateLimitAwareHandler.cs
@@ -18,7 +18,7 @@ internal sealed class RateLimitAwareHandler : DelegatingHandler
     private readonly ILogger? _logger;
 
     /// <param name="onRateLimit">429/503 検出時に呼び出すコールバック。引数は Retry-After 値（null の場合は不明）。</param>
-    /// <param name="logger">レートリミット標準放出用ロガー。null の場合はログ出力なし。</param>
+    /// <param name="logger">レートリミット検出時のログ出力用ロガー。null の場合はログ出力なし。</param>
     internal RateLimitAwareHandler(Action<TimeSpan?> onRateLimit, ILogger? logger = null)
     {
         _onRateLimit = onRateLimit;

--- a/src/CloudMigrator.Providers.Graph/Http/RateLimitAwareHandler.cs
+++ b/src/CloudMigrator.Providers.Graph/Http/RateLimitAwareHandler.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Microsoft.Extensions.Logging;
 
 namespace CloudMigrator.Providers.Graph.Http;
 
@@ -14,11 +15,14 @@ namespace CloudMigrator.Providers.Graph.Http;
 internal sealed class RateLimitAwareHandler : DelegatingHandler
 {
     private readonly Action<TimeSpan?> _onRateLimit;
+    private readonly ILogger? _logger;
 
     /// <param name="onRateLimit">429/503 検出時に呼び出すコールバック。引数は Retry-After 値（null の場合は不明）。</param>
-    internal RateLimitAwareHandler(Action<TimeSpan?> onRateLimit)
+    /// <param name="logger">レートリミット標準放出用ロガー。null の場合はログ出力なし。</param>
+    internal RateLimitAwareHandler(Action<TimeSpan?> onRateLimit, ILogger? logger = null)
     {
         _onRateLimit = onRateLimit;
+        _logger = logger;
     }
 
     /// <inheritdoc/>
@@ -39,6 +43,17 @@ internal sealed class RateLimitAwareHandler : DelegatingHandler
                 var delta = date - DateTimeOffset.UtcNow;
                 retryAfter = delta > TimeSpan.Zero ? delta : TimeSpan.Zero;
             }
+
+            var waitSec = retryAfter.HasValue ? (int)Math.Ceiling(retryAfter.Value.TotalSeconds) : (int?)null;
+            if (waitSec.HasValue)
+                _logger?.LogWarning(
+                    "429/503 レートリミット検出。{WaitSec}秒待機要求: {Method} {Url}",
+                    waitSec, request.Method, request.RequestUri?.AbsolutePath);
+            else
+                _logger?.LogWarning(
+                    "429/503 レートリミット検出（Retry-After なし）: {Method} {Url}",
+                    request.Method, request.RequestUri?.AbsolutePath);
+
             _onRateLimit(retryAfter);
         }
 

--- a/task.md
+++ b/task.md
@@ -232,7 +232,7 @@ Welcome
 - [x] Step 0 で SharePoint 路線を選択するとプレースホルダー画面が表示される（v0.4.0 スコープで #113残ステップにて本実装に置換）
 - [x] Dropbox 路線でステップ 0→1→2a→3→4 がエンド・ツー・エンドで動作する（Step 1・2a は #110・#111 実装後）
 - [x] Step 4 が Credential Verify → Discovery Verify → Migration Preflight の 3 層を実行する
-- [ ] 期限切れ・無効なトークンの場合にステップが `Failed` として検出される（→ #113残ステップで対応）
+- [x] 期限切れ・無効なトークンの場合にステップが `Failed` として検出される（→ #113残ステップで対応）
 - [x] `InProgress` 状態でアプリを終了した場合、`wizard-state.json` には `NotStarted` として保存される
 - [x] 中断後の再起動で最初の未完了ステップから再開できる
 - [x] Step 4 接続テスト失敗時に失敗した層（Credential / Discovery / Preflight）が表示される
@@ -300,9 +300,9 @@ Welcome
 - [x] App-only 認証の制約（UPN またはユーザー ID 入力必須）が UI 上で明示されている
 - [x] SharePoint Site をキーワード検索で絞り込める（`search=*` は使用しない）
 - [x] キーワード検索で 0 件の場合に Site URL 直接入力フォールバックが表示される（#113残ステップで UI 実装）
-- [ ] Document Library の一覧に表示名（Display Name）が表示される（#113残ステップで UI 実装）
+- [x] Document Library の一覧に表示名（Display Name）が表示される（#113残ステップで UI 実装）
 - [x] Discovery 結果が config.json スキーマに従って保存される
-- [ ] Discovery Verify と Migration Preflight の両方が成功した場合のみステップが `Verified` になる（UI は #113残ステップ）
+- [x] Discovery Verify と Migration Preflight の両方が成功した場合のみステップが `Verified` になる（UI は #113残ステップ）
 - [x] OneDrive→Dropbox 路線選択時に SharePoint 取得 UI がスキップされ、Dropbox 用スキーマで保存される
 - [ ] Graph Explorer が補助参照ツールとして利用できる（または外部ブラウザで開く）（Graph Explorer リンク形式で対応済み）
 - [x] Admin Consent 未付与エラー時に適切なガイドが表示される
@@ -317,18 +317,18 @@ Welcome
 
 ### 実装タスク（SharePoint 路線追加分）
 
-- [ ] Step 1（Azure 認証設定）: Step 1-1〜1-6 のウィザード UI（#110 連携）
-- [ ] Step 2a（OneDrive Discovery）: UPN 入力 → Drive ID 取得・確認画面（#111 連携）
-- [ ] Step 2b（SharePoint Discovery）: Site 検索 → Library 選択 → 確認画面（#111 連携）
-- [ ] Step 4 を SharePoint 路線でも動作させる（Dropbox 路線との分岐拡張）
-- [ ] 期限切れ・無効なトークンの場合にステップが `Failed` として検出される実装
-- [ ] 失効時の UI 通知 + 該当ステップを `NotStarted` に戻す実装（#112 連携）
+- [x] Step 1（Azure 認証設定）: Step 1-1〜1-6 のウィザード UI（#110 連携）← AzureSetupPage.razor で対応済み（両路線共通）
+- [x] Step 2a（OneDrive Discovery）: UPN 入力 → Drive ID 取得・確認画面（#111 連携）← DriveDiscoveryPage.razor で対応済み（両路線共通）
+- [x] Step 2b（SharePoint Discovery）: Site 検索 → Library 選択 → 確認画面（#111 連携）← SharePointDiscoveryPage.razor 実装
+- [x] Step 4 を SharePoint 路線でも動作させる（Dropbox 路線との分岐拡張）← ConnectionTestPage.razor + ISharePointVerifyService
+- [x] 期限切れ・無効なトークンの場合にステップが `Failed` として検出される実装
+- [x] 失効時の UI 通知 + 該当ステップを `NotStarted` に戻す実装（#112 連携）
 
 ### 受け入れ基準
 
-- [ ] Personal OneDrive → SharePoint 路線のウィザードがエンド・ツー・エンドで動作する
-- [ ] Step 1〜2a〜2b〜4 の順序でステップが進行できる
-- [ ] 期限切れ・無効なトークンの場合にステップが `Failed` として検出される
+- [x] Personal OneDrive → SharePoint 路線のウィザードがエンド・ツー・エンドで動作する
+- [x] Step 1〜2a〜2b〜4 の順序でステップが進行できる
+- [x] 期限切れ・無効なトークンの場合にステップが `Failed` として検出される
 
 ---
 

--- a/tests/unit/ConfigurationServiceTests.cs
+++ b/tests/unit/ConfigurationServiceTests.cs
@@ -151,6 +151,90 @@ public sealed class ConfigurationServiceTests : IDisposable
         result.DestinationRoot.Should().Be("Documents/テスト");
     }
 
+    // ── NormalizeProvider: GetConfigAsync 経由での正規化検証 ─────────────
+
+    [Theory]
+    [InlineData("graph", "sharepoint")]
+    [InlineData("Graph", "sharepoint")]
+    [InlineData("GRAPH", "sharepoint")]
+    public async Task GetConfigAsync_WhenDestinationProviderIsGraphAlias_ReturnsSharepoint(
+        string rawValue, string expected)
+    {
+        // 検証対象: GetConfigAsync（NormalizeProvider）
+        // 目的: "graph" / "Graph" 等の旧エイリアスが "sharepoint" に正規化されること
+        WriteConfig(new
+        {
+            migrator = new
+            {
+                maxParallelTransfers = 4,
+                chunkSizeMb = 5,
+                largeFileThresholdMb = 4,
+                retryCount = 3,
+                timeoutSec = 300,
+                destinationRoot = string.Empty,
+                destinationProvider = rawValue
+            }
+        });
+        var svc = new ConfigurationService(_configPath);
+
+        var result = await svc.GetConfigAsync();
+
+        result.DestinationProvider.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("DROPBOX", "dropbox")]
+    [InlineData("Dropbox", "dropbox")]
+    public async Task GetConfigAsync_WhenDestinationProviderIsDropboxVariant_ReturnsDropbox(
+        string rawValue, string expected)
+    {
+        // 検証対象: GetConfigAsync（NormalizeProvider）
+        // 目的: 大文字バリアントの "DROPBOX" / "Dropbox" が "dropbox" に正規化されること
+        WriteConfig(new
+        {
+            migrator = new
+            {
+                maxParallelTransfers = 4,
+                chunkSizeMb = 5,
+                largeFileThresholdMb = 4,
+                retryCount = 3,
+                timeoutSec = 300,
+                destinationRoot = string.Empty,
+                destinationProvider = rawValue
+            }
+        });
+        var svc = new ConfigurationService(_configPath);
+
+        var result = await svc.GetConfigAsync();
+
+        result.DestinationProvider.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task GetConfigAsync_WhenDestinationProviderIsUnknown_ReturnsLowerCased()
+    {
+        // 検証対象: GetConfigAsync（NormalizeProvider）
+        // 目的: 未知のプロバイダー値は小文字化されて返されること
+        WriteConfig(new
+        {
+            migrator = new
+            {
+                maxParallelTransfers = 4,
+                chunkSizeMb = 5,
+                largeFileThresholdMb = 4,
+                retryCount = 3,
+                timeoutSec = 300,
+                destinationRoot = string.Empty,
+                destinationProvider = "OneDrive"
+            }
+        });
+        var svc = new ConfigurationService(_configPath);
+
+        var result = await svc.GetConfigAsync();
+
+        result.DestinationProvider.Should().Be("onedrive");
+    }
+
     // ── ヘルパー ────────────────────────────────────────────────────────
 
     private void WriteConfig(object data)

--- a/tests/unit/GraphClientFactoryTests.cs
+++ b/tests/unit/GraphClientFactoryTests.cs
@@ -1,0 +1,75 @@
+using CloudMigrator.Providers.Graph.Auth;
+using CloudMigrator.Providers.Graph.Http;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace CloudMigrator.Tests.Unit;
+
+/// <summary>
+/// 検証対象: GraphClientFactory
+/// 目的: GraphServiceClient が各オプションパラメーターのブランチを通じて正しく生成されることを確認する
+/// </summary>
+public sealed class GraphClientFactoryTests
+{
+    /// <summary>
+    /// テスト用のダミー認証情報。実際の API 疎通は行わない。
+    /// </summary>
+    private static GraphAuthenticator CreateAuthenticator() =>
+        new("test-client-id", "test-tenant-id", "test-client-secret");
+
+    [Fact]
+    public void Create_WithDefaultParameters_ReturnsGraphServiceClient()
+    {
+        // 検証対象: Create（デフォルトパラメーター）
+        // 目的: 必須の authenticator のみ渡した場合に GraphServiceClient が生成されること
+        var client = GraphClientFactory.Create(CreateAuthenticator());
+
+        client.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Create_WithOnRateLimitCallback_ReturnsGraphServiceClient()
+    {
+        // 検証対象: Create（onRateLimit != null ブランチ）
+        // 目的: onRateLimit コールバックを指定した場合でも GraphServiceClient が生成されること
+        var callbackInvoked = false;
+        var client = GraphClientFactory.Create(
+            CreateAuthenticator(),
+            onRateLimit: _ => callbackInvoked = true);
+
+        client.Should().NotBeNull();
+        callbackInvoked.Should().BeFalse(); // 生成時点ではコールバックが呼ばれていないこと
+    }
+
+    [Fact]
+    public void Create_WithCopyLocationCaptureHandler_ReturnsGraphServiceClient()
+    {
+        // 検証対象: Create（copyLocationCapture != null ブランチ）
+        // 目的: CopyLocationCaptureHandler を渡した場合でも GraphServiceClient が生成されること
+        using var captureHandler = new CopyLocationCaptureHandler();
+        var client = GraphClientFactory.Create(
+            CreateAuthenticator(),
+            copyLocationCapture: captureHandler);
+
+        client.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Create_WithAllOptionalParameters_ReturnsGraphServiceClient()
+    {
+        // 検証対象: Create（全オプションパラメーター）
+        // 目的: onRateLimit・copyLocationCapture・rateLimitLogger をすべて指定した場合でも正常に生成されること
+        using var captureHandler = new CopyLocationCaptureHandler();
+        var mockLogger = new Mock<ILogger>();
+        var client = GraphClientFactory.Create(
+            CreateAuthenticator(),
+            timeoutSec: 60,
+            maxRetry: 2,
+            onRateLimit: _ => { },
+            copyLocationCapture: captureHandler,
+            rateLimitLogger: mockLogger.Object);
+
+        client.Should().NotBeNull();
+    }
+}

--- a/tests/unit/GraphDiscoveryServiceTests.cs
+++ b/tests/unit/GraphDiscoveryServiceTests.cs
@@ -1,17 +1,59 @@
 using CloudMigrator.Providers.Graph.Auth;
 using FluentAssertions;
+using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using Microsoft.Graph.Models.ODataErrors;
 using Microsoft.Kiota.Abstractions;
+using Microsoft.Kiota.Abstractions.Serialization;
+using Moq;
 
 namespace CloudMigrator.Tests.Unit;
 
 /// <summary>
-/// GraphDiscoveryService のユニットテスト（入力バリデーション + エラーハンドリング）。
+/// GraphDiscoveryService のユニットテスト（入力バリデーション + エラーハンドリング + 正常系）。
 /// ネットワーク疎通が不要なケースのみテストする。実際の API 疎通は E2E テストで確認する。
 /// </summary>
 public sealed class GraphDiscoveryServiceTests
 {
     private readonly GraphDiscoveryService _sut = new();
+
+    // ── IRequestAdapter モック ヘルパー ────────────────────────────────
+
+    /// <summary>
+    /// IRequestAdapter をモックして単一の SendAsync レスポンスを設定する。
+    /// </summary>
+    private static GraphServiceClient BuildGraphClientReturning<T>(T? response)
+        where T : class, IParsable
+    {
+        var mockAdapter = new Mock<IRequestAdapter>(MockBehavior.Loose);
+        mockAdapter.SetupProperty(a => a.BaseUrl, "https://graph.microsoft.com/v1.0");
+        mockAdapter
+            .Setup(a => a.SendAsync<T>(
+                It.IsAny<RequestInformation>(),
+                It.IsAny<ParsableFactory<T>>(),
+                It.IsAny<Dictionary<string, ParsableFactory<IParsable>>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+        return new GraphServiceClient(mockAdapter.Object);
+    }
+
+    /// <summary>
+    /// IRequestAdapter をモックして DriveItemCollectionResponse を返す GraphServiceClient を生成する。
+    /// </summary>
+    private static GraphServiceClient BuildGraphClientReturningDriveItemCollection(
+        DriveItemCollectionResponse? response)
+    {
+        var mockAdapter = new Mock<IRequestAdapter>(MockBehavior.Loose);
+        mockAdapter.SetupProperty(a => a.BaseUrl, "https://graph.microsoft.com/v1.0");
+        mockAdapter
+            .Setup(a => a.SendAsync<DriveItemCollectionResponse>(
+                It.IsAny<RequestInformation>(),
+                It.IsAny<ParsableFactory<DriveItemCollectionResponse>>(),
+                It.IsAny<Dictionary<string, ParsableFactory<IParsable>>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+        return new GraphServiceClient(mockAdapter.Object);
+    }
 
     // ── GetOneDriveDriveIdAsync 入力バリデーション ─────────────────────
 
@@ -739,4 +781,215 @@ public sealed class GraphDiscoveryServiceTests
 
         await act.Should().ThrowAsync<OperationCanceledException>();
     }
+
+    // ── GetOneDriveDriveIdAsync 正常系テスト ──────────────────────────
+
+    [Fact]
+    public async Task GetOneDriveDriveIdAsync_WhenDriveIdIsNullInResponse_ReturnsFailure()
+    {
+        // 検証対象: GetOneDriveDriveIdAsync  目的: API が Drive を返すが Id が null の場合に失敗結果が返されること
+        var sut = new GraphDiscoveryService();
+        sut.ClientFactory = (_, _, _) =>
+            BuildGraphClientReturning(new Drive { Id = null, Name = "My Drive" });
+
+        var result = await sut.GetOneDriveDriveIdAsync("c", "t", "s", "user@contoso.com");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Drive が見つかりませんでした");
+    }
+
+    [Fact]
+    public async Task GetOneDriveDriveIdAsync_WhenDriveIdExistsInResponse_ReturnsSuccess()
+    {
+        // 検証対象: GetOneDriveDriveIdAsync  目的: API が有効な Drive を返した場合に成功結果と Drive ID が返されること
+        var sut = new GraphDiscoveryService();
+        sut.ClientFactory = (_, _, _) =>
+            BuildGraphClientReturning(new Drive { Id = "test-drive-id", Name = "My Drive" });
+
+        var result = await sut.GetOneDriveDriveIdAsync("c", "t", "s", "user@contoso.com");
+
+        result.Success.Should().BeTrue();
+        result.DriveId.Should().Be("test-drive-id");
+        result.DisplayName.Should().Be("My Drive");
+    }
+
+    [Fact]
+    public async Task GetOneDriveDriveIdAsync_WhenDriveNameIsNull_UsesUserIdAsDisplayName()
+    {
+        // 検証対象: GetOneDriveDriveIdAsync  目的: Drive.Name が null の場合に userId が DisplayName として使われること
+        var sut = new GraphDiscoveryService();
+        sut.ClientFactory = (_, _, _) =>
+            BuildGraphClientReturning(new Drive { Id = "drive-id", Name = null });
+
+        var result = await sut.GetOneDriveDriveIdAsync("c", "t", "s", "user@contoso.com");
+
+        result.Success.Should().BeTrue();
+        result.DisplayName.Should().Be("user@contoso.com");
+    }
+
+    // ── GetSharePointSiteByUrlAsync 正常系テスト ──────────────────────
+
+    [Fact]
+    public async Task GetSharePointSiteByUrlAsync_WhenSiteIdIsNullInResponse_ReturnsFailure()
+    {
+        // 検証対象: GetSharePointSiteByUrlAsync  目的: API が Site を返すが Id が null の場合に失敗結果が返されること
+        var sut = new GraphDiscoveryService();
+        sut.ClientFactory = (_, _, _) =>
+            BuildGraphClientReturning<Site>(new Site { Id = null, DisplayName = "My Site" });
+
+        var result = await sut.GetSharePointSiteByUrlAsync(
+            "c", "t", "s", "https://contoso.sharepoint.com/sites/MyTeam");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("見つかりませんでした");
+    }
+
+    [Fact]
+    public async Task GetSharePointSiteByUrlAsync_WhenSiteExists_ReturnsSuccess()
+    {
+        // 検証対象: GetSharePointSiteByUrlAsync  目的: API が有効な Site を返した場合に成功結果が返されること
+        var sut = new GraphDiscoveryService();
+        sut.ClientFactory = (_, _, _) =>
+            BuildGraphClientReturning<Site>(new Site
+            {
+                Id = "site-id",
+                DisplayName = "My Team",
+                WebUrl = "https://contoso.sharepoint.com/sites/MyTeam"
+            });
+
+        var result = await sut.GetSharePointSiteByUrlAsync(
+            "c", "t", "s", "https://contoso.sharepoint.com/sites/MyTeam");
+
+        result.Success.Should().BeTrue();
+        result.Sites.Should().ContainSingle(s => s.SiteId == "site-id");
+    }
+
+    // ── VerifyDriveAsync 正常系テスト ─────────────────────────────────
+
+    [Fact]
+    public async Task VerifyDriveAsync_WhenDriveExists_ReturnsSuccess()
+    {
+        // 検証対象: VerifyDriveAsync  目的: API が有効な Drive を返した場合に成功結果が返されること
+        var sut = new GraphDiscoveryService();
+        sut.ClientFactory = (_, _, _) =>
+            BuildGraphClientReturning(new Drive { Id = "drive-id" });
+
+        var result = await sut.VerifyDriveAsync("c", "t", "s", "drive-id");
+
+        result.Success.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task VerifyDriveAsync_WhenDriveIdIsNullInResponse_ReturnsFailure()
+    {
+        // 検証対象: VerifyDriveAsync  目的: API が Drive を返すが Id が null の場合に失敗結果が返されること
+        var sut = new GraphDiscoveryService();
+        sut.ClientFactory = (_, _, _) =>
+            BuildGraphClientReturning(new Drive { Id = null });
+
+        var result = await sut.VerifyDriveAsync("c", "t", "s", "drive-id");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("見つかりませんでした");
+    }
+
+    // ── GetSharePointDrivesAsync 正常系テスト ─────────────────────────
+
+    [Fact]
+    public async Task GetSharePointDrivesAsync_WhenDrivesExist_ReturnsSuccess()
+    {
+        // 検証対象: GetSharePointDrivesAsync  目的: API がドライブリストを返した場合に成功結果とドライブ一覧が返されること
+        var sut = new GraphDiscoveryService();
+        var drivesResponse = new DriveCollectionResponse
+        {
+            Value =
+            [
+                new Drive { Id = "drive-1", Name = "Documents", DriveType = "documentLibrary" },
+                new Drive { Id = "drive-2", Name = "Site Assets", DriveType = "documentLibrary" }
+            ]
+        };
+        var mockAdapter = new Mock<IRequestAdapter>(MockBehavior.Loose);
+        mockAdapter.SetupProperty(a => a.BaseUrl, "https://graph.microsoft.com/v1.0");
+        mockAdapter
+            .Setup(a => a.SendAsync<DriveCollectionResponse>(
+                It.IsAny<RequestInformation>(),
+                It.IsAny<ParsableFactory<DriveCollectionResponse>>(),
+                It.IsAny<Dictionary<string, ParsableFactory<IParsable>>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(drivesResponse);
+        sut.ClientFactory = (_, _, _) => new GraphServiceClient(mockAdapter.Object);
+
+        var result = await sut.GetSharePointDrivesAsync("c", "t", "s", "site-id");
+
+        result.Success.Should().BeTrue();
+        result.Drives.Should().HaveCount(2);
+        result.Drives![0].DriveId.Should().Be("drive-1");
+    }
+
+    [Fact]
+    public async Task GetSharePointDrivesAsync_WhenResponseIsEmpty_ReturnsSuccessWithEmptyList()
+    {
+        // 検証対象: GetSharePointDrivesAsync  目的: API が空リストを返した場合に成功結果と空リストが返されること
+        var sut = new GraphDiscoveryService();
+        var drivesResponse = new DriveCollectionResponse { Value = [] };
+        var mockAdapter = new Mock<IRequestAdapter>(MockBehavior.Loose);
+        mockAdapter.SetupProperty(a => a.BaseUrl, "https://graph.microsoft.com/v1.0");
+        mockAdapter
+            .Setup(a => a.SendAsync<DriveCollectionResponse>(
+                It.IsAny<RequestInformation>(),
+                It.IsAny<ParsableFactory<DriveCollectionResponse>>(),
+                It.IsAny<Dictionary<string, ParsableFactory<IParsable>>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(drivesResponse);
+        sut.ClientFactory = (_, _, _) => new GraphServiceClient(mockAdapter.Object);
+
+        var result = await sut.GetSharePointDrivesAsync("c", "t", "s", "site-id");
+
+        result.Success.Should().BeTrue();
+        result.Drives.Should().BeEmpty();
+    }
+
+    // ── ListDriveFoldersAsync 正常系テスト ────────────────────────────
+
+    [Fact]
+    public async Task ListDriveFoldersAsync_WhenFolderIdIsNull_UsesRootChildren()
+    {
+        // 検証対象: ListDriveFoldersAsync  目的: folderId=null のとき root の子アイテムが取得されること
+        var sut = new GraphDiscoveryService();
+        var items = new DriveItemCollectionResponse
+        {
+            Value =
+            [
+                new DriveItem { Id = "folder-1", Name = "Documents", Folder = new Folder() },
+                new DriveItem { Id = "file-1", Name = "readme.txt", Folder = null } // フォルダでないのでフィルター除外
+            ]
+        };
+        sut.ClientFactory = (_, _, _) => BuildGraphClientReturningDriveItemCollection(items);
+
+        var result = await sut.ListDriveFoldersAsync("c", "t", "s", "drive-id", folderId: null);
+
+        result.Success.Should().BeTrue();
+        result.Folders.Should().ContainSingle(f => f.FolderId == "folder-1");
+    }
+
+    [Fact]
+    public async Task ListDriveFoldersAsync_WhenFolderIdIsSpecified_UsesItemChildren()
+    {
+        // 検証対象: ListDriveFoldersAsync  目的: folderId が指定されたとき、そのアイテムの子が取得されること
+        var sut = new GraphDiscoveryService();
+        var items = new DriveItemCollectionResponse
+        {
+            Value =
+            [
+                new DriveItem { Id = "sub-folder-1", Name = "SubFolder", Folder = new Folder() }
+            ]
+        };
+        sut.ClientFactory = (_, _, _) => BuildGraphClientReturningDriveItemCollection(items);
+
+        var result = await sut.ListDriveFoldersAsync("c", "t", "s", "drive-id", folderId: "parent-folder-id");
+
+        result.Success.Should().BeTrue();
+        result.Folders.Should().ContainSingle(f => f.FolderId == "sub-folder-1");
+    }
 }
+

--- a/tests/unit/RateLimitAwareHandlerTests.cs
+++ b/tests/unit/RateLimitAwareHandlerTests.cs
@@ -1,0 +1,216 @@
+using System.Net;
+using System.Net.Http.Headers;
+using CloudMigrator.Providers.Graph.Http;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace CloudMigrator.Tests.Unit;
+
+/// <summary>
+/// 検証対象: RateLimitAwareHandler
+/// 目的: 429/503 レスポンス傍受・コールバック通知・ロギングが正しく動作することを確認する
+/// </summary>
+public sealed class RateLimitAwareHandlerTests
+{
+    // ── ヘルパー ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 固定レスポンスを返す末端 HttpMessageHandler。
+    /// DelegatingHandler チェーンのテストに使用する。
+    /// </summary>
+    private sealed class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+
+        internal StubHttpMessageHandler(HttpResponseMessage response) => _response = response;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => Task.FromResult(_response);
+    }
+
+    /// <summary>
+    /// テスト用ハンドラーチェーンを構築し HttpMessageInvoker を返す。
+    /// </summary>
+    private static (HttpMessageInvoker Invoker, RateLimitAwareHandler Handler) BuildChain(
+        HttpResponseMessage response,
+        Action<TimeSpan?> onRateLimit,
+        ILogger? logger = null)
+    {
+        var inner = new StubHttpMessageHandler(response);
+        // RateLimitAwareHandler は internal sealed かつ InnerHandler を外部設定可能
+        var handler = (RateLimitAwareHandler)Activator.CreateInstance(
+            typeof(RateLimitAwareHandler),
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+            null,
+            [onRateLimit, logger],
+            null)!;
+        handler.InnerHandler = inner;
+        return (new HttpMessageInvoker(handler), handler);
+    }
+
+    private static HttpRequestMessage MakeRequest() =>
+        new(HttpMethod.Get, "https://graph.microsoft.com/v1.0/test");
+
+    // ── コールバック呼び出しテスト ─────────────────────────────────────
+
+    [Fact]
+    public async Task SendAsync_WhenResponseIs200_DoesNotInvokeCallback()
+    {
+        // 検証対象: SendAsync  目的: 200 OK レスポンス時にコールバックが呼ばれないこと
+        var called = false;
+        var response = new HttpResponseMessage(HttpStatusCode.OK);
+        var (invoker, _) = BuildChain(response, _ => called = true);
+
+        await invoker.SendAsync(MakeRequest(), CancellationToken.None);
+
+        called.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenResponseIs429WithDeltaRetryAfter_InvokesCallbackWithTimeSpan()
+    {
+        // 検証対象: SendAsync  目的: 429 + Retry-After Delta ヘッダーがある場合にコールバックへ TimeSpan が渡されること
+        TimeSpan? received = TimeSpan.Zero;
+        var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(30));
+        var (invoker, _) = BuildChain(response, ts => received = ts);
+
+        await invoker.SendAsync(MakeRequest(), CancellationToken.None);
+
+        received.Should().Be(TimeSpan.FromSeconds(30));
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenResponseIs429WithDateRetryAfter_InvokesCallbackWithPositiveTimeSpan()
+    {
+        // 検証対象: SendAsync  目的: 429 + Retry-After Date ヘッダーがある場合に正の TimeSpan がコールバックへ渡されること
+        TimeSpan? received = null;
+        var futureDate = DateTimeOffset.UtcNow.AddSeconds(60);
+        var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(futureDate);
+        var (invoker, _) = BuildChain(response, ts => received = ts);
+
+        await invoker.SendAsync(MakeRequest(), CancellationToken.None);
+
+        received.Should().NotBeNull();
+        received!.Value.TotalSeconds.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenResponseIs429WithPastDateRetryAfter_InvokesCallbackWithZeroTimeSpan()
+    {
+        // 検証対象: SendAsync  目的: Retry-After Date が過去時刻の場合にコールバックへ TimeSpan.Zero が渡されること
+        TimeSpan? received = null;
+        var pastDate = DateTimeOffset.UtcNow.AddSeconds(-10);
+        var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(pastDate);
+        var (invoker, _) = BuildChain(response, ts => received = ts);
+
+        await invoker.SendAsync(MakeRequest(), CancellationToken.None);
+
+        received.Should().Be(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenResponseIs429WithoutRetryAfter_InvokesCallbackWithNull()
+    {
+        // 検証対象: SendAsync  目的: 429 で Retry-After ヘッダーがない場合にコールバックへ null が渡されること
+        TimeSpan? received = TimeSpan.Zero; // null でないことを示す初期値
+        var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        var (invoker, _) = BuildChain(response, ts => received = ts);
+
+        await invoker.SendAsync(MakeRequest(), CancellationToken.None);
+
+        received.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenResponseIs503_InvokesCallback()
+    {
+        // 検証対象: SendAsync  目的: 503 Service Unavailable でもコールバックが呼ばれること
+        var called = false;
+        var response = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(5));
+        var (invoker, _) = BuildChain(response, _ => called = true);
+
+        await invoker.SendAsync(MakeRequest(), CancellationToken.None);
+
+        called.Should().BeTrue();
+    }
+
+    // ── レスポンスパスルー確認 ─────────────────────────────────────────
+
+    [Fact]
+    public async Task SendAsync_AlwaysReturnsOriginalResponse()
+    {
+        // 検証対象: SendAsync  目的: 429 を検出した後も元のレスポンスがそのまま返されること
+        var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        var (invoker, _) = BuildChain(response, _ => { });
+
+        var result = await invoker.SendAsync(MakeRequest(), CancellationToken.None);
+
+        result.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+    }
+
+    // ── ロギングテスト ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SendAsync_WhenResponseIs429WithDelta_LogsWarningWithWaitSec()
+    {
+        // 検証対象: SendAsync  目的: Retry-After Delta がある場合に待機秒数付きの Warning ログが出力されること
+        var mockLogger = new Mock<ILogger>();
+        mockLogger.Setup(l => l.IsEnabled(LogLevel.Warning)).Returns(true);
+
+        var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(45));
+        var (invoker, _) = BuildChain(response, _ => { }, mockLogger.Object);
+
+        await invoker.SendAsync(MakeRequest(), CancellationToken.None);
+
+        mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("45")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenResponseIs429WithoutRetryAfter_LogsWarningWithoutWaitSec()
+    {
+        // 検証対象: SendAsync  目的: Retry-After なしの場合にヘッダーなし旨の Warning ログが出力されること
+        var mockLogger = new Mock<ILogger>();
+        mockLogger.Setup(l => l.IsEnabled(LogLevel.Warning)).Returns(true);
+
+        var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        var (invoker, _) = BuildChain(response, _ => { }, mockLogger.Object);
+
+        await invoker.SendAsync(MakeRequest(), CancellationToken.None);
+
+        mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Retry-After なし")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenLoggerIsNull_DoesNotThrow()
+    {
+        // 検証対象: SendAsync  目的: logger=null のときでも NullReferenceException が発生しないこと
+        var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        var (invoker, _) = BuildChain(response, _ => { }, logger: null);
+
+        var act = async () => await invoker.SendAsync(MakeRequest(), CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/tests/unit/SetupDoctorServiceTests.cs
+++ b/tests/unit/SetupDoctorServiceTests.cs
@@ -175,7 +175,7 @@ public sealed class SetupDoctorServiceTests
 
         result.OverallStatus.Should().Be(OverallStatus.Unhealthy);
         result.Checks[2].Status.Should().Be(DoctorStatus.Fail);
-        result.Checks[2].Detail.Should().Contain("destinationRoot が見つかりません");
+        result.Checks[2].Detail.Should().Contain("destinationRoot フォルダが未作成です");
         result.Checks[2].Detail.Should().Contain("Migration/2026");
     }
 


### PR DESCRIPTION
## 概要
プロバイダー設定の正規化、クロール状態管理の修正、Rate Limit ログの追加、GraphDiscovery/SharePointVerify サービスの追加を行います。

## 変更内容

### ConfigurationService.cs
- `NormalizeProvider()` メソッド追加（`"Graph"` → `"sharepoint"` の正規化）
- `GetConfigAsync()` で `NormalizeProvider()` 経由で読み取り

### SharePointMigrationPipeline.cs
- Phase B 開始前に `crawl_complete = "false"` を明示保存（フレッシュスタート時のバッジ表示修正）
- `pipeline_working_seconds` チェックポイントを `finally` ブロックで累積保存

### DropboxMigrationPipeline.cs
- `pipeline_working_seconds` チェックポイント追加

### SetupDoctorService.cs
- セットアップ診断サービス実装

### RateLimitAwareHandler.cs
- `ILogger?` フィールド追加
- 429/503 検出時に `LogWarning` 出力（レートリミット監視）

### GraphClientFactory.cs
- `rateLimitLogger` パラメータ追加
- `new RateLimitAwareHandler(onRateLimit, rateLimitLogger)` に変更

### 新規ファイル
- `IGraphDiscoveryService.cs`: DriveId 探索インターフェース
- `GraphDiscoveryService.cs`: DriveId 探索実装
- `ISharePointVerifyService.cs`: SharePoint 検証インターフェース
- `SharePointVerifyService.cs`: SharePoint 検証実装

### App.xaml.cs
- `TransferJobService` に `loggerFactory2.CreateLogger<TransferJobService>()` 注入
- `GraphClientFactory.Create` に `rateLimitLogger` 接続

### その他
- `Directory.Build.props`: ビルドプロパティ更新
- `task.md`: タスク状態更新

> **Note:** `configs/config.json` は `.gitignore` 対象のため含まれていません。ローカルで `"destinationProvider": "sharepoint"` に変更してください。

## 依存 PR
- base: `feature/fix-transfer-job-service` (#126) — `TransferJobService` コンストラクタ変更への依存があります