### PR TITLE
fix: ウィザードのフォルダ指定が転送処理に反映されないバグを修正

### DIFF
--- a/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
@@ -325,11 +325,19 @@ public sealed class ConfigurationService : IConfigurationService
             if (update.OneDriveUserId is not null) g["oneDriveUserId"] = update.OneDriveUserId;
             if (update.OneDriveDriveId is not null) g["oneDriveDriveId"] = update.OneDriveDriveId;
             if (update.OneDriveSourceFolderId is not null) g["oneDriveSourceFolderId"] = update.OneDriveSourceFolderId;
-            if (update.OneDriveSourceFolderPath is not null)
+
+            // oneDriveSourceFolderPath（Discovery 表示用）と oneDriveSourceFolder（転送処理用）を常に同値へ正規化する。
+            // update が null の場合は既存値（どちらか一方）をフォールバックとして双方に同期し、
+            // init/bootstrap 等の別経路で oneDriveSourceFolder だけが更新された場合の乖離を防ぐ。
+            var existingFolderPath = g["oneDriveSourceFolderPath"]?.GetValue<string>();
+            var existingSourceFolder = g["oneDriveSourceFolder"]?.GetValue<string>();
+            var effectiveFolderPath = update.OneDriveSourceFolderPath
+                ?? existingFolderPath
+                ?? existingSourceFolder;
+            if (effectiveFolderPath is not null)
             {
-                g["oneDriveSourceFolderPath"] = update.OneDriveSourceFolderPath;
-                // 転送処理（GraphStorageProvider）が読む oneDriveSourceFolder にも同期する
-                g["oneDriveSourceFolder"] = update.OneDriveSourceFolderPath;
+                g["oneDriveSourceFolderPath"] = effectiveFolderPath;
+                g["oneDriveSourceFolder"] = effectiveFolderPath;
             }
             if (update.SharePointSiteId is not null) g["sharePointSiteId"] = update.SharePointSiteId;
             if (update.SharePointDriveId is not null) g["sharePointDriveId"] = update.SharePointDriveId;

--- a/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
@@ -325,7 +325,12 @@ public sealed class ConfigurationService : IConfigurationService
             if (update.OneDriveUserId is not null) g["oneDriveUserId"] = update.OneDriveUserId;
             if (update.OneDriveDriveId is not null) g["oneDriveDriveId"] = update.OneDriveDriveId;
             if (update.OneDriveSourceFolderId is not null) g["oneDriveSourceFolderId"] = update.OneDriveSourceFolderId;
-            if (update.OneDriveSourceFolderPath is not null) g["oneDriveSourceFolderPath"] = update.OneDriveSourceFolderPath;
+            if (update.OneDriveSourceFolderPath is not null)
+            {
+                g["oneDriveSourceFolderPath"] = update.OneDriveSourceFolderPath;
+                // 転送処理（GraphStorageProvider）が読む oneDriveSourceFolder にも同期する
+                g["oneDriveSourceFolder"] = update.OneDriveSourceFolderPath;
+            }
             if (update.SharePointSiteId is not null) g["sharePointSiteId"] = update.SharePointSiteId;
             if (update.SharePointDriveId is not null) g["sharePointDriveId"] = update.SharePointDriveId;
             if (update.SharePointDestFolderId is not null) g["sharePointDestFolderId"] = update.SharePointDestFolderId;

--- a/tests/unit/ConfigurationServiceDiscoveryTests.cs
+++ b/tests/unit/ConfigurationServiceDiscoveryTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Nodes;
 using CloudMigrator.Core.Configuration;
 using FluentAssertions;
 
@@ -153,5 +154,79 @@ public sealed class ConfigurationServiceDiscoveryTests : IDisposable
         result.SharePointDriveId.Should().Be("b!sp-drive");
         result.MigrationRoute.Should().Be("OneDriveToSharePoint");
         result.DestinationProvider.Should().Be("sharepoint");
+    }
+
+    [Fact]
+    public async Task UpdateDiscoveryConfigAsync_WhenOneDriveSourceFolderPathIsSet_AlsoSyncsOneDriveSourceFolder()
+    {
+        // 検証対象: UpdateDiscoveryConfigAsync
+        // 目的: OneDriveSourceFolderPath を設定した場合、転送処理が読む oneDriveSourceFolder にも同値が保存されること
+        await _sut.UpdateDiscoveryConfigAsync(new DiscoveryConfigUpdateDto(
+            OneDriveSourceFolderPath: "Documents/Projects"));
+
+        var json = JsonNode.Parse(await File.ReadAllTextAsync(_configFile))!;
+        var g = json["migrator"]!["graph"]!;
+        g["oneDriveSourceFolderPath"]!.GetValue<string>().Should().Be("Documents/Projects");
+        g["oneDriveSourceFolder"]!.GetValue<string>().Should().Be("Documents/Projects");
+    }
+
+    [Fact]
+    public async Task UpdateDiscoveryConfigAsync_WhenOneDriveSourceFolderPathIsNull_FallsBackFromExistingSourceFolder()
+    {
+        // 検証対象: UpdateDiscoveryConfigAsync
+        // 目的: OneDriveSourceFolderPath が null のとき、既存の oneDriveSourceFolder を
+        //        oneDriveSourceFolderPath にも正規化し、乖離を解消すること
+        //        （init/bootstrap 等の別経路で oneDriveSourceFolder だけが書かれた場合のケース）
+        File.WriteAllText(_configFile, """
+            {
+              "migrator": {
+                "destinationProvider": "sharepoint",
+                "graph": {
+                  "clientId": "",
+                  "tenantId": "",
+                  "oneDriveSourceFolder": "Documents/Legacy"
+                }
+              }
+            }
+            """);
+        var sut = new ConfigurationService(_configFile);
+
+        // OneDriveSourceFolderPath を指定せずに他フィールドだけ更新
+        await sut.UpdateDiscoveryConfigAsync(new DiscoveryConfigUpdateDto(
+            OneDriveUserId: "user@contoso.com"));
+
+        var json = JsonNode.Parse(await File.ReadAllTextAsync(_configFile))!;
+        var g = json["migrator"]!["graph"]!;
+        g["oneDriveSourceFolderPath"]!.GetValue<string>().Should().Be("Documents/Legacy");
+        g["oneDriveSourceFolder"]!.GetValue<string>().Should().Be("Documents/Legacy");
+    }
+
+    [Fact]
+    public async Task UpdateDiscoveryConfigAsync_WhenOneDriveSourceFolderPathIsNull_FallsBackFromExistingFolderPath()
+    {
+        // 検証対象: UpdateDiscoveryConfigAsync
+        // 目的: OneDriveSourceFolderPath が null のとき、既存の oneDriveSourceFolderPath を
+        //        oneDriveSourceFolder にも正規化し、乖離を解消すること
+        File.WriteAllText(_configFile, """
+            {
+              "migrator": {
+                "destinationProvider": "sharepoint",
+                "graph": {
+                  "clientId": "",
+                  "tenantId": "",
+                  "oneDriveSourceFolderPath": "Documents/Projects"
+                }
+              }
+            }
+            """);
+        var sut = new ConfigurationService(_configFile);
+
+        await sut.UpdateDiscoveryConfigAsync(new DiscoveryConfigUpdateDto(
+            OneDriveUserId: "user@contoso.com"));
+
+        var json = JsonNode.Parse(await File.ReadAllTextAsync(_configFile))!;
+        var g = json["migrator"]!["graph"]!;
+        g["oneDriveSourceFolderPath"]!.GetValue<string>().Should().Be("Documents/Projects");
+        g["oneDriveSourceFolder"]!.GetValue<string>().Should().Be("Documents/Projects");
     }
 }


### PR DESCRIPTION
## Summary

- ウィザードで選択したフォルダが転送処理に反映されず、常にドライブ全体をクロールしていたバグを修正

### 原因

`UpdateDiscoveryConfigAsync` は `oneDriveSourceFolderId` / `oneDriveSourceFolderPath` に保存していたが、`GraphStorageProvider` が読む `migrator.graph.oneDriveSourceFolder` を更新していなかった。

### 修正内容

`oneDriveSourceFolderPath` を保存する際に `oneDriveSourceFolder`（転送処理が読むキー）にも同じ値を同期するよう変更。

## Test plan

- [x] ビルド成功（警告 0・エラー 0）
- [x] ユニットテスト 570 件全合格
- [ ] ウィザードでフォルダを指定して転送を実行し、指定フォルダ配下のみがクロールされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)