### PR TITLE
fix: WiX Files/Exclude を DepsDir アプローチに置換（WIX0004）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,10 +176,19 @@ jobs:
       - name: MSI ビルド
         shell: pwsh
         run: |
+          # WiX 5.0.2 は Files/Exclude 未サポートのため、BinDir から *.exe / *.pdb を
+          # 除いた DepsDir を作成して DashboardComponents に渡す
+          $binDir  = "${{ github.workspace }}/published/win-x64"
+          $depsDir = "${{ github.workspace }}/published/win-x64-deps"
+          Copy-Item -Path $binDir -Destination $depsDir -Recurse -Force
+          Get-ChildItem $depsDir -Filter "*.exe" | Remove-Item -Force
+          Get-ChildItem $depsDir -Recurse -Filter "*.pdb" | Remove-Item -Force
+
           wix build installer/wix/Product.wxs `
             -arch x64 `
             -d Version=${{ steps.version.outputs.version }} `
-            -d "BinDir=${{ github.workspace }}/published/win-x64" `
+            -d "BinDir=$binDir" `
+            -d "DepsDir=$depsDir" `
             -o cloud-migrator-setup.msi
 
       - name: MSI をリリースにアップロード

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,7 @@ jobs:
           $binDir  = "${{ github.workspace }}/published/win-x64"
           $depsDir = "${{ github.workspace }}/published/win-x64-deps"
           Copy-Item -Path $binDir -Destination $depsDir -Recurse -Force
-          Get-ChildItem $depsDir -Filter "*.exe" | Remove-Item -Force
+          Get-ChildItem $depsDir -Recurse -Filter "*.exe" | Remove-Item -Force
           Get-ChildItem $depsDir -Recurse -Filter "*.pdb" | Remove-Item -Force
 
           wix build installer/wix/Product.wxs `

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   - `installer/wix/Product.wxs` の `xmlns` が `http://wixtoolset.org/schemas/v5/wxs` となっており、WiX 5.0.2 ビルド時に `WIX0199` エラーが発生していた。
   - WiX ツールセットはバージョン 4/5 ともに `http://wixtoolset.org/schemas/v4/wxs` 名前空間を使用するため、`v4/wxs` に修正。
 
-- **MSI ビルド: `Files/Exclude` を DepsDir アプローチに置換** (#TBD)
+- **MSI ビルド: `Files/Exclude` を DepsDir アプローチに置換** (#140)
   - WiX 5.0.2 は `Files` 要素の `Exclude` 属性を未サポート（`WIX0004`）。
   - CI ステップで `BinDir` から `*.exe` / `*.pdb` を除いた `DepsDir` を作成し `DashboardComponents` に参照させる方式に変更。
   - ローカル検証スクリプト `tools/Test-WixBuild.ps1` を追加（CI を再現してタグプッシュ前に検証可能）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
   - `installer/wix/Product.wxs` の `xmlns` が `http://wixtoolset.org/schemas/v5/wxs` となっており、WiX 5.0.2 ビルド時に `WIX0199` エラーが発生していた。
   - WiX ツールセットはバージョン 4/5 ともに `http://wixtoolset.org/schemas/v4/wxs` 名前空間を使用するため、`v4/wxs` に修正。
 
+- **MSI ビルド: `Files/Exclude` を DepsDir アプローチに置換** (#TBD)
+  - WiX 5.0.2 は `Files` 要素の `Exclude` 属性を未サポート（`WIX0004`）。
+  - CI ステップで `BinDir` から `*.exe` / `*.pdb` を除いた `DepsDir` を作成し `DashboardComponents` に参照させる方式に変更。
+  - ローカル検証スクリプト `tools/Test-WixBuild.ps1` を追加（CI を再現してタグプッシュ前に検証可能）。
+
 ---
 
 ## [0.4.0] - 2026-04-14

--- a/installer/wix/Product.wxs
+++ b/installer/wix/Product.wxs
@@ -65,12 +65,13 @@
 
     <!--
       Dashboard 依存ファイル群（DLL / config / wwwroot / runtimes など）
-      BinDir 配下を再帰的に収集。主要 exe と PDB は除外済み。
+      DepsDir は BinDir から *.exe / *.pdb を取り除いた専用ディレクトリ。
+      WiX 5.0.2 の Files 要素は Exclude 属性を未サポートのため、
+      CI / ローカル検証スクリプトで事前フィルタリングしたディレクトリを参照する。
       サブディレクトリ（wwwroot/ / runtimes/ など）の構造はそのまま INSTALLFOLDER 下に展開される
     -->
     <ComponentGroup Id="DashboardComponents" Directory="INSTALLFOLDER">
-      <Files Include="$(var.BinDir)\**\*"
-             Exclude="$(var.BinDir)\cloud-migrator.exe;$(var.BinDir)\CloudMigrator.Dashboard.exe;$(var.BinDir)\**\*.pdb" />
+      <Files Include="$(var.DepsDir)\**\*" />
     </ComponentGroup>
 
     <!-- スタートメニューショートカット -->

--- a/installer/wix/Product.wxs
+++ b/installer/wix/Product.wxs
@@ -11,7 +11,10 @@
     wix build Product.wxs -arch x64 \
       -d Version=1.2.3 \
       -d BinDir=path\to\publish\win-x64 \
+      -d DepsDir=path\to\publish\win-x64-deps \
       -o cloud-migrator-setup.msi
+
+  DepsDir は BinDir から *.exe / *.pdb を除いたディレクトリ（tools/Test-WixBuild.ps1 が自動生成）。
 
   注意: WiX ツールセットはバージョン 4/5 ともに v4 名前空間を使用する。
 -->

--- a/tools/Test-WixBuild.ps1
+++ b/tools/Test-WixBuild.ps1
@@ -1,0 +1,87 @@
+<#
+.SYNOPSIS
+    MSI インストーラービルドをローカルで検証するスクリプト。
+    CI の release.yml "msi" ジョブと同等の手順を実行する。
+
+.DESCRIPTION
+    1. CLI / Dashboard を win-x64 向けにパブリッシュ
+    2. DepsDir（*.exe / *.pdb を除いた依存ファイル専用ディレクトリ）を作成
+    3. wix build で MSI を生成
+
+    事前条件:
+      - dotnet tool install wix --version 5.0.2 --global
+      - .NET 10 SDK インストール済み
+
+.PARAMETER Version
+    MSI に埋め込むバージョン文字列（既定: 0.0.1-test）
+
+.PARAMETER SkipPublish
+    publish 済みバイナリが publish/win-x64 に存在する場合、パブリッシュをスキップする
+
+.EXAMPLE
+    # 初回検証
+    .\tools\Test-WixBuild.ps1
+
+    # バイナリ再利用（2 回目以降）
+    .\tools\Test-WixBuild.ps1 -SkipPublish
+#>
+[CmdletBinding()]
+param(
+    [string]$Version     = "0.0.1-test",
+    [switch]$SkipPublish
+)
+
+$ErrorActionPreference = "Stop"
+$root    = (Split-Path $PSScriptRoot)
+$binDir  = "$root\publish\win-x64"
+$depsDir = "$root\publish\win-x64-deps"
+$outMsi  = "$root\publish\cloud-migrator-test.msi"
+
+# ─── 前提チェック ────────────────────────────────────────────────────────────
+if (-not (Get-Command wix -ErrorAction SilentlyContinue)) {
+    Write-Error "wix コマンドが見つかりません。以下でインストールしてください:`n  dotnet tool install wix --version 5.0.2 --global"
+}
+
+# ─── 1. パブリッシュ ─────────────────────────────────────────────────────────
+if (-not $SkipPublish) {
+    Write-Host "▶ CLI をパブリッシュ中..." -ForegroundColor Cyan
+    dotnet publish "$root\src\CloudMigrator.Cli\CloudMigrator.Cli.csproj" `
+        --configuration Release `
+        --runtime win-x64 `
+        --self-contained true `
+        -p:PublishSingleFile=true `
+        -p:Version=$Version `
+        --output $binDir
+
+    Write-Host "▶ Dashboard をパブリッシュ中..." -ForegroundColor Cyan
+    dotnet publish "$root\src\CloudMigrator.Dashboard\CloudMigrator.Dashboard.csproj" `
+        --configuration Release `
+        --runtime win-x64 `
+        --self-contained false `
+        -p:Version=$Version `
+        --output $binDir
+} else {
+    Write-Host "▶ パブリッシュをスキップ（SkipPublish 指定）" -ForegroundColor Yellow
+    if (-not (Test-Path $binDir)) {
+        Write-Error "publish\win-x64 が存在しません。-SkipPublish なしで実行してください。"
+    }
+}
+
+# ─── 2. DepsDir 作成（*.exe / *.pdb を除外）────────────────────────────────
+Write-Host "▶ DepsDir を作成中..." -ForegroundColor Cyan
+if (Test-Path $depsDir) { Remove-Item $depsDir -Recurse -Force }
+Copy-Item -Path $binDir -Destination $depsDir -Recurse -Force
+Get-ChildItem $depsDir -Filter "*.exe"            | Remove-Item -Force
+Get-ChildItem $depsDir -Recurse -Filter "*.pdb"   | Remove-Item -Force
+
+# ─── 3. wix build ────────────────────────────────────────────────────────────
+Write-Host "▶ MSI をビルド中..." -ForegroundColor Cyan
+wix build "$root\installer\wix\Product.wxs" `
+    -arch x64 `
+    -d Version=$Version `
+    -d "BinDir=$binDir" `
+    -d "DepsDir=$depsDir" `
+    -o $outMsi
+
+Write-Host ""
+Write-Host "✓ 完了: $outMsi" -ForegroundColor Green

--- a/tools/Test-WixBuild.ps1
+++ b/tools/Test-WixBuild.ps1
@@ -51,7 +51,7 @@ if (-not $SkipPublish) {
         --self-contained true `
         -p:PublishSingleFile=true `
         -p:Version=$Version `
-        --output $binDir
+        --output "$binDir"
 
     Write-Host "▶ Dashboard をパブリッシュ中..." -ForegroundColor Cyan
     dotnet publish "$root\src\CloudMigrator.Dashboard\CloudMigrator.Dashboard.csproj" `
@@ -59,7 +59,7 @@ if (-not $SkipPublish) {
         --runtime win-x64 `
         --self-contained false `
         -p:Version=$Version `
-        --output $binDir
+        --output "$binDir"
 } else {
     Write-Host "▶ パブリッシュをスキップ（SkipPublish 指定）" -ForegroundColor Yellow
     if (-not (Test-Path $binDir)) {
@@ -71,7 +71,7 @@ if (-not $SkipPublish) {
 Write-Host "▶ DepsDir を作成中..." -ForegroundColor Cyan
 if (Test-Path $depsDir) { Remove-Item $depsDir -Recurse -Force }
 Copy-Item -Path $binDir -Destination $depsDir -Recurse -Force
-Get-ChildItem $depsDir -Filter "*.exe"            | Remove-Item -Force
+Get-ChildItem $depsDir -Recurse -Filter "*.exe"   | Remove-Item -Force
 Get-ChildItem $depsDir -Recurse -Filter "*.pdb"   | Remove-Item -Force
 
 # ─── 3. wix build ────────────────────────────────────────────────────────────
@@ -81,7 +81,7 @@ wix build "$root\installer\wix\Product.wxs" `
     -d Version=$Version `
     -d "BinDir=$binDir" `
     -d "DepsDir=$depsDir" `
-    -o $outMsi
+    -o "$outMsi"
 
 Write-Host ""
 Write-Host "✓ 完了: $outMsi" -ForegroundColor Green


### PR DESCRIPTION
WiX 5.0.2 は Files 要素の Exclude 属性を未サポート（WIX0004）。CI で BinDir から exe/pdb を除いた DepsDir を作成する方式に変更。ローカル検証スクリプト tools/Test-WixBuild.ps1 も追加。