### PR TITLE
fix: v0.4.0 起動テスト UX 改善（OneDrive→SharePoint ハッピーパス）

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
       デフォルトバージョン（開発ビルド用）。
       リリースビルドは GitHub Actions でタグから -p:Version=x.y.z を渡して上書きする。
     -->
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/src/CloudMigrator.Dashboard/Components/Wizard/DriveDiscoveryPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/DriveDiscoveryPage.razor
@@ -14,34 +14,50 @@
         <div>
             <MudText Typo="Typo.h5">OneDrive の接続先を設定する</MudText>
             <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mt-1">
-                移行元の Personal OneDrive の Drive ID を取得します。
+                移行したい OneDrive を所有しているアカウントのメールアドレスを入力してください。
             </MudText>
         </div>
 
-        @* App-only 認証の制約説明 *@
-        <MudAlert Severity="Severity.Info" Dense="true" Icon="@Icons.Material.Filled.Info">
-            <strong>App-only 認証の制約</strong>: <code>/me/drive</code> は使用できません。
-            OneDrive の所有者の <strong>UPN（メールアドレス形式のユーザー名）</strong> またはユーザー ID を入力してください。
+        @* メールアドレス確認方法の案内 *@
+        <MudAlert Severity="Severity.Info" Dense="true" Icon="@Icons.Material.Filled.HelpOutline">
+            <MudText Typo="Typo.body2">
+                <strong>自分の OneDrive を移行する場合</strong>: Microsoft 365 にサインインしているメールアドレスを入力してください。
+            </MudText>
+            <MudStack Row="true" Spacing="2" Class="mt-2">
+                <MudLink Href="https://outlook.office.com" Target="_blank" Typo="Typo.body2">
+                    <MudIcon Icon="@Icons.Material.Filled.OpenInBrowser" Size="Size.Small" Class="mr-1" />Outlook でメールアドレスを確認
+                </MudLink>
+                <MudText Typo="Typo.body2" Color="Color.Secondary">|</MudText>
+                <MudLink Href="https://admin.microsoft.com/AdminPortal/Home#/users" Target="_blank" Typo="Typo.body2">
+                    <MudIcon Icon="@Icons.Material.Filled.AdminPanelSettings" Size="Size.Small" Class="mr-1" />Microsoft 365 管理センター（管理者用）
+                </MudLink>
+            </MudStack>
         </MudAlert>
 
-        @* Graph Explorer リンク（補助参照） *@
-        <MudAlert Severity="Severity.Normal" Dense="true" Icon="@Icons.Material.Filled.OpenInBrowser">
-            UPN がわからない場合は
-            <MudLink Href="https://developer.microsoft.com/graph/graph-explorer" Target="_blank">
-                Graph Explorer
-            </MudLink>
-            で <code>GET /users</code> を実行して確認できます（管理者アカウントでサインイン要）。
+        @* 個人Microsoftアカウント非対応の注記 *@
+        <MudAlert Severity="Severity.Warning" Dense="true" Icon="@Icons.Material.Filled.Warning">
+            <strong>@@outlook.com / @@hotmail.com などの個人Microsoftアカウントは対応していません。</strong>
+            会社・学校アカウント（例: user@contoso.com）のみ利用可能です。
         </MudAlert>
 
-        @* UPN / ユーザー ID 入力 *@
+        @* メールアドレス入力 *@
         <MudTextField T="string"
                       Value="_userId"
-                      ValueChanged="@(v => { _userId = v; _discoveryResult = null; })"
-                      Label="UPN またはユーザー ID"
+                      ValueChanged="@(v => _userId = v)"
+                      Label="Microsoft アカウントのメールアドレス（会社・学校）"
                       Variant="Variant.Outlined"
-                      Placeholder="例: user@contoso.onmicrosoft.com"
+                      Placeholder="例: taro@contoso.com または taro@contoso.onmicrosoft.com"
                       Disabled="@_isBusy"
-                      HelperText="OneDrive の所有者のメールアドレス（UPN）を入力してください。" />
+                      HelperText="移行する OneDrive を所有している会社・学校アカウントのメールアドレス" />
+
+        @* UPN 変更後・未再取得の警告 *@
+        @if (_discoveryResult is { Success: true } &&
+             !string.Equals(_userId.Trim(), _fetchedUserId, StringComparison.OrdinalIgnoreCase))
+        {
+            <MudAlert Severity="Severity.Warning" Dense="true" Icon="@Icons.Material.Filled.Warning">
+                メールアドレスが変更されています。「Drive ID を取得」を押して再取得してください。
+            </MudAlert>
+        }
 
         @* 取得ボタン *@
         <MudButton Variant="Variant.Filled"
@@ -112,7 +128,8 @@
             <MudButton Variant="Variant.Filled"
                        Color="Color.Primary"
                        EndIcon="@Icons.Material.Filled.ArrowForward"
-                       Disabled="@(_isBusy || _discoveryResult is not { Success: true })"
+                       Disabled="@(_isBusy || _discoveryResult is not { Success: true } ||
+                                  !string.Equals(_userId.Trim(), _fetchedUserId, StringComparison.OrdinalIgnoreCase))"
                        OnClick="SaveAndContinueAsync">
                 次へ
             </MudButton>
@@ -129,6 +146,7 @@
     [Parameter] public EventCallback OnDiscoveryCompleted { get; set; }
 
     private string _userId = string.Empty;
+    private string _fetchedUserId = string.Empty;
     private string _clientId = string.Empty;
     private string _tenantId = string.Empty;
     private string _clientSecret = string.Empty;
@@ -144,6 +162,7 @@
         // 既存の設定からプリロードする
         var config = await ConfigurationService.GetDiscoveryConfigAsync();
         _userId = config.OneDriveUserId;
+        _fetchedUserId = config.OneDriveUserId; // 保存済み = 取得済みとみなす
         _initialSourceFolderId = config.OneDriveSourceFolderId;
         _initialSourceFolderPath = config.OneDriveSourceFolderPath;
 
@@ -180,6 +199,9 @@
 
             _discoveryResult = await DiscoveryService.GetOneDriveDriveIdAsync(
                 clientId, tenantId, clientSecret, _userId.Trim());
+
+            if (_discoveryResult.Success)
+                _fetchedUserId = _userId.Trim();
 
             if (!_discoveryResult.Success)
             {

--- a/src/CloudMigrator.Dashboard/Components/Wizard/SharePointDiscoveryPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/SharePointDiscoveryPage.razor
@@ -165,8 +165,31 @@
 
             @if (_driveListResult is { Success: true, Drives.Count: 0 })
             {
-                <MudAlert Severity="Severity.Warning" Dense="true">
-                    このサイトに Document Library が見つかりませんでした。
+                <MudAlert Severity="Severity.Warning">
+                    <MudText Typo="Typo.body2">
+                        このサイトに Document Library が見つかりませんでした。
+                        先に SharePoint でドキュメントライブラリを作成してから、再試行してください。
+                    </MudText>
+                    <MudStack Row="true" Spacing="2" Class="mt-2">
+                        @if (!string.IsNullOrEmpty(_selectedSite?.WebUrl))
+                        {
+                            <MudLink Href="@_selectedSite.WebUrl" Target="_blank" Typo="Typo.body2">
+                                <MudIcon Icon="@Icons.Material.Filled.OpenInBrowser" Size="Size.Small" Class="mr-1" />このサイトを SharePoint で開く
+                            </MudLink>
+                            <MudText Typo="Typo.body2" Color="Color.Secondary">|</MudText>
+                        }
+                        <MudLink Href="https://admin.microsoft.com/sharepoint" Target="_blank" Typo="Typo.body2">
+                            <MudIcon Icon="@Icons.Material.Filled.AdminPanelSettings" Size="Size.Small" Class="mr-1" />SharePoint 管理センター（管理者用）
+                        </MudLink>
+                    </MudStack>
+                    <MudButton Variant="Variant.Outlined"
+                               Size="Size.Small"
+                               StartIcon="@Icons.Material.Filled.Refresh"
+                               Class="mt-3"
+                               Disabled="@_isBusy"
+                               OnClick="LoadDrivesAsync">
+                        再試行
+                    </MudButton>
                 </MudAlert>
             }
         }

--- a/src/CloudMigrator.Dashboard/MainWindow.xaml.cs
+++ b/src/CloudMigrator.Dashboard/MainWindow.xaml.cs
@@ -29,5 +29,11 @@ public partial class MainWindow : Window
             Selector = "#app",
             ComponentType = typeof(Components.DashboardApp),
         });
+
+        // WebView2 初期化後に右クリックコンテキストメニュー（貼り付け等）を有効化する
+        BlazorWebView.BlazorWebViewInitialized += (sender, args) =>
+        {
+            args.WebView.CoreWebView2.Settings.AreDefaultContextMenusEnabled = true;
+        };
     }
 }

--- a/src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs
+++ b/src/CloudMigrator.Providers.Graph/Auth/GraphDiscoveryService.cs
@@ -43,6 +43,10 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
                 DriveId: drive.Id,
                 DisplayName: drive.Name ?? userId);
         }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 401)
+        {
+            return new OneDriveDiscoveryResult(false, ErrorMessage: BuildAuthError());
+        }
         catch (ODataError ex) when (ex.ResponseStatusCode == 403)
         {
             return new OneDriveDiscoveryResult(false,
@@ -57,6 +61,10 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         {
             return new OneDriveDiscoveryResult(false,
                 ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
+        catch (ApiException ex) when (ex.ResponseStatusCode == 401)
+        {
+            return new OneDriveDiscoveryResult(false, ErrorMessage: BuildAuthError());
         }
         catch (ApiException ex) when (ex.ResponseStatusCode == 403)
         {
@@ -111,6 +119,10 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
 
             return new SharePointSiteSearchResult(Success: true, Sites: sites);
         }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 401)
+        {
+            return new SharePointSiteSearchResult(false, ErrorMessage: BuildAuthError());
+        }
         catch (ODataError ex) when (ex.ResponseStatusCode == 403)
         {
             return new SharePointSiteSearchResult(false,
@@ -120,6 +132,10 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         {
             return new SharePointSiteSearchResult(false,
                 ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
+        catch (ApiException ex) when (ex.ResponseStatusCode == 401)
+        {
+            return new SharePointSiteSearchResult(false, ErrorMessage: BuildAuthError());
         }
         catch (ApiException ex) when (ex.ResponseStatusCode == 403)
         {
@@ -180,6 +196,10 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
 
             return new SharePointSiteSearchResult(Success: true, Sites: sites);
         }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 401)
+        {
+            return new SharePointSiteSearchResult(false, ErrorMessage: BuildAuthError());
+        }
         catch (ODataError ex) when (ex.ResponseStatusCode == 403)
         {
             return new SharePointSiteSearchResult(false,
@@ -189,6 +209,10 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         {
             return new SharePointSiteSearchResult(false,
                 ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
+        catch (ApiException ex) when (ex.ResponseStatusCode == 401)
+        {
+            return new SharePointSiteSearchResult(false, ErrorMessage: BuildAuthError());
         }
         catch (ApiException ex) when (ex.ResponseStatusCode == 403)
         {
@@ -250,6 +274,10 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
 
             return new SharePointSiteSearchResult(Success: true, Sites: [entry]);
         }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 401)
+        {
+            return new SharePointSiteSearchResult(false, ErrorMessage: BuildAuthError());
+        }
         catch (ODataError ex) when (ex.ResponseStatusCode == 403)
         {
             return new SharePointSiteSearchResult(false,
@@ -264,6 +292,10 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         {
             return new SharePointSiteSearchResult(false,
                 ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
+        catch (ApiException ex) when (ex.ResponseStatusCode == 401)
+        {
+            return new SharePointSiteSearchResult(false, ErrorMessage: BuildAuthError());
         }
         catch (ApiException ex) when (ex.ResponseStatusCode == 403)
         {
@@ -314,6 +346,10 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
 
             return new SharePointDriveListResult(Success: true, Drives: drives);
         }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 401)
+        {
+            return new SharePointDriveListResult(false, ErrorMessage: BuildAuthError());
+        }
         catch (ODataError ex) when (ex.ResponseStatusCode == 403)
         {
             return new SharePointDriveListResult(false,
@@ -323,6 +359,10 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         {
             return new SharePointDriveListResult(false,
                 ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
+        catch (ApiException ex) when (ex.ResponseStatusCode == 401)
+        {
+            return new SharePointDriveListResult(false, ErrorMessage: BuildAuthError());
         }
         catch (ApiException ex) when (ex.ResponseStatusCode == 403)
         {
@@ -367,6 +407,10 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
                 ? new DiscoveryVerifyResult(true)
                 : new DiscoveryVerifyResult(false, "Drive が見つかりませんでした。");
         }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 401)
+        {
+            return new DiscoveryVerifyResult(false, BuildAuthError());
+        }
         catch (ODataError ex) when (ex.ResponseStatusCode == 403)
         {
             return new DiscoveryVerifyResult(false, BuildAdminConsentError(ex.Error?.Code));
@@ -379,6 +423,10 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         {
             return new DiscoveryVerifyResult(false,
                 $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
+        catch (ApiException ex) when (ex.ResponseStatusCode == 401)
+        {
+            return new DiscoveryVerifyResult(false, BuildAuthError());
         }
         catch (ApiException ex) when (ex.ResponseStatusCode == 403)
         {
@@ -436,6 +484,10 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
 
             return new DriveFolderListResult(Success: true, Folders: folders);
         }
+        catch (ODataError ex) when (ex.ResponseStatusCode == 401)
+        {
+            return new DriveFolderListResult(false, ErrorMessage: BuildAuthError());
+        }
         catch (ODataError ex) when (ex.ResponseStatusCode == 403)
         {
             return new DriveFolderListResult(false,
@@ -450,6 +502,10 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         {
             return new DriveFolderListResult(false,
                 ErrorMessage: $"Graph API エラー ({ex.ResponseStatusCode}): {ex.Error?.Message}");
+        }
+        catch (ApiException ex) when (ex.ResponseStatusCode == 401)
+        {
+            return new DriveFolderListResult(false, ErrorMessage: BuildAuthError());
         }
         catch (ApiException ex)
         {
@@ -491,6 +547,16 @@ public sealed class GraphDiscoveryService : IGraphDiscoveryService
         var authenticator = new GraphAuthenticator(clientId, tenantId, clientSecret);
         return Http.GraphClientFactory.Create(authenticator);
     }
+
+    /// <summary>
+    /// 401 レスポンスを受けた際の認証エラーメッセージを生成する。
+    /// </summary>
+    internal static string BuildAuthError() =>
+        "Azure 認証に失敗しました（401）。\n" +
+        "以下を確認してください：\n" +
+        "・クライアント ID・テナント ID が正しいか\n" +
+        "・クライアントシークレットが正しく、有効期限が切れていないか\n" +
+        "Step 1 に戻って認証情報を再確認・再入力してください。";
 
     /// <summary>
     /// 403 レスポンスを受けた際の管理者同意エラーメッセージを生成する。

--- a/tests/unit/GraphDiscoveryServiceTests.cs
+++ b/tests/unit/GraphDiscoveryServiceTests.cs
@@ -258,6 +258,28 @@ public sealed class GraphDiscoveryServiceTests
     // ── GetOneDriveDriveIdAsync 例外ハンドリング ──────────────────────
 
     [Fact]
+    public async Task GetOneDriveDriveIdAsync_When401ODataError_ReturnsAuthError()
+    {
+        // 検証対象: GetOneDriveDriveIdAsync  目的: 401 ODataError で認証エラーガイダンスが返されること
+        var result = await CreateSutThrowing(MakeODataError(401))
+            .GetOneDriveDriveIdAsync("c", "t", "s", "user@contoso.com");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Azure 認証に失敗しました");
+    }
+
+    [Fact]
+    public async Task GetOneDriveDriveIdAsync_WhenApiException401_ReturnsAuthError()
+    {
+        // 検証対象: GetOneDriveDriveIdAsync  目的: 非-OData ApiException 401 で認証エラーガイダンスが返されること
+        var result = await CreateSutThrowing(new ApiException { ResponseStatusCode = 401 })
+            .GetOneDriveDriveIdAsync("c", "t", "s", "user@contoso.com");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Azure 認証に失敗しました");
+    }
+
+    [Fact]
     public async Task GetOneDriveDriveIdAsync_When403ODataError_WithAuthorizationRequestDenied_ReturnsAdminConsentGuide()
     {
         // 検証対象: GetOneDriveDriveIdAsync  目的: 403 + Authorization_RequestDenied で管理者同意ガイドが返されること
@@ -337,6 +359,28 @@ public sealed class GraphDiscoveryServiceTests
     // ── SearchSharePointSitesAsync 例外ハンドリング ────────────────────
 
     [Fact]
+    public async Task SearchSharePointSitesAsync_When401ODataError_ReturnsAuthError()
+    {
+        // 検証対象: SearchSharePointSitesAsync  目的: 401 ODataError で認証エラーガイダンスが返されること
+        var result = await CreateSutThrowing(MakeODataError(401))
+            .SearchSharePointSitesAsync("c", "t", "s", "contoso");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Azure 認証に失敗しました");
+    }
+
+    [Fact]
+    public async Task SearchSharePointSitesAsync_WhenApiException401_ReturnsAuthError()
+    {
+        // 検証対象: SearchSharePointSitesAsync  目的: 非-OData ApiException 401 で認証エラーガイダンスが返されること
+        var result = await CreateSutThrowing(new ApiException { ResponseStatusCode = 401 })
+            .SearchSharePointSitesAsync("c", "t", "s", "contoso");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Azure 認証に失敗しました");
+    }
+
+    [Fact]
     public async Task SearchSharePointSitesAsync_When403ODataError_ReturnsAdminConsentMessage()
     {
         // 検証対象: SearchSharePointSitesAsync  目的: 403 で管理者同意メッセージが返されること
@@ -383,6 +427,28 @@ public sealed class GraphDiscoveryServiceTests
     // ── GetSharePointSiteByUrlAsync 例外ハンドリング ───────────────────
 
     [Fact]
+    public async Task GetSharePointSiteByUrlAsync_When401ODataError_ReturnsAuthError()
+    {
+        // 検証対象: GetSharePointSiteByUrlAsync  目的: 401 ODataError で認証エラーガイダンスが返されること
+        var result = await CreateSutThrowing(MakeODataError(401))
+            .GetSharePointSiteByUrlAsync("c", "t", "s", "https://contoso.sharepoint.com/sites/MyTeam");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Azure 認証に失敗しました");
+    }
+
+    [Fact]
+    public async Task GetSharePointSiteByUrlAsync_WhenApiException401_ReturnsAuthError()
+    {
+        // 検証対象: GetSharePointSiteByUrlAsync  目的: 非-OData ApiException 401 で認証エラーガイダンスが返されること
+        var result = await CreateSutThrowing(new ApiException { ResponseStatusCode = 401 })
+            .GetSharePointSiteByUrlAsync("c", "t", "s", "https://contoso.sharepoint.com/sites/MyTeam");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Azure 認証に失敗しました");
+    }
+
+    [Fact]
     public async Task GetSharePointSiteByUrlAsync_When403ODataError_ReturnsAdminConsentMessage()
     {
         // 検証対象: GetSharePointSiteByUrlAsync  目的: 403 で管理者同意メッセージが返されること
@@ -418,6 +484,28 @@ public sealed class GraphDiscoveryServiceTests
     // ── GetSharePointDrivesAsync 例外ハンドリング ──────────────────────
 
     [Fact]
+    public async Task GetSharePointDrivesAsync_When401ODataError_ReturnsAuthError()
+    {
+        // 検証対象: GetSharePointDrivesAsync  目的: 401 ODataError で認証エラーガイダンスが返されること
+        var result = await CreateSutThrowing(MakeODataError(401))
+            .GetSharePointDrivesAsync("c", "t", "s", "site-id");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Azure 認証に失敗しました");
+    }
+
+    [Fact]
+    public async Task GetSharePointDrivesAsync_WhenApiException401_ReturnsAuthError()
+    {
+        // 検証対象: GetSharePointDrivesAsync  目的: 非-OData ApiException 401 で認証エラーガイダンスが返されること
+        var result = await CreateSutThrowing(new ApiException { ResponseStatusCode = 401 })
+            .GetSharePointDrivesAsync("c", "t", "s", "site-id");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Azure 認証に失敗しました");
+    }
+
+    [Fact]
     public async Task GetSharePointDrivesAsync_When403ODataError_ReturnsAdminConsentMessage()
     {
         // 検証対象: GetSharePointDrivesAsync  目的: 403 で管理者同意メッセージが返されること
@@ -451,6 +539,28 @@ public sealed class GraphDiscoveryServiceTests
     }
 
     // ── VerifyDriveAsync 例外ハンドリング ──────────────────────────────
+
+    [Fact]
+    public async Task VerifyDriveAsync_When401ODataError_ReturnsAuthError()
+    {
+        // 検証対象: VerifyDriveAsync  目的: 401 ODataError で認証エラーガイダンスが返されること
+        var result = await CreateSutThrowing(MakeODataError(401))
+            .VerifyDriveAsync("c", "t", "s", "driveId");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Azure 認証に失敗しました");
+    }
+
+    [Fact]
+    public async Task VerifyDriveAsync_WhenApiException401_ReturnsAuthError()
+    {
+        // 検証対象: VerifyDriveAsync  目的: 非-OData ApiException 401 で認証エラーガイダンスが返されること
+        var result = await CreateSutThrowing(new ApiException { ResponseStatusCode = 401 })
+            .VerifyDriveAsync("c", "t", "s", "driveId");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Azure 認証に失敗しました");
+    }
 
     [Fact]
     public async Task VerifyDriveAsync_When403ODataError_ReturnsAdminConsentMessage()
@@ -651,6 +761,28 @@ public sealed class GraphDiscoveryServiceTests
     // ── ListDriveFoldersAsync 例外ハンドリング ─────────────────────────
 
     [Fact]
+    public async Task ListDriveFoldersAsync_When401ODataError_ReturnsAuthError()
+    {
+        // 検証対象: ListDriveFoldersAsync  目的: 401 ODataError で認証エラーガイダンスが返されること
+        var result = await CreateSutThrowing(MakeODataError(401))
+            .ListDriveFoldersAsync("c", "t", "s", "drive-id");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Azure 認証に失敗しました");
+    }
+
+    [Fact]
+    public async Task ListDriveFoldersAsync_WhenApiException401_ReturnsAuthError()
+    {
+        // 検証対象: ListDriveFoldersAsync  目的: 非-OData ApiException 401 で認証エラーガイダンスが返されること
+        var result = await CreateSutThrowing(new ApiException { ResponseStatusCode = 401 })
+            .ListDriveFoldersAsync("c", "t", "s", "drive-id");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Azure 認証に失敗しました");
+    }
+
+    [Fact]
     public async Task ListDriveFoldersAsync_When403ODataError_ReturnsAdminConsentMessage()
     {
         // 検証対象: ListDriveFoldersAsync  目的: 403 で管理者同意メッセージが返されること
@@ -716,6 +848,28 @@ public sealed class GraphDiscoveryServiceTests
     }
 
     // ── ListAllSharePointSitesAsync 例外ハンドリング ───────────────────
+
+    [Fact]
+    public async Task ListAllSharePointSitesAsync_When401ODataError_ReturnsAuthError()
+    {
+        // 検証対象: ListAllSharePointSitesAsync  目的: 401 ODataError で認証エラーガイダンスが返されること
+        var result = await CreateSutThrowing(MakeODataError(401))
+            .ListAllSharePointSitesAsync("c", "t", "s");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Azure 認証に失敗しました");
+    }
+
+    [Fact]
+    public async Task ListAllSharePointSitesAsync_WhenApiException401_ReturnsAuthError()
+    {
+        // 検証対象: ListAllSharePointSitesAsync  目的: 非-OData ApiException 401 で認証エラーガイダンスが返されること
+        var result = await CreateSutThrowing(new ApiException { ResponseStatusCode = 401 })
+            .ListAllSharePointSitesAsync("c", "t", "s");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Azure 認証に失敗しました");
+    }
 
     [Fact]
     public async Task ListAllSharePointSitesAsync_When403ODataError_ReturnsAdminConsentMessage()


### PR DESCRIPTION
## Summary

- バージョンを `0.3.0` → `0.4.0` に更新
- WebView2 の右クリックコンテキストメニュー（貼り付け等）を有効化
- OneDrive 接続先設定（Step 2a）の UX 改善
  - 「UPN」という専門用語を「Microsoft アカウントのメールアドレス」に変更
  - 個人 MSA（`@outlook.com` / `@hotmail.com` 等）非対応の警告アラートを追加
  - Outlook / M365 管理センターへの確認リンクを追加
  - メールアドレス変更時にフォルダ選択が即時リセットされないよう修正（誤操作防止）
- Graph API 401 エラー時に具体的なガイダンスを表示（全 Discovery メソッド共通）
- SharePoint Discovery（Step 2b）で Document Library 未発見時に案内リンク＋再試行ボタンを追加

## Test plan

- [x] ビルド成功（警告 0・エラー 0）
- [x] ユニットテスト 556 件全合格
- [x] OneDrive → SharePoint ハッピーパスを手動確認
- [x] 右クリック貼り付けが設定画面で動作することを確認
- [x] メールアドレス変更後にフォルダ選択が保持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)