### PR TITLE
fix: WiX 4.0.5 → 5.0.2 アップグレード（MSI ビルド修正）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,8 +151,8 @@ jobs:
         with:
           dotnet-version: '10.0.201'
 
-      - name: WiX Toolset v4 インストール
-        run: dotnet tool install wix --version 4.0.5 --global
+      - name: WiX Toolset v5 インストール
+        run: dotnet tool install wix --version 5.0.2 --global
 
       - name: win-x64 バイナリをダウンロード
         uses: actions/download-artifact@v8
@@ -173,53 +173,10 @@ jobs:
           $version = $Matches['version']
           "version=$version" >> $env:GITHUB_OUTPUT
 
-      - name: Dashboard コンポーネントリストを生成
-        shell: pwsh
-        run: |
-          # WiX 4.0.5 は ComponentGroup 内の Files 要素を未サポートのため PowerShell で動的生成する
-          # ProductComponents で明示定義済みの exe と PDB は除外する
-          $binDir  = (Resolve-Path "published\win-x64").Path
-          $excluded = @('cloud-migrator.exe', 'CloudMigrator.Dashboard.exe')
-
-          $allFiles = Get-ChildItem -Path $binDir -Recurse -File |
-              Where-Object { $_.Name -notin $excluded -and $_.Name -notlike '*.pdb' } |
-              Sort-Object FullName
-
-          $sb = [System.Text.StringBuilder]::new()
-          [void]$sb.AppendLine('<?xml version="1.0" encoding="utf-8"?>')
-          [void]$sb.AppendLine('<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">')
-          [void]$sb.AppendLine('  <Fragment>')
-          [void]$sb.AppendLine('    <ComponentGroup Id="DashboardComponents" Directory="INSTALLFOLDER">')
-
-          foreach ($file in $allFiles) {
-              $relPath = $file.FullName.Substring($binDir.Length + 1)
-              $subDir  = [System.IO.Path]::GetDirectoryName($relPath)
-              # WiX ID: 先頭に固定プレフィックスを付け、使用不可文字をアンダースコアに置換
-              $safe = 'Dash_' + ($relPath -replace '[\\./\-\s\[\]@+]', '_')
-
-              if ([string]::IsNullOrEmpty($subDir)) {
-                  [void]$sb.AppendLine("      <Component Id=""Comp_$safe"" Guid=""*"">")
-              } else {
-                  [void]$sb.AppendLine("      <Component Id=""Comp_$safe"" Guid=""*"" Subdirectory=""$subDir"">")
-              }
-              # `$(var.BinDir) は WiX プリプロセッサ変数（PowerShell 展開させないようバッククォートでエスケープ）
-              [void]$sb.AppendLine("        <File Id=""File_$safe"" Source=""`$(var.BinDir)\$relPath"" KeyPath=""yes"" />")
-              [void]$sb.AppendLine("      </Component>")
-          }
-
-          [void]$sb.AppendLine('    </ComponentGroup>')
-          [void]$sb.AppendLine('  </Fragment>')
-          [void]$sb.AppendLine('</Wix>')
-
-          $outPath = Join-Path (Get-Location) 'installer' 'wix' 'DashboardComponents.wxs'
-          [System.IO.File]::WriteAllText($outPath, $sb.ToString(), [System.Text.UTF8Encoding]::new($false))
-          Write-Host "完了: $($allFiles.Count) ファイル → DashboardComponents.wxs"
-
       - name: MSI ビルド
         shell: pwsh
         run: |
           wix build installer/wix/Product.wxs `
-            installer/wix/DashboardComponents.wxs `
             -arch x64 `
             -d Version=${{ steps.version.outputs.version }} `
             -d "BinDir=${{ github.workspace }}/published/win-x64" `

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,10 +173,53 @@ jobs:
           $version = $Matches['version']
           "version=$version" >> $env:GITHUB_OUTPUT
 
+      - name: Dashboard コンポーネントリストを生成
+        shell: pwsh
+        run: |
+          # WiX 4.0.5 は ComponentGroup 内の Files 要素を未サポートのため PowerShell で動的生成する
+          # ProductComponents で明示定義済みの exe と PDB は除外する
+          $binDir  = (Resolve-Path "published\win-x64").Path
+          $excluded = @('cloud-migrator.exe', 'CloudMigrator.Dashboard.exe')
+
+          $allFiles = Get-ChildItem -Path $binDir -Recurse -File |
+              Where-Object { $_.Name -notin $excluded -and $_.Name -notlike '*.pdb' } |
+              Sort-Object FullName
+
+          $sb = [System.Text.StringBuilder]::new()
+          [void]$sb.AppendLine('<?xml version="1.0" encoding="utf-8"?>')
+          [void]$sb.AppendLine('<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">')
+          [void]$sb.AppendLine('  <Fragment>')
+          [void]$sb.AppendLine('    <ComponentGroup Id="DashboardComponents" Directory="INSTALLFOLDER">')
+
+          foreach ($file in $allFiles) {
+              $relPath = $file.FullName.Substring($binDir.Length + 1)
+              $subDir  = [System.IO.Path]::GetDirectoryName($relPath)
+              # WiX ID: 先頭に固定プレフィックスを付け、使用不可文字をアンダースコアに置換
+              $safe = 'Dash_' + ($relPath -replace '[\\./\-\s\[\]@+]', '_')
+
+              if ([string]::IsNullOrEmpty($subDir)) {
+                  [void]$sb.AppendLine("      <Component Id=""Comp_$safe"" Guid=""*"">")
+              } else {
+                  [void]$sb.AppendLine("      <Component Id=""Comp_$safe"" Guid=""*"" Subdirectory=""$subDir"">")
+              }
+              # `$(var.BinDir) は WiX プリプロセッサ変数（PowerShell 展開させないようバッククォートでエスケープ）
+              [void]$sb.AppendLine("        <File Id=""File_$safe"" Source=""`$(var.BinDir)\$relPath"" KeyPath=""yes"" />")
+              [void]$sb.AppendLine("      </Component>")
+          }
+
+          [void]$sb.AppendLine('    </ComponentGroup>')
+          [void]$sb.AppendLine('  </Fragment>')
+          [void]$sb.AppendLine('</Wix>')
+
+          $outPath = Join-Path (Get-Location) 'installer' 'wix' 'DashboardComponents.wxs'
+          [System.IO.File]::WriteAllText($outPath, $sb.ToString(), [System.Text.UTF8Encoding]::new($false))
+          Write-Host "完了: $($allFiles.Count) ファイル → DashboardComponents.wxs"
+
       - name: MSI ビルド
         shell: pwsh
         run: |
           wix build installer/wix/Product.wxs `
+            installer/wix/DashboardComponents.wxs `
             -arch x64 `
             -d Version=${{ steps.version.outputs.version }} `
             -d "BinDir=${{ github.workspace }}/published/win-x64" `

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,3 @@ configs/config.json
 *.trx
 TestResults/
 LocalQualityResults/
-
-# MSI ビルド時に動的生成されるファイル
-installer/wix/DashboardComponents.wxs

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ configs/config.json
 *.trx
 TestResults/
 LocalQualityResults/
+
+# MSI ビルド時に動的生成されるファイル
+installer/wix/DashboardComponents.wxs

--- a/installer/wix/Product.wxs
+++ b/installer/wix/Product.wxs
@@ -62,14 +62,11 @@
     </ComponentGroup>
 
     <!--
-      Dashboard 依存ファイル群（DLL / config / wwwroot / runtimes など）
-      BinDir 配下を再帰的に収集。主要 exe と PDB は除外済み。
-      サブディレクトリ（wwwroot/ / runtimes/ など）の構造はそのまま INSTALLFOLDER 下に展開される
+      DashboardComponents は CI（release.yml）の PowerShell ステップで
+      BinDir 配下から動的生成される DashboardComponents.wxs に定義される。
+      WiX 4.0.5 は ComponentGroup 内の Files 要素を未サポートのため動的生成方式を採用。
+      ローカルビルド時は事前に DashboardComponents.wxs を生成してから wix build を実行すること。
     -->
-    <ComponentGroup Id="DashboardComponents" Directory="INSTALLFOLDER">
-      <Files Include="$(var.BinDir)\**\*"
-             Exclude="$(var.BinDir)\cloud-migrator.exe;$(var.BinDir)\CloudMigrator.Dashboard.exe;$(var.BinDir)\**\*.pdb" />
-    </ComponentGroup>
 
     <!-- スタートメニューショートカット -->
     <ComponentGroup Id="ShortcutComponents" Directory="AppMenuFolder">

--- a/installer/wix/Product.wxs
+++ b/installer/wix/Product.wxs
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Product.wxs - Cloud Migrator MSI インストーラー定義 (WiX Toolset v4)
+  Product.wxs - Cloud Migrator MSI インストーラー定義 (WiX Toolset v5)
 
   インストール先 : %LOCALAPPDATA%\Programs\CloudMigrator\
   スコープ       : perUser（UAC 昇格不要）
@@ -13,7 +13,7 @@
       -d BinDir=path\to\publish\win-x64 \
       -o cloud-migrator-setup.msi
 -->
-<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v5/wxs">
 
   <Package Name="Cloud Migrator"
            Manufacturer="scottlz0310"
@@ -62,11 +62,14 @@
     </ComponentGroup>
 
     <!--
-      DashboardComponents は CI（release.yml）の PowerShell ステップで
-      BinDir 配下から動的生成される DashboardComponents.wxs に定義される。
-      WiX 4.0.5 は ComponentGroup 内の Files 要素を未サポートのため動的生成方式を採用。
-      ローカルビルド時は事前に DashboardComponents.wxs を生成してから wix build を実行すること。
+      Dashboard 依存ファイル群（DLL / config / wwwroot / runtimes など）
+      BinDir 配下を再帰的に収集。主要 exe と PDB は除外済み。
+      サブディレクトリ（wwwroot/ / runtimes/ など）の構造はそのまま INSTALLFOLDER 下に展開される
     -->
+    <ComponentGroup Id="DashboardComponents" Directory="INSTALLFOLDER">
+      <Files Include="$(var.BinDir)\**\*"
+             Exclude="$(var.BinDir)\cloud-migrator.exe;$(var.BinDir)\CloudMigrator.Dashboard.exe;$(var.BinDir)\**\*.pdb" />
+    </ComponentGroup>
 
     <!-- スタートメニューショートカット -->
     <ComponentGroup Id="ShortcutComponents" Directory="AppMenuFolder">


### PR DESCRIPTION
## 概要

`v0.4.0` タグの Release CI で MSI ビルドが失敗した問題を修正。

### 根本原因

WiX 4.0.5 は `<ComponentGroup>` 内の `<Files>` 要素を未サポート（WiX v5 以降の機能）。
ワークアラウンド（PowerShell 動的生成）ではなく WiX v5 へのアップグレードで対処。

### 変更内容

| ファイル | 変更 |
|---|---|
| `release.yml` | `wix --version 4.0.5` → `5.0.2`、不要な PowerShell 生成ステップを削除 |
| `installer/wix/Product.wxs` | `xmlns` を `v4` → `v5` に変更。`<Files>` ワイルドカードをそのまま利用 |
| `.gitignore` | 不要になった `DashboardComponents.wxs` エントリを削除 |

### マージ後

`v0.4.0` タグを削除・再発行して Release CI を再実行する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)