### PR TITLE
feat: AdaptiveConcurrency の増速制御を成功カウントから時間ベース（秒数）に変更

### DIFF
--- a/src/CloudMigrator.Cli/CliServices.cs
+++ b/src/CloudMigrator.Cli/CliServices.cs
@@ -125,11 +125,17 @@ internal sealed class CliServices : IDisposable
         {
             if (!profile.Enabled) continue;
             var useDropboxAdaptiveMode = options.DestinationProvider.Equals("dropbox", StringComparison.OrdinalIgnoreCase);
+            // InitialDegree > 0: 設定値を使用（スロースタート）
+            // InitialDegree == 0 かつ Dropbox: min(2, max)（旧来のスロースタート）
+            // InitialDegree == 0 かつ SharePoint: max（スロースタートなし）
+            var initialDegree = profile.InitialDegree > 0
+                ? Math.Min(profile.InitialDegree, options.MaxParallelTransfers)
+                : useDropboxAdaptiveMode ? Math.Min(2, options.MaxParallelTransfers) : options.MaxParallelTransfers;
             controllers[profileName] = new AdaptiveConcurrencyController(
-                initialDegree: useDropboxAdaptiveMode ? Math.Min(2, options.MaxParallelTransfers) : options.MaxParallelTransfers,
+                initialDegree: initialDegree,
                 minDegree: profile.MinDegree,
                 maxDegree: options.MaxParallelTransfers,
-                successThreshold: profile.SuccessThresholdToIncrease,
+                increaseIntervalSec: profile.IncreaseIntervalSec,
                 logger: loggerFactory.CreateLogger<AdaptiveConcurrencyController>(),
                 increaseStep: profile.IncreaseStep,
                 decreaseStep: profile.DecreaseStep,

--- a/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
@@ -125,14 +125,20 @@ public sealed class ConfigurationService : IConfigurationService
         using var doc = JsonDocument.Parse(json);
         var m = doc.RootElement.GetProperty("migrator");
 
-        // adaptiveConcurrency.sharepoint セクションを読み取る
+        // adaptiveConcurrency.sharepoint セクションを読み取る（なければ default プロファイルにフォールバック）
         var adaptiveEnabled = false;
         var adaptiveInitialDegree = 0;
-        if (m.TryGetProperty("adaptiveConcurrency", out var acProp) && acProp.ValueKind == JsonValueKind.Object &&
-            acProp.TryGetProperty("sharepoint", out var spAc) && spAc.ValueKind == JsonValueKind.Object)
+        if (m.TryGetProperty("adaptiveConcurrency", out var acProp) && acProp.ValueKind == JsonValueKind.Object)
         {
-            adaptiveEnabled = spAc.TryGetProperty("enabled", out var enProp) && enProp.ValueKind == JsonValueKind.True;
-            adaptiveInitialDegree = GetInt(spAc, "initialDegree", 0);
+            // sharepoint キーがなければ default プロファイルを試みる
+            JsonElement acProfile;
+            var hasProfile = (acProp.TryGetProperty("sharepoint", out acProfile) && acProfile.ValueKind == JsonValueKind.Object)
+                          || (acProp.TryGetProperty("default", out acProfile) && acProfile.ValueKind == JsonValueKind.Object);
+            if (hasProfile)
+            {
+                adaptiveEnabled = acProfile.TryGetProperty("enabled", out var enProp) && enProp.ValueKind == JsonValueKind.True;
+                adaptiveInitialDegree = GetInt(acProfile, "initialDegree", 0);
+            }
         }
 
         return new ConfigDto(

--- a/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
@@ -15,7 +15,9 @@ public sealed record ConfigDto(
     int RetryCount,
     int TimeoutSec,
     string DestinationRoot,
-    string DestinationProvider);
+    string DestinationProvider,
+    bool AdaptiveConcurrencyEnabled = false,
+    int AdaptiveConcurrencyInitialDegree = 0);
 
 /// <summary>
 /// PUT /api/config で受け取るマージ更新 DTO。null フィールドは上書きしない。
@@ -28,7 +30,9 @@ public sealed record ConfigUpdateDto(
     int? RetryCount = null,
     int? TimeoutSec = null,
     string? DestinationRoot = null,
-    string? DestinationProvider = null);
+    string? DestinationProvider = null,
+    bool? AdaptiveConcurrencyEnabled = null,
+    int? AdaptiveConcurrencyInitialDegree = null);
 
 /// <summary>
 /// Graph プロバイダー設定 DTO（シークレット除外済み）。
@@ -121,6 +125,16 @@ public sealed class ConfigurationService : IConfigurationService
         using var doc = JsonDocument.Parse(json);
         var m = doc.RootElement.GetProperty("migrator");
 
+        // adaptiveConcurrency.sharepoint セクションを読み取る
+        var adaptiveEnabled = false;
+        var adaptiveInitialDegree = 0;
+        if (m.TryGetProperty("adaptiveConcurrency", out var acProp) && acProp.ValueKind == JsonValueKind.Object &&
+            acProp.TryGetProperty("sharepoint", out var spAc) && spAc.ValueKind == JsonValueKind.Object)
+        {
+            adaptiveEnabled = spAc.TryGetProperty("enabled", out var enProp) && enProp.ValueKind == JsonValueKind.True;
+            adaptiveInitialDegree = GetInt(spAc, "initialDegree", 0);
+        }
+
         return new ConfigDto(
             MaxParallelTransfers: GetInt(m, "maxParallelTransfers", 4),
             MaxParallelFolderCreations: GetInt(m, "maxParallelFolderCreations", 4),
@@ -129,7 +143,9 @@ public sealed class ConfigurationService : IConfigurationService
             RetryCount: GetInt(m, "retryCount", 3),
             TimeoutSec: GetInt(m, "timeoutSec", 300),
             DestinationRoot: GetString(m, "destinationRoot", string.Empty),
-            DestinationProvider: NormalizeProvider(GetString(m, "destinationProvider", "sharepoint")));
+            DestinationProvider: NormalizeProvider(GetString(m, "destinationProvider", "sharepoint")),
+            AdaptiveConcurrencyEnabled: adaptiveEnabled,
+            AdaptiveConcurrencyInitialDegree: adaptiveInitialDegree);
     }
 
     /// <inheritdoc />
@@ -152,6 +168,25 @@ public sealed class ConfigurationService : IConfigurationService
             if (update.TimeoutSec.HasValue) m["timeoutSec"] = update.TimeoutSec.Value;
             if (update.DestinationRoot is not null) m["destinationRoot"] = update.DestinationRoot;
             if (update.DestinationProvider is not null) m["destinationProvider"] = update.DestinationProvider;
+
+            // adaptiveConcurrency.sharepoint セクションを更新
+            if (update.AdaptiveConcurrencyEnabled.HasValue || update.AdaptiveConcurrencyInitialDegree.HasValue)
+            {
+                if (m["adaptiveConcurrency"] is not JsonObject acObj)
+                {
+                    acObj = new JsonObject();
+                    m["adaptiveConcurrency"] = acObj;
+                }
+                if (acObj["sharepoint"] is not JsonObject spAcObj)
+                {
+                    spAcObj = new JsonObject();
+                    acObj["sharepoint"] = spAcObj;
+                }
+                if (update.AdaptiveConcurrencyEnabled.HasValue)
+                    spAcObj["enabled"] = update.AdaptiveConcurrencyEnabled.Value;
+                if (update.AdaptiveConcurrencyInitialDegree.HasValue)
+                    spAcObj["initialDegree"] = update.AdaptiveConcurrencyInitialDegree.Value;
+            }
 
             // アトミック書き込み: 一時ファイルに書き込んでからリネーム
             var tmpPath = _configFilePath + ".tmp";

--- a/src/CloudMigrator.Core/Configuration/MigratorOptions.cs
+++ b/src/CloudMigrator.Core/Configuration/MigratorOptions.cs
@@ -171,11 +171,17 @@ public sealed class AdaptiveConcurrencyOptions
     /// <summary>動的並列度制御を有効にするかどうか。デフォルト false（既存の固定並列度方式を維持）</summary>
     public bool Enabled { get; set; } = false;
 
+    /// <summary>
+    /// 開始時の初期並列度。0 の場合は MaxParallelTransfers と同値（スロースタートなし）。
+    /// 1 を設定すると 1 並列から徐々に増加するスロースタートになる。デフォルト 0
+    /// </summary>
+    public int InitialDegree { get; set; } = 0;
+
     /// <summary>並列度の下限。レート制限が続いてもこの値より下がらない。デフォルト 1</summary>
     public int MinDegree { get; set; } = 1;
 
-    /// <summary>並列度を回復させるために必要な連続成功回数（増速の条件）。デフォルト 10</summary>
-    public int SuccessThresholdToIncrease { get; set; } = 10;
+    /// <summary>並列度を回復させるまでの待機時間（秒）。0 = 即時増速可能。429 後に N 秒経過してから増速を許可する。デフォルト 30</summary>
+    public int IncreaseIntervalSec { get; set; } = 30;
 
     /// <summary>1 回の回復で増加する並列度の幅（増速のスピード）。デフォルト 1</summary>
     public int IncreaseStep { get; set; } = 1;

--- a/src/CloudMigrator.Core/Migration/SharePointMigrationPipeline.cs
+++ b/src/CloudMigrator.Core/Migration/SharePointMigrationPipeline.cs
@@ -229,6 +229,20 @@ public sealed class SharePointMigrationPipeline : IMigrationPipeline
         // folder_total チェックポイント保存（ダッシュボードの進捗バー用）
         await _stateDb.SaveCheckpointAsync(FolderTotalKey, allFolders.Count.ToString(), ct).ConfigureAwait(false);
 
+        var controller = _concurrencyController;
+        var maxDegree = controller?.MaxDegree ?? _options.MaxParallelFolderCreations;
+
+        // Phase C の初期並列度をメトリクスに記録（ダッシュボードの「現在並列数」表示用）
+        try
+        {
+            await _stateDb.RecordMetricAsync(
+                "current_parallelism", (double)(controller?.CurrentDegree ?? _options.MaxParallelFolderCreations), ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Phase C current_parallelism メトリクス記録に失敗しました。");
+        }
+
         if (allFolders.Count == 0)
         {
             _logger.LogInformation("Phase C: フォルダ作成対象なし");
@@ -251,27 +265,58 @@ public sealed class SharePointMigrationPipeline : IMigrationPipeline
                 depthGroup,
                 new ParallelOptions
                 {
-                    MaxDegreeOfParallelism = _options.MaxParallelFolderCreations,
+                    MaxDegreeOfParallelism = maxDegree,
                     CancellationToken = ct,
                 },
                 async (folderRelPath, folderCt) =>
                 {
-                    var normalizedRoot = _options.DestinationRoot?.Replace('\\', '/').Trim('/');
-                    var destFolderPath = string.IsNullOrEmpty(normalizedRoot)
-                        ? folderRelPath
-                        : $"{normalizedRoot}/{folderRelPath}";
+                    // 動的並列度制御のゲート（AdaptiveConcurrencyController が有効な場合）
+                    if (controller is not null)
+                        await controller.AcquireAsync(folderCt).ConfigureAwait(false);
 
-                    // EnsureFolderAsync は 409 Conflict を無視する冪等実装のため並列・再実行で安全
-                    await _destinationProvider.EnsureFolderAsync(destFolderPath, folderCt).ConfigureAwait(false);
-
-                    var count = Interlocked.Increment(ref _folderDoneCount);
                     try
                     {
-                        await _stateDb.RecordMetricAsync("sp_folder_done", (double)count, folderCt).ConfigureAwait(false);
+                        var normalizedRoot = _options.DestinationRoot?.Replace('\\', '/').Trim('/');
+                        var destFolderPath = string.IsNullOrEmpty(normalizedRoot)
+                            ? folderRelPath
+                            : $"{normalizedRoot}/{folderRelPath}";
+
+                        // EnsureFolderAsync は 409 Conflict を無視する冪等実装のため並列・再実行で安全
+                        await _destinationProvider.EnsureFolderAsync(destFolderPath, folderCt).ConfigureAwait(false);
+
+                        controller?.NotifySuccess();
+
+                        var count = Interlocked.Increment(ref _folderDoneCount);
+                        try
+                        {
+                            await _stateDb.RecordMetricAsync("sp_folder_done", (double)count, folderCt).ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogWarning(ex, "sp_folder_done メトリクス記録に失敗しました。");
+                        }
+
+                        // 並列度が変化した場合は即時記録
+                        if (controller is not null)
+                        {
+                            var currentDegree = controller.CurrentDegree;
+                            if (Interlocked.Exchange(ref _lastRecordedParallelism, currentDegree) != currentDegree)
+                            {
+                                try
+                                {
+                                    await _stateDb.RecordMetricAsync(
+                                        "current_parallelism", (double)currentDegree, folderCt).ConfigureAwait(false);
+                                }
+                                catch (Exception ex)
+                                {
+                                    _logger.LogWarning(ex, "Phase C current_parallelism 即時記録に失敗しました。");
+                                }
+                            }
+                        }
                     }
-                    catch (Exception ex)
+                    finally
                     {
-                        _logger.LogWarning(ex, "sp_folder_done メトリクス記録に失敗しました。");
+                        controller?.Release();
                     }
                 }).ConfigureAwait(false);
         }

--- a/src/CloudMigrator.Core/Migration/SharePointMigrationPipeline.cs
+++ b/src/CloudMigrator.Core/Migration/SharePointMigrationPipeline.cs
@@ -230,7 +230,11 @@ public sealed class SharePointMigrationPipeline : IMigrationPipeline
         await _stateDb.SaveCheckpointAsync(FolderTotalKey, allFolders.Count.ToString(), ct).ConfigureAwait(false);
 
         var controller = _concurrencyController;
-        var maxDegree = controller?.MaxDegree ?? _options.MaxParallelFolderCreations;
+        // MaxParallelFolderCreations を上限として維持する（controller.MaxDegree は MaxParallelTransfers ベースのため）
+        var maxFolderCreationDegree = Math.Max(1, _options.MaxParallelFolderCreations);
+        var maxDegree = controller is null
+            ? maxFolderCreationDegree
+            : Math.Min(maxFolderCreationDegree, controller.MaxDegree);
 
         // Phase C の初期並列度をメトリクスに記録（ダッシュボードの「現在並列数」表示用）
         try

--- a/src/CloudMigrator.Core/Migration/SharePointMigrationPipeline.cs
+++ b/src/CloudMigrator.Core/Migration/SharePointMigrationPipeline.cs
@@ -240,7 +240,7 @@ public sealed class SharePointMigrationPipeline : IMigrationPipeline
         try
         {
             await _stateDb.RecordMetricAsync(
-                "current_parallelism", (double)(controller?.CurrentDegree ?? _options.MaxParallelFolderCreations), ct).ConfigureAwait(false);
+                "current_parallelism", (double)Math.Min(maxDegree, controller?.CurrentDegree ?? maxDegree), ct).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -300,10 +300,10 @@ public sealed class SharePointMigrationPipeline : IMigrationPipeline
                             _logger.LogWarning(ex, "sp_folder_done メトリクス記録に失敗しました。");
                         }
 
-                        // 並列度が変化した場合は即時記録
+                        // 並列度が変化した場合は即時記録（Phase C 上限 maxDegree でキャップ）
                         if (controller is not null)
                         {
-                            var currentDegree = controller.CurrentDegree;
+                            var currentDegree = Math.Min(maxDegree, controller.CurrentDegree);
                             if (Interlocked.Exchange(ref _lastRecordedParallelism, currentDegree) != currentDegree)
                             {
                                 try

--- a/src/CloudMigrator.Core/Transfer/AdaptiveConcurrencyController.cs
+++ b/src/CloudMigrator.Core/Transfer/AdaptiveConcurrencyController.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace CloudMigrator.Core.Transfer;
@@ -6,7 +7,7 @@ namespace CloudMigrator.Core.Transfer;
 /// Graph API のレート制限（429/503）に応じて並列転送数を動的に調整するコントローラー。
 /// <list type="bullet">
 ///   <item>429/503 を受けると並列度を 1 削減する（<see cref="MinDegree"/> まで）</item>
-///   <item>連続成功が <see cref="SuccessThreshold"/> に達すると並列度を 1 回復する（<see cref="MaxDegree"/> まで）</item>
+///   <item>最後の減速から <see cref="IncreaseIntervalSec"/> 秒が経過し、<see cref="NotifySuccess"/> が呼ばれると並列度を 1 回復する（<see cref="MaxDegree"/> まで）</item>
 ///   <item>内部で <see cref="SemaphoreSlim"/> を使用し、スロット取得 / 解放で並列数を制御する</item>
 /// </list>
 /// </summary>
@@ -26,7 +27,7 @@ public sealed class AdaptiveConcurrencyController : IDisposable
     private int _current;
     private int _startupHeadroom;    // ソフトスタートでまだセマフォに放流していない容量
     private int _absorbedActual;      // 実際にセマフォから吸収済みのスロット数
-    private int _consecutiveSuccesses;
+    private long _increaseAvailableAfterTicks;  // この Stopwatch タイムスタンプ以降でないと増速しない
     private int _pendingDecreases;    // 減速トリガーカウンター
 
     // レート制限通知の累計回数（Interlocked でスレッドセーフに更新）
@@ -40,7 +41,7 @@ public sealed class AdaptiveConcurrencyController : IDisposable
     /// <param name="initialDegree">開始時の並列度（<paramref name="maxDegree"/> と同じ値を推奨）</param>
     /// <param name="minDegree">並列度の下限</param>
     /// <param name="maxDegree">並列度の上限</param>
-    /// <param name="successThreshold">並列度を回復するために必要な連続成功回数</param>
+    /// <param name="increaseIntervalSec">減速後に増速を許可するまでの待機時間（秒）。0 = 即時増速可能</param>
     /// <param name="logger">ロガー</param>
     /// <param name="increaseStep">1 回の回復で増加する並列度の幅。デフォルト 1</param>
     /// <param name="decreaseStep">1 回の減速イベントで減少する並列度の幅。デフォルト 1</param>
@@ -49,7 +50,7 @@ public sealed class AdaptiveConcurrencyController : IDisposable
         int initialDegree,
         int minDegree,
         int maxDegree,
-        int successThreshold,
+        int increaseIntervalSec,
         ILogger<AdaptiveConcurrencyController> logger,
         int increaseStep = 1,
         int decreaseStep = 1,
@@ -58,7 +59,7 @@ public sealed class AdaptiveConcurrencyController : IDisposable
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(minDegree, 1);
         ArgumentOutOfRangeException.ThrowIfLessThan(maxDegree, minDegree);
-        ArgumentOutOfRangeException.ThrowIfLessThan(successThreshold, 1);
+        ArgumentOutOfRangeException.ThrowIfNegative(increaseIntervalSec);
         ArgumentOutOfRangeException.ThrowIfLessThan(increaseStep, 1);
         ArgumentOutOfRangeException.ThrowIfLessThan(decreaseStep, 1);
         ArgumentOutOfRangeException.ThrowIfLessThan(decreaseTriggerCount, 1);
@@ -67,12 +68,15 @@ public sealed class AdaptiveConcurrencyController : IDisposable
         _max = maxDegree;
         _current = Math.Clamp(initialDegree, minDegree, maxDegree);
         _startupHeadroom = _max - _current;
-        SuccessThreshold = successThreshold;
+        IncreaseIntervalSec = increaseIntervalSec;
         _increaseStep = increaseStep;
         _decreaseStep = decreaseStep;
         _decreaseTriggerCount = decreaseTriggerCount;
         _halveOnRateLimit = halveOnRateLimit;
         _logger = logger;
+
+        // 初期は増速可能（long.MinValue = 既に過去）
+        _increaseAvailableAfterTicks = long.MinValue;
 
         // 初期並列度でセマフォを作成（maxDegree が上限）
         _semaphore = new SemaphoreSlim(_current, maxDegree);
@@ -91,8 +95,8 @@ public sealed class AdaptiveConcurrencyController : IDisposable
     /// <summary>並列度の下限。</summary>
     public int MinDegree => _min;
 
-    /// <summary>並列度を回復するために必要な連続成功回数。</summary>
-    public int SuccessThreshold { get; }
+    /// <summary>減速後に増速を許可するまでの待機時間（秒）。0 = 即時増速可能。</summary>
+    public int IncreaseIntervalSec { get; }
 
     /// <summary>1 回の回復で増加する並列度の幅。</summary>
     public int IncreaseStep => _increaseStep;
@@ -138,8 +142,6 @@ public sealed class AdaptiveConcurrencyController : IDisposable
         int prevDegree = -1, newDegree = -1, step = 0;
         lock (_syncRoot)
         {
-            _consecutiveSuccesses = 0;
-
             // MinDegree 到達時はカウンターを増やさない（回復後の最初の通知で即減速しないようにする）
             if (_current > _min)
                 _pendingDecreases++;
@@ -153,6 +155,14 @@ public sealed class AdaptiveConcurrencyController : IDisposable
                     : _current - Math.Min(_decreaseStep, _current - _min);
                 step = prevDegree - _current;
                 newDegree = _current;
+
+                // 減速発火時に次の増速可能タイムスタンプを更新（Retry-After + IncreaseIntervalSec）
+                var retryAfterTicks = retryAfter.HasValue
+                    ? (long)(retryAfter.Value.TotalSeconds * Stopwatch.Frequency) : 0L;
+                var intervalTicks = (long)(IncreaseIntervalSec * Stopwatch.Frequency);
+                var available = Stopwatch.GetTimestamp() + retryAfterTicks + intervalTicks;
+                if (available > _increaseAvailableAfterTicks)
+                    _increaseAvailableAfterTicks = available;
             }
         }
 
@@ -179,13 +189,12 @@ public sealed class AdaptiveConcurrencyController : IDisposable
         int prevDegree = -1, newDegree = -1, step = 0, fromStartupHeadroom = 0, fromAbsorbed = 0;
         lock (_syncRoot)
         {
-            _consecutiveSuccesses++;
-            if (_consecutiveSuccesses >= SuccessThreshold && _current < _max)
+            // 増速可能タイムスタンプを過ぎていれば増速を試みる
+            if (Stopwatch.GetTimestamp() >= _increaseAvailableAfterTicks && _current < _max)
             {
                 var releasable = _startupHeadroom + _absorbedActual;
                 if (releasable > 0)
                 {
-                    _consecutiveSuccesses = 0;
                     step = Math.Min(_increaseStep, Math.Min(_max - _current, releasable));
                     fromAbsorbed = Math.Min(step, _absorbedActual);
                     fromStartupHeadroom = step - fromAbsorbed;
@@ -194,6 +203,10 @@ public sealed class AdaptiveConcurrencyController : IDisposable
                     _absorbedActual -= fromAbsorbed;
                     _startupHeadroom -= fromStartupHeadroom;
                     newDegree = _current;
+
+                    // 増速後、次の増速まで IncreaseIntervalSec 秒待つ
+                    _increaseAvailableAfterTicks = Stopwatch.GetTimestamp()
+                        + (long)(IncreaseIntervalSec * Stopwatch.Frequency);
                 }
             }
         }
@@ -204,8 +217,8 @@ public sealed class AdaptiveConcurrencyController : IDisposable
         for (int i = 0; i < step; i++)
             _semaphore.Release(); // 吸収済みスロットを循環に戻す
         _logger.LogInformation(
-            "連続成功 {Threshold} 回達成。並列度を {Prev} → {Current}/{Max} に回復します",
-            SuccessThreshold, prevDegree, newDegree, _max);
+            "並列度を {Prev} → {Current}/{Max} に回復します (増速インターバル: {IntervalSec} 秒)",
+            prevDegree, newDegree, _max, IncreaseIntervalSec);
     }
 
     // ─────────────────────────────────────────────────────────────
@@ -241,6 +254,13 @@ public sealed class AdaptiveConcurrencyController : IDisposable
 
     /// <summary>実際に吸収済みのスロット数（テスト用）。</summary>
     internal int AbsorbedSlotCount { get { lock (_syncRoot) return _absorbedActual; } }
+
+    /// <summary>増速可能タイムスタンプを即時（過去）に設定する（テスト用）。</summary>
+    internal void SetIncreaseAvailableNow()
+    {
+        lock (_syncRoot)
+            _increaseAvailableAfterTicks = long.MinValue;
+    }
 
     // ─────────────────────────────────────────────────────────────
     // Dispose

--- a/src/CloudMigrator.Core/Transfer/AdaptiveConcurrencyController.cs
+++ b/src/CloudMigrator.Core/Transfer/AdaptiveConcurrencyController.cs
@@ -144,7 +144,18 @@ public sealed class AdaptiveConcurrencyController : IDisposable
         {
             // MinDegree 到達時はカウンターを増やさない（回復後の最初の通知で即減速しないようにする）
             if (_current > _min)
+            {
                 _pendingDecreases++;
+
+                // 429/503 を受けた時点で増速可能タイムスタンプを更新する。
+                // DecreaseTriggerCount > 1 の場合、減速発火前でも NotifySuccess による即時増速を防ぐ。
+                var retryAfterTicks = retryAfter.HasValue
+                    ? (long)(retryAfter.Value.TotalSeconds * Stopwatch.Frequency) : 0L;
+                var intervalTicks = (long)(IncreaseIntervalSec * Stopwatch.Frequency);
+                var available = Stopwatch.GetTimestamp() + retryAfterTicks + intervalTicks;
+                if (available > _increaseAvailableAfterTicks)
+                    _increaseAvailableAfterTicks = available;
+            }
 
             if (_pendingDecreases >= _decreaseTriggerCount && _current > _min)
             {
@@ -155,14 +166,6 @@ public sealed class AdaptiveConcurrencyController : IDisposable
                     : _current - Math.Min(_decreaseStep, _current - _min);
                 step = prevDegree - _current;
                 newDegree = _current;
-
-                // 減速発火時に次の増速可能タイムスタンプを更新（Retry-After + IncreaseIntervalSec）
-                var retryAfterTicks = retryAfter.HasValue
-                    ? (long)(retryAfter.Value.TotalSeconds * Stopwatch.Frequency) : 0L;
-                var intervalTicks = (long)(IncreaseIntervalSec * Stopwatch.Frequency);
-                var available = Stopwatch.GetTimestamp() + retryAfterTicks + intervalTicks;
-                if (available > _increaseAvailableAfterTicks)
-                    _increaseAvailableAfterTicks = available;
             }
         }
 
@@ -180,7 +183,7 @@ public sealed class AdaptiveConcurrencyController : IDisposable
 
     /// <summary>
     /// 転送成功を通知する。
-    /// 連続成功数が <see cref="SuccessThreshold"/> に達した場合、
+    /// 最後の増減速から <see cref="IncreaseIntervalSec"/> 秒が経過している場合、
     /// ソフトスタート時の未使用ヘッドルームまたは吸収済みスロットを使って
     /// 並列度を <see cref="IncreaseStep"/> 回復する。
     /// </summary>

--- a/src/CloudMigrator.Core/Transfer/AdaptiveConcurrencyController.cs
+++ b/src/CloudMigrator.Core/Transfer/AdaptiveConcurrencyController.cs
@@ -142,19 +142,20 @@ public sealed class AdaptiveConcurrencyController : IDisposable
         int prevDegree = -1, newDegree = -1, step = 0;
         lock (_syncRoot)
         {
+            // 429/503 を受けた時点で増速可能タイムスタンプを更新する。
+            // MinDegree 到達中でも NotifySuccess による即時増速を防ぐため、
+            // 減速可否に関係なく毎回更新する。
+            var retryAfterTicks = retryAfter.HasValue
+                ? (long)(retryAfter.Value.TotalSeconds * Stopwatch.Frequency) : 0L;
+            var intervalTicks = (long)(IncreaseIntervalSec * Stopwatch.Frequency);
+            var available = Stopwatch.GetTimestamp() + retryAfterTicks + intervalTicks;
+            if (available > _increaseAvailableAfterTicks)
+                _increaseAvailableAfterTicks = available;
+
             // MinDegree 到達時はカウンターを増やさない（回復後の最初の通知で即減速しないようにする）
             if (_current > _min)
             {
                 _pendingDecreases++;
-
-                // 429/503 を受けた時点で増速可能タイムスタンプを更新する。
-                // DecreaseTriggerCount > 1 の場合、減速発火前でも NotifySuccess による即時増速を防ぐ。
-                var retryAfterTicks = retryAfter.HasValue
-                    ? (long)(retryAfter.Value.TotalSeconds * Stopwatch.Frequency) : 0L;
-                var intervalTicks = (long)(IncreaseIntervalSec * Stopwatch.Frequency);
-                var available = Stopwatch.GetTimestamp() + retryAfterTicks + intervalTicks;
-                if (available > _increaseAvailableAfterTicks)
-                    _increaseAvailableAfterTicks = available;
             }
 
             if (_pendingDecreases >= _decreaseTriggerCount && _current > _min)

--- a/src/CloudMigrator.Dashboard/App.xaml.cs
+++ b/src/CloudMigrator.Dashboard/App.xaml.cs
@@ -90,38 +90,68 @@ public partial class App : Application
                     ?? AppConfiguration.GetGraphClientSecret();
 
                 var auth = new GraphAuthenticator(opts.Graph.ClientId, opts.Graph.TenantId, clientSecret);
-                var graphClient = GraphClientFactory.Create(
-                    auth,
-                    timeoutSec: opts.TimeoutSec,
-                    maxRetry: opts.RetryCount,
-                    onRateLimit: _ => { },  // ダッシュボードでは並列度制御なし。ロガー経由でログのみ記録
-                    rateLimitLogger: loggerFactory2.CreateLogger<GraphStorageProvider>());
 
-                var storageOptions = new GraphStorageOptions
+                // AdaptiveConcurrencyController の初期化（config.json の AdaptiveConcurrency.sharepoint.Enabled = true で有効）
+                var adaptiveOpts = opts.GetAdaptiveConcurrency("sharepoint");
+                AdaptiveConcurrencyController? concurrencyController = null;
+                Action<TimeSpan?>? onRateLimit = null;
+                if (adaptiveOpts.Enabled)
                 {
-                    OneDriveUserId = opts.Graph.OneDriveUserId,
-                    SharePointDriveId = opts.Graph.SharePointDriveId,
-                    OneDriveSourceFolder = opts.Graph.OneDriveSourceFolder,
-                };
+                    var initialDegree = adaptiveOpts.InitialDegree > 0
+                        ? Math.Min(adaptiveOpts.InitialDegree, opts.MaxParallelTransfers)
+                        : opts.MaxParallelTransfers;
+                    concurrencyController = new AdaptiveConcurrencyController(
+                        initialDegree: initialDegree,
+                        minDegree: adaptiveOpts.MinDegree,
+                        maxDegree: opts.MaxParallelTransfers,
+                        increaseIntervalSec: adaptiveOpts.IncreaseIntervalSec,
+                        logger: loggerFactory2.CreateLogger<AdaptiveConcurrencyController>(),
+                        increaseStep: adaptiveOpts.IncreaseStep,
+                        decreaseStep: adaptiveOpts.DecreaseStep,
+                        decreaseTriggerCount: adaptiveOpts.DecreaseTriggerCount);
+                    onRateLimit = retryAfter => concurrencyController.NotifyRateLimit(retryAfter);
+                }
 
-                var sessionStore = new UploadSessionStore(Path.Combine(AppDataPaths.LogsDirectory, "upload_sessions.json"));
+                try
+                {
+                    var graphClient = GraphClientFactory.Create(
+                        auth,
+                        timeoutSec: opts.TimeoutSec,
+                        maxRetry: opts.RetryCount,
+                        onRateLimit: onRateLimit ?? (_ => { }),
+                        rateLimitLogger: loggerFactory2.CreateLogger<GraphStorageProvider>());
 
-                var storageProvider = new GraphStorageProvider(
-                    graphClient,
-                    loggerFactory2.CreateLogger<GraphStorageProvider>(),
-                    storageOptions,
-                    largeFileThresholdMb: opts.LargeFileThresholdMb,
-                    chunkSizeMb: opts.ChunkSizeMb,
-                    sessionStore: sessionStore);
+                    var storageOptions = new GraphStorageOptions
+                    {
+                        OneDriveUserId = opts.Graph.OneDriveUserId,
+                        SharePointDriveId = opts.Graph.SharePointDriveId,
+                        OneDriveSourceFolder = opts.Graph.OneDriveSourceFolder,
+                    };
 
-                var pipeline = new SharePointMigrationPipeline(
-                    storageProvider,
-                    storageProvider,
-                    stateDb,
-                    opts,
-                    loggerFactory2.CreateLogger<SharePointMigrationPipeline>());
+                    var sessionStore = new UploadSessionStore(Path.Combine(AppDataPaths.LogsDirectory, "upload_sessions.json"));
 
-                await pipeline.RunAsync(ct).ConfigureAwait(false);
+                    var storageProvider = new GraphStorageProvider(
+                        graphClient,
+                        loggerFactory2.CreateLogger<GraphStorageProvider>(),
+                        storageOptions,
+                        largeFileThresholdMb: opts.LargeFileThresholdMb,
+                        chunkSizeMb: opts.ChunkSizeMb,
+                        sessionStore: sessionStore);
+
+                    var pipeline = new SharePointMigrationPipeline(
+                        storageProvider,
+                        storageProvider,
+                        stateDb,
+                        opts,
+                        loggerFactory2.CreateLogger<SharePointMigrationPipeline>(),
+                        concurrencyController);
+
+                    await pipeline.RunAsync(ct).ConfigureAwait(false);
+                }
+                finally
+                {
+                    concurrencyController?.Dispose();
+                }
             }
 
             return new TransferJobService(

--- a/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
@@ -67,6 +67,31 @@ else
                         <MudSelectItem Value="@("dropbox")">dropbox</MudSelectItem>
                     </MudSelect>
                 </MudItem>
+
+                @* ── 動的並列制御 ──────────────────────────────────────── *@
+                <MudItem xs="12">
+                    <MudDivider Class="my-2" />
+                    <MudText Typo="Typo.subtitle2" Class="mb-2">動的並列制御（レート制限対応）</MudText>
+                </MudItem>
+                <MudItem xs="12">
+                    <MudSwitch @bind-Value="_editAdaptiveConcurrencyEnabled"
+                               Label="動的並列制御を有効にする"
+                               Color="Color.Primary" />
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">
+                        Graph API から 429 を受信したとき、自動的に並列数を減らして再加速します。
+                        無効時は「最大並行転送数」の固定値で動作します。
+                    </MudText>
+                </MudItem>
+                @if (_editAdaptiveConcurrencyEnabled)
+                {
+                    <MudItem xs="12" sm="6">
+                        <MudNumericField @bind-Value="_editAdaptiveConcurrencyInitialDegree"
+                                         Label="初期並列数（0 = 最大と同じ）"
+                                         Min="0" Max="256"
+                                         Variant="Variant.Outlined"
+                                         HelperText="0: 最大並行転送数から開始（スロースタートなし）。1〜n: その数から徐々に増加（スロースタート）。" />
+                    </MudItem>
+                }
             </MudGrid>
         </MudCardContent>
         <MudCardActions>
@@ -139,6 +164,8 @@ else
     private int _editTimeoutSec;
     private string _editDestinationRoot = string.Empty;
     private string _editDestinationProvider = string.Empty;
+    private bool _editAdaptiveConcurrencyEnabled;
+    private int _editAdaptiveConcurrencyInitialDegree;
 
     protected override async Task OnInitializedAsync()
     {
@@ -168,6 +195,8 @@ else
         _editTimeoutSec = cfg.TimeoutSec;
         _editDestinationRoot = cfg.DestinationRoot;
         _editDestinationProvider = cfg.DestinationProvider;
+        _editAdaptiveConcurrencyEnabled = cfg.AdaptiveConcurrencyEnabled;
+        _editAdaptiveConcurrencyInitialDegree = cfg.AdaptiveConcurrencyInitialDegree;
     }
 
     private async Task SaveAsync()
@@ -219,7 +248,9 @@ else
                 RetryCount: _editRetryCount,
                 TimeoutSec: _editTimeoutSec,
                 DestinationRoot: _editDestinationRoot,
-                DestinationProvider: _editDestinationProvider);
+                DestinationProvider: _editDestinationProvider,
+                AdaptiveConcurrencyEnabled: _editAdaptiveConcurrencyEnabled,
+                AdaptiveConcurrencyInitialDegree: _editAdaptiveConcurrencyInitialDegree);
             await ConfigService.UpdateConfigAsync(update);
             _config = await ConfigService.GetConfigAsync();
             Snackbar.Add("設定を保存しました。", Severity.Success);

--- a/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
@@ -237,6 +237,11 @@ else
             Snackbar.Add("転送先プロバイダーは sharepoint または dropbox を選択してください。", Severity.Warning);
             return;
         }
+        if (_editAdaptiveConcurrencyInitialDegree is < 0 or > 256)
+        {
+            Snackbar.Add("初期並列数は 0〜256 の範囲で入力してください。", Severity.Warning);
+            return;
+        }
 
         try
         {

--- a/tests/unit/AdaptiveConcurrencyControllerTests.cs
+++ b/tests/unit/AdaptiveConcurrencyControllerTests.cs
@@ -413,7 +413,7 @@ public sealed class AdaptiveConcurrencyControllerTests
     [Fact]
     public void NotifySuccess_SoftStart_IncreasesFromInitialDegreeToMax()
     {
-        // 検証対象: InitialDegree (ソフトスタート)  目的: initialDegree < maxDegree の場合、SetIncreaseAvailableNow 後に 1 回ずつ増加できること
+        // 検証対象: InitialDegree (ソフトスタート)  目的: initialDegree < maxDegree の場合、NotifySuccess ごとに 1 回ずつ増加できること
         var controller = CreateController(initial: 1, min: 1, max: 4, increaseIntervalSec: 0);
         controller.CurrentDegree.Should().Be(1);
 

--- a/tests/unit/AdaptiveConcurrencyControllerTests.cs
+++ b/tests/unit/AdaptiveConcurrencyControllerTests.cs
@@ -458,7 +458,7 @@ public sealed class AdaptiveConcurrencyControllerTests
         // 検証対象: Retry-After 加算  目的: Retry-After 付きのレート制限後、即座に NotifySuccess しても増速しないこと
         var controller = CreateController(initial: 4, min: 1, max: 4, increaseIntervalSec: 30);
 
-        // Retry-After = 60秒 + IncreaseIntervalSec 30秒 = 合記90秒待機
+        // Retry-After = 60秒 + IncreaseIntervalSec 30秒 = 合計90秒待機
         controller.NotifyRateLimit(retryAfter: TimeSpan.FromSeconds(60));
 
         // SetIncreaseAvailableNow なしでは増速しない

--- a/tests/unit/AdaptiveConcurrencyControllerTests.cs
+++ b/tests/unit/AdaptiveConcurrencyControllerTests.cs
@@ -14,8 +14,8 @@ public sealed class AdaptiveConcurrencyControllerTests
         int initial = 4,
         int min = 1,
         int max = 4,
-        int threshold = 10) =>
-        new(initial, min, max, threshold,
+        int increaseIntervalSec = 0) =>
+        new(initial, min, max, increaseIntervalSec,
             Mock.Of<ILogger<AdaptiveConcurrencyController>>());
 
     // ─── 初期状態 ────────────────────────────────────────────────────────────
@@ -56,13 +56,21 @@ public sealed class AdaptiveConcurrencyControllerTests
     }
 
     [Fact]
-    public void Constructor_Throws_WhenSuccessThresholdIsZero()
+    public void Constructor_Throws_WhenIncreaseIntervalSecIsNegative()
     {
-        // 検証対象: コンストラクタバリデーション  目的: successThreshold < 1 は ArgumentOutOfRangeException になること
+        // 検証対象: コンストラクタバリデーション  目的: increaseIntervalSec < 0 は ArgumentOutOfRangeException になること
         Action act = () => new AdaptiveConcurrencyController(
-            4, 1, 4, 0,
+            4, 1, 4, -1,
             Mock.Of<ILogger<AdaptiveConcurrencyController>>());
         act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Constructor_ExposesIncreaseIntervalSec()
+    {
+        // 検証対象: IncreaseIntervalSec  目的: コンストラクタで設定した値が参照できること
+        var controller = CreateController(increaseIntervalSec: 30);
+        controller.IncreaseIntervalSec.Should().Be(30);
     }
 
     // ─── NotifyRateLimit ──────────────────────────────────────────────────────
@@ -79,23 +87,16 @@ public sealed class AdaptiveConcurrencyControllerTests
     }
 
     [Fact]
-    public void NotifyRateLimit_ResetsConsecutiveSuccessCounter()
+    public void NotifyRateLimit_PreventsIncreaseBeforeIntervalElapsed()
     {
-        // 検証対象: NotifyRateLimit  目的: 連続成功カウンターがリセットされること（threshold-1 まで積み上げた後でリセット）
-        var controller = CreateController(initial: 4, min: 1, max: 4, threshold: 5);
+        // 検証対象: NotifyRateLimit  目的: 減速後はインターバル時間経過前に NotifySuccess を呼んでも増速しないこと
+        var controller = CreateController(initial: 4, min: 1, max: 4, increaseIntervalSec: 30);
 
-        // 4回成功（閾値未達）
-        for (int i = 0; i < 4; i++)
-            controller.NotifySuccess();
+        controller.NotifyRateLimit(null); // 減速により _increaseAvailableAfterTicks = now + 30s
 
-        // レート制限 → カウンターリセット
-        controller.NotifyRateLimit(null);
-
-        // 再度 5 回未満成功しても増加しないこと
-        for (int i = 0; i < 4; i++)
-            controller.NotifySuccess();
-
-        controller.CurrentDegree.Should().Be(3); // 3 のまま（吸収なしなので回復しない）
+        // 時間が経過していないので増速しない
+        controller.NotifySuccess();
+        controller.CurrentDegree.Should().Be(3); // 3 のまま
     }
 
     [Fact]
@@ -114,7 +115,7 @@ public sealed class AdaptiveConcurrencyControllerTests
     public async Task NotifyRateLimit_AbsorbsSlot_WhenSemaphoreHasFreeSlots()
     {
         // 検証対象: NotifyRateLimit → AbsorbSlotAsync  目的: セマフォに空きがある状態では吸収が完了すること
-        var controller = CreateController(initial: 2, min: 1, max: 2, threshold: 5);
+        var controller = CreateController(initial: 2, min: 1, max: 2, increaseIntervalSec: 0);
 
         // Rate limit: degree 2 → 1, AbsorbSlotAsync がバックグラウンドで起動
         controller.NotifyRateLimit(null);
@@ -131,7 +132,7 @@ public sealed class AdaptiveConcurrencyControllerTests
     public void NotifySuccess_DoesNotIncreaseAboveMaxDegree_WhenNothingAbsorbed()
     {
         // 検証対象: NotifySuccess  目的: 吸収済みスロットがない場合は MaxDegree を超えないこと
-        var controller = CreateController(initial: 4, min: 1, max: 4, threshold: 2);
+        var controller = CreateController(initial: 4, min: 1, max: 4, increaseIntervalSec: 0);
 
         controller.NotifySuccess();
         controller.NotifySuccess();
@@ -142,48 +143,49 @@ public sealed class AdaptiveConcurrencyControllerTests
     [Fact]
     public void NotifySuccess_IncreasesCurrentDegree_FromInitialHeadroomWithoutAbsorption()
     {
-        // 検証対象: NotifySuccess  目的: initialDegree < maxDegree のソフトスタート時も成功で増加できること
-        var controller = CreateController(initial: 2, min: 1, max: 4, threshold: 2);
+        // 検証対象: NotifySuccess  目的: initialDegree < maxDegree のソフトスタート時も NotifySuccess 1 回で増加できること
+        // increaseIntervalSec: 0 なので即時増速可能
+        var controller = CreateController(initial: 2, min: 1, max: 4, increaseIntervalSec: 0);
 
         controller.NotifySuccess();
-        controller.CurrentDegree.Should().Be(2); // 閾値未達
-
-        controller.NotifySuccess();
-        controller.CurrentDegree.Should().Be(3); // 未吸収ヘッドルームを使って増加
+        controller.CurrentDegree.Should().Be(3); // 即時増加
     }
 
     [Fact]
-    public async Task NotifySuccess_IncreasesCurrentDegree_AfterAbsorptionAndThreshold()
+    public async Task NotifySuccess_IncreasesCurrentDegree_AfterAbsorptionAndIntervalElapsed()
     {
-        // 検証対象: NotifySuccess  目的: 吸収済みスロットがある状態で閾値回数成功すると並列度が回復すること
-        var controller = CreateController(initial: 2, min: 1, max: 2, threshold: 3);
+        // 検証対象: NotifySuccess  目的: 吸収済みスロットがある状態でインターバル経過後に並列度が回復すること
+        var controller = CreateController(initial: 2, min: 1, max: 2, increaseIntervalSec: 30);
 
-        // rate limit → degree 2→1、吸収を待機
+        // rate limit: degree 2→1、吸収を待機
         controller.NotifyRateLimit(null);
         await WaitUntilAsync(() => controller.AbsorbedSlotCount > 0, timeoutMs: 1000);
 
-        // 閾値未満の成功（2 回）
+        // インターバル経過前は増速しない
         controller.NotifySuccess();
-        controller.NotifySuccess();
-        controller.CurrentDegree.Should().Be(1); // まだ回復しない
+        controller.CurrentDegree.Should().Be(1);
 
-        // 閾値達成（3 回目）
+        // SetIncreaseAvailableNow で待機解除→増速
+        controller.SetIncreaseAvailableNow();
         controller.NotifySuccess();
-        controller.CurrentDegree.Should().Be(2); // 回復
+        controller.CurrentDegree.Should().Be(2);
     }
 
     [Fact]
     public async Task NotifySuccess_DoesNotThrowOrIncrease_WhenDecreaseAbsorptionIsStillPending()
     {
         // 検証対象: NotifySuccess  目的: 減速直後で吸収未完了の間は回復せず、SemaphoreFullException も起こさないこと
-        var controller = CreateController(initial: 4, min: 1, max: 4, threshold: 1);
+        var controller = CreateController(initial: 4, min: 1, max: 4, increaseIntervalSec: 0);
 
         await controller.AcquireAsync(CancellationToken.None);
         await controller.AcquireAsync(CancellationToken.None);
         await controller.AcquireAsync(CancellationToken.None);
         await controller.AcquireAsync(CancellationToken.None);
 
-        controller.NotifyRateLimit(null); // 4 -> 3, ただし吸収は in-flight のため未完了
+        controller.NotifyRateLimit(null); // 4 -> 3、ただし吸収は in-flight のため未完了
+
+        // SetIncreaseAvailableNow で待機解除して増速を試みても、吸収未完なので増速しない
+        controller.SetIncreaseAvailableNow();
         controller.NotifySuccess();
 
         controller.CurrentDegree.Should().Be(3);
@@ -198,23 +200,27 @@ public sealed class AdaptiveConcurrencyControllerTests
     }
 
     [Fact]
-    public async Task NotifySuccess_ResetsConsecutiveCounter_AfterIncrease()
+    public async Task NotifySuccess_RespectsIntervalAfterIncrease()
     {
-        // 検証対象: NotifySuccess  目的: 回復後に連続成功カウンターがリセットされること
-        var controller = CreateController(initial: 4, min: 1, max: 4, threshold: 2);
+        // 検証対象: NotifySuccess  目的: 増速後に再度インターバル待機が起き、SetIncreaseAvailableNow 後に次の増速が可能なこと
+        var controller = CreateController(initial: 4, min: 1, max: 4, increaseIntervalSec: 30);
 
         // rate limit ×2 → degree 2、吸収を待機
         controller.NotifyRateLimit(null);
         controller.NotifyRateLimit(null);
         await WaitUntilAsync(() => controller.AbsorbedSlotCount >= 2, timeoutMs: 1000);
 
-        // 1回目の回復（2 回成功で +1）
-        controller.NotifySuccess();
+        // 1 回目の増速
+        controller.SetIncreaseAvailableNow();
         controller.NotifySuccess();
         controller.CurrentDegree.Should().Be(3);
 
-        // 2回目の回復（もう 2 回成功で +1）
+        // 増速後は即座に増速できない（インターバル待機）
         controller.NotifySuccess();
+        controller.CurrentDegree.Should().Be(3);
+
+        // SetIncreaseAvailableNow 後は再増速可能
+        controller.SetIncreaseAvailableNow();
         controller.NotifySuccess();
         controller.CurrentDegree.Should().Be(4);
     }
@@ -225,7 +231,7 @@ public sealed class AdaptiveConcurrencyControllerTests
     public async Task AcquireAsync_LimitsConcurrency_ToCurrentDegree()
     {
         // 検証対象: AcquireAsync  目的: CurrentDegree 個のスロットしか同時取得できないこと
-        var controller = CreateController(initial: 2, min: 1, max: 2, threshold: 5);
+        var controller = CreateController(initial: 2, min: 1, max: 2, increaseIntervalSec: 0);
 
         // 2 スロット取得（これが上限）
         await controller.AcquireAsync(CancellationToken.None);
@@ -244,7 +250,7 @@ public sealed class AdaptiveConcurrencyControllerTests
     public async Task Release_AllowsNextAcquire()
     {
         // 検証対象: Release  目的: Release 後に次の AcquireAsync が成功すること
-        var controller = CreateController(initial: 1, min: 1, max: 1, threshold: 5);
+        var controller = CreateController(initial: 1, min: 1, max: 1, increaseIntervalSec: 0);
 
         await controller.AcquireAsync(CancellationToken.None);
         controller.Release();
@@ -293,7 +299,7 @@ public sealed class AdaptiveConcurrencyControllerTests
     {
         // 検証対象: decreaseTriggerCount  目的: 2 回目の NotifyRateLimit で初めて並列度が下がること
         var controller = new AdaptiveConcurrencyController(
-            4, 1, 4, 10,
+            4, 1, 4, 30,
             Mock.Of<ILogger<AdaptiveConcurrencyController>>(),
             decreaseTriggerCount: 2);
 
@@ -309,7 +315,7 @@ public sealed class AdaptiveConcurrencyControllerTests
     {
         // 検証対象: decreaseTriggerCount  目的: 減速発火後にカウンターがリセットされ、さらに 2 回必要になること
         var controller = new AdaptiveConcurrencyController(
-            4, 1, 4, 10,
+            4, 1, 4, 30,
             Mock.Of<ILogger<AdaptiveConcurrencyController>>(),
             decreaseTriggerCount: 2);
 
@@ -331,7 +337,7 @@ public sealed class AdaptiveConcurrencyControllerTests
     {
         // 検証対象: decreaseStep  目的: 1 回のイベントで並列度が 2 下がること
         var controller = new AdaptiveConcurrencyController(
-            4, 1, 4, 10,
+            4, 1, 4, 30,
             Mock.Of<ILogger<AdaptiveConcurrencyController>>(),
             decreaseStep: 2);
 
@@ -344,7 +350,7 @@ public sealed class AdaptiveConcurrencyControllerTests
     {
         // 検証対象: decreaseStep  目的: step が大きくても MinDegree を下回らないこと
         var controller = new AdaptiveConcurrencyController(
-            2, 1, 4, 10,
+            2, 1, 4, 30,
             Mock.Of<ILogger<AdaptiveConcurrencyController>>(),
             decreaseStep: 5);
 
@@ -357,9 +363,9 @@ public sealed class AdaptiveConcurrencyControllerTests
     [Fact]
     public async Task NotifySuccess_WithIncreaseStep2_IncreasesByTwo()
     {
-        // 検証対象: increaseStep  目的: 閾値達成時に並列度が 2 上がること
+        // 検証対象: increaseStep  目的: SetIncreaseAvailableNow 後に並列度が 2 上がること
         var controller = new AdaptiveConcurrencyController(
-            4, 1, 4, 2,
+            4, 1, 4, 30,
             Mock.Of<ILogger<AdaptiveConcurrencyController>>(),
             increaseStep: 2);
 
@@ -368,8 +374,8 @@ public sealed class AdaptiveConcurrencyControllerTests
         controller.NotifyRateLimit(null);
         await WaitUntilAsync(() => controller.AbsorbedSlotCount >= 2, timeoutMs: 1000);
 
-        // 閾値 2 回成功で +2 回復
-        controller.NotifySuccess();
+        // SetIncreaseAvailableNow 後に 1 回成功で +2 回復
+        controller.SetIncreaseAvailableNow();
         controller.NotifySuccess();
         controller.CurrentDegree.Should().Be(4);
     }
@@ -379,14 +385,14 @@ public sealed class AdaptiveConcurrencyControllerTests
     {
         // 検証対象: increaseStep  目的: step が大きくても MaxDegree を超えないこと
         var controller = new AdaptiveConcurrencyController(
-            4, 1, 4, 2,
+            4, 1, 4, 30,
             Mock.Of<ILogger<AdaptiveConcurrencyController>>(),
             increaseStep: 5);
 
         controller.NotifyRateLimit(null); // degree 3
         await WaitUntilAsync(() => controller.AbsorbedSlotCount >= 1, timeoutMs: 1000);
 
-        controller.NotifySuccess();
+        controller.SetIncreaseAvailableNow();
         controller.NotifySuccess();
         controller.CurrentDegree.Should().Be(4); // 3+5 → clamp → 4
     }
@@ -400,6 +406,64 @@ public sealed class AdaptiveConcurrencyControllerTests
         var controller = CreateController();
         Action act = () => controller.Dispose();
         act.Should().NotThrow();
+    }
+
+    // ─── InitialDegree ソフトスタート ──────────────────────────────────────────────
+
+    [Fact]
+    public void NotifySuccess_SoftStart_IncreasesFromInitialDegreeToMax()
+    {
+        // 検証対象: InitialDegree (ソフトスタート)  目的: initialDegree < maxDegree の場合、SetIncreaseAvailableNow 後に 1 回ずつ増加できること
+        var controller = CreateController(initial: 1, min: 1, max: 4, increaseIntervalSec: 0);
+        controller.CurrentDegree.Should().Be(1);
+
+        controller.NotifySuccess();
+        controller.CurrentDegree.Should().Be(2);
+
+        controller.NotifySuccess();
+        controller.CurrentDegree.Should().Be(3);
+
+        controller.NotifySuccess();
+        controller.CurrentDegree.Should().Be(4); // max に到達
+
+        controller.NotifySuccess();
+        controller.CurrentDegree.Should().Be(4); // max を超えない
+    }
+
+    [Fact]
+    public void NotifySuccess_SoftStart_RespectsIntervalBetweenIncreases()
+    {
+        // 検証対象: InitialDegree のインターバル  目的: increaseIntervalSec > 0 の場合、ソフトスタート中もインターバル内の連続呼び出しでは増加しないこと
+        var controller = CreateController(initial: 1, min: 1, max: 4, increaseIntervalSec: 30);
+
+        // 最初は即時増速可能（long.MinValue）
+        controller.NotifySuccess(); // 1→2
+        controller.CurrentDegree.Should().Be(2);
+
+        // 増速後はインターバル待機中
+        controller.NotifySuccess(); // 増加しない
+        controller.CurrentDegree.Should().Be(2);
+
+        // SetIncreaseAvailableNow 後に増速再開
+        controller.SetIncreaseAvailableNow();
+        controller.NotifySuccess(); // 2→3
+        controller.CurrentDegree.Should().Be(3);
+    }
+
+    // ─── Retry-After 加算 ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void NotifyRateLimit_WithRetryAfter_PreventsIncreaseBeforeRetryAfterElapses()
+    {
+        // 検証対象: Retry-After 加算  目的: Retry-After 付きのレート制限後、即座に NotifySuccess しても増速しないこと
+        var controller = CreateController(initial: 4, min: 1, max: 4, increaseIntervalSec: 30);
+
+        // Retry-After = 60秒 + IncreaseIntervalSec 30秒 = 合記90秒待機
+        controller.NotifyRateLimit(retryAfter: TimeSpan.FromSeconds(60));
+
+        // SetIncreaseAvailableNow なしでは増速しない
+        controller.NotifySuccess();
+        controller.CurrentDegree.Should().Be(3);
     }
 
     // ─── ヘルパー ─────────────────────────────────────────────────────────────

--- a/tests/unit/DropboxMigrationPipelineTests.cs
+++ b/tests/unit/DropboxMigrationPipelineTests.cs
@@ -495,7 +495,7 @@ public class DropboxMigrationPipelineTests
             SetupDestBase();
 
             using var controller = new AdaptiveConcurrencyController(
-                initialDegree: 4, minDegree: 1, maxDegree: 4, successThreshold: 10,
+                initialDegree: 4, minDegree: 1, maxDegree: 4, increaseIntervalSec: 30,
                 Mock.Of<ILogger<AdaptiveConcurrencyController>>());
 
             var pipeline = new DropboxMigrationPipeline(

--- a/tests/unit/SharePointMigrationPipelineTests.cs
+++ b/tests/unit/SharePointMigrationPipelineTests.cs
@@ -360,7 +360,7 @@ public class SharePointMigrationPipelineTests
                 initialDegree: _options.MaxParallelTransfers,
                 minDegree: 1,
                 maxDegree: _options.MaxParallelTransfers,
-                successThreshold: 10,
+                increaseIntervalSec: 30,
                 NullLogger<AdaptiveConcurrencyController>.Instance);
 
             SetupDbWithBothPhasesComplete();


### PR DESCRIPTION
## 変更概要

`AdaptiveConcurrencyController` の増速トリガーを「連続成功カウント（`SuccessThreshold`）」から「経過秒数（`IncreaseIntervalSec`）」に変更します。

### 背景

小ファイルを大量移行する場合、成功カウントが素早く閾値を超えて増速が過敏になる問題がありました。時間ベースにすることで、ファイルサイズや処理速度に依存しない安定した増速制御が可能になります。

## 主な変更

| 変更前 | 変更後 |
|--------|--------|
| `SuccessThreshold`（成功カウント、デフォルト 10） | `IncreaseIntervalSec`（秒数、デフォルト 30） |
| `_consecutiveSuccesses` フィールド | `_increaseAvailableAfterTicks` フィールド（`Stopwatch` タイムスタンプ） |

### 設計詳細

- **デフォルト 30 秒**: 最後に増速（または減速）してから 30 秒経過後に次の増速が許可される
- **Retry-After 加算方式**: レート制限時は `now + retryAfter + increaseIntervalSec` でタイムスタンプを設定（減速→増速の間隔を確実に確保）
- **`increaseIntervalSec = 0`**: 即時増速可能（テスト・非アダプティブモード向け）
- **初期状態**: `_increaseAvailableAfterTicks = long.MinValue` → 初回 `NotifySuccess()` で即座に増速可能
- **`SetIncreaseAvailableNow()`**: `internal` テスト補助メソッド（タイムスタンプを `long.MinValue` にリセット）

### InitialDegree（ソフトスタート）

本 PR には以前実装した InitialDegree 機能も含みます：
- 移行開始時に低い並列度からスタートし、徐々に最大値へ増速
- `SettingsPage.razor` に有効/無効スイッチと初期並列度入力フィールド追加済み

## 変更ファイル

| ファイル | 変更内容 |
|----------|----------|
| `src/CloudMigrator.Core/Transfer/AdaptiveConcurrencyController.cs` | 時間ベース増速制御に全面変更 |
| `src/CloudMigrator.Core/Configuration/MigratorOptions.cs` | `SuccessThresholdToIncrease` → `IncreaseIntervalSec = 30` |
| `src/CloudMigrator.Cli/CliServices.cs` | 引数名変更 + InitialDegree 対応 |
| `src/CloudMigrator.Dashboard/App.xaml.cs` | 引数名変更 + コントローラー初期化改善 |
| `src/CloudMigrator.Core/Configuration/ConfigurationService.cs` | AdaptiveConcurrency 設定 I/O（InitialDegree 追加） |
| `src/CloudMigrator.Core/Migration/SharePointMigrationPipeline.cs` | Phase C でのコントローラー活用 |
| `src/CloudMigrator.Dashboard/Components/SettingsPage.razor` | 有効スイッチ + InitialDegree UI 追加 |
| `tests/unit/AdaptiveConcurrencyControllerTests.cs` | 時間ベーステストに全面更新 + 新規テスト追加 |
| `tests/unit/DropboxMigrationPipelineTests.cs` | 引数名修正 |
| `tests/unit/SharePointMigrationPipelineTests.cs` | 引数名修正 |

## テスト結果

```
テスト概要: 合計: 577, 失敗数: 0, 成功数: 577, スキップ済み数: 0
```