### PR TITLE
fix: WiX 名前空間を v5/wxs から v4/wxs に修正（WIX0199）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **MSI ビルド: WiX 名前空間を `v4/wxs` に修正** (PR #TBD)
+  - `installer/wix/Product.wxs` の `xmlns` が `http://wixtoolset.org/schemas/v5/wxs` となっており、WiX 5.0.2 ビルド時に `WIX0199` エラーが発生していた。
+  - WiX ツールセットはバージョン 4/5 ともに `http://wixtoolset.org/schemas/v4/wxs` 名前空間を使用するため、`v4/wxs` に修正。
+
 ---
 
 ## [0.4.0] - 2026-04-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- **MSI ビルド: WiX 名前空間を `v4/wxs` に修正** (PR #TBD)
+- **MSI ビルド: WiX 名前空間を `v4/wxs` に修正** (#139)
   - `installer/wix/Product.wxs` の `xmlns` が `http://wixtoolset.org/schemas/v5/wxs` となっており、WiX 5.0.2 ビルド時に `WIX0199` エラーが発生していた。
   - WiX ツールセットはバージョン 4/5 ともに `http://wixtoolset.org/schemas/v4/wxs` 名前空間を使用するため、`v4/wxs` に修正。
 

--- a/installer/wix/Product.wxs
+++ b/installer/wix/Product.wxs
@@ -12,8 +12,10 @@
       -d Version=1.2.3 \
       -d BinDir=path\to\publish\win-x64 \
       -o cloud-migrator-setup.msi
+
+  注意: WiX ツールセットはバージョン 4/5 ともに v4 名前空間を使用する。
 -->
-<Wix xmlns="http://wixtoolset.org/schemas/v5/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
 
   <Package Name="Cloud Migrator"
            Manufacturer="scottlz0310"


### PR DESCRIPTION
## 概要

`installer/wix/Product.wxs` の XML 名前空間が誤っており、MSI ビルドジョブが失敗していた。

## 原因

`Product.wxs` の `xmlns` が以下のように設定されていた。

```xml
<Wix xmlns="http://wixtoolset.org/schemas/v5/wxs">
```

WiX ツールセット（v4/v5 いずれも）は実際には `http://wixtoolset.org/schemas/v4/wxs` 名前空間を使用する。このため `wix build` 実行時に以下のエラーが発生していた。

```
error WIX0199: The Wix element has an incorrect namespace of 'http://wixtoolset.org/schemas/v5/wxs'.
Please make the Wix element look like the following: <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">.
```

## 修正内容

| ファイル | 変更 |
|---|---|
| `installer/wix/Product.wxs` | `xmlns` を `v5/wxs` → `v4/wxs` に修正 |
| `CHANGELOG.md` | Unreleased セクションに修正内容を追記 |

## 検証

リリースタグ `v0.4.0` の MSI ビルドジョブで 2 回連続発生していたエラー（run #24375107688, #24374078753）が対象。
