### PR TITLE
ci: MSI ビルド検証ジョブ（msi-check）を CI に追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,26 +76,6 @@ jobs:
             "**/TestResults/**/*.trx"
             "**/TestResults/**/coverage.cobertura.xml"
 
-      - name: CLI / Dashboard を win-x64 向けにパブリッシュ（MSI ビルド検証用）
-        # windows-latest のみ実行（matrix.os が追加されても MSI は win-x64 専用）
-        if: matrix.os == 'windows-latest'
-        shell: pwsh
-        run: |
-          dotnet publish src/CloudMigrator.Cli/CloudMigrator.Cli.csproj `
-            --configuration Release --runtime win-x64 --self-contained true `
-            -p:PublishSingleFile=true -p:Version=0.0.0-ci --output publish/win-x64
-          dotnet publish src/CloudMigrator.Dashboard/CloudMigrator.Dashboard.csproj `
-            --configuration Release --runtime win-x64 --self-contained false `
-            -p:Version=0.0.0-ci --output "publish/win-x64"
-
-      - name: バイナリをアーティファクトに保存（MSI ビルド検証用）
-        if: matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v7
-        with:
-          name: ci-publish-win-x64
-          path: publish/win-x64/
-          retention-days: 1
-
   quality-gate:
     name: Quality Gate
     runs-on: windows-latest
@@ -139,8 +119,8 @@ jobs:
       - name: セキュリティスキャン
         run: dotnet run --project src/CloudMigrator.Cli/CloudMigrator.Cli.csproj --configuration Release -- security-scan
 
-  msi-check:
-    name: MSI ビルド検証（WiX 回帰防止）
+  publish-win:
+    name: win-x64 パブリッシュ（MSI ビルド用）
     runs-on: windows-latest
     needs: build-test
     env:
@@ -148,6 +128,43 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: .NET SDK セットアップ
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: CLI / Dashboard を win-x64 向けにパブリッシュ（MSI ビルド検証用）
+        shell: pwsh
+        run: |
+          dotnet publish src/CloudMigrator.Cli/CloudMigrator.Cli.csproj `
+            --configuration Release --runtime win-x64 --self-contained true `
+            -p:PublishSingleFile=true -p:Version=0.0.0-ci --output publish/win-x64
+          dotnet publish src/CloudMigrator.Dashboard/CloudMigrator.Dashboard.csproj `
+            --configuration Release --runtime win-x64 --self-contained false `
+            -p:Version=0.0.0-ci --output "publish/win-x64"
+
+      - name: バイナリをアーティファクトに保存（MSI ビルド検証用）
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-publish-win-x64
+          path: publish/win-x64/
+          retention-days: 1
+
+  msi-check:
+    name: MSI ビルド検証（WiX 回帰防止）
+    runs-on: windows-latest
+    needs: publish-win
+    env:
+      HUSKY: 0
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: .NET SDK セットアップ
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
 
       - name: WiX Toolset v5 インストール
         run: dotnet tool install wix --version 5.0.2 --global

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
     name: win-x64 パブリッシュ（MSI ビルド用）
     runs-on: windows-latest
     needs: build-test
+    if: github.event_name == 'pull_request'
     env:
       HUSKY: 0
 
@@ -132,7 +133,7 @@ jobs:
       - name: .NET SDK セットアップ
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: "10.0"
 
       - name: CLI / Dashboard を win-x64 向けにパブリッシュ（MSI ビルド検証用）
         shell: pwsh
@@ -164,7 +165,7 @@ jobs:
       - name: .NET SDK セットアップ
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: "10.0"
 
       - name: WiX Toolset v5 インストール
         run: dotnet tool install wix --version 5.0.2 --global

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
     name: MSI ビルド検証（WiX 回帰防止）
     runs-on: windows-latest
     needs: publish-win
+    if: github.event_name == 'pull_request'
     env:
       HUSKY: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,26 @@ jobs:
             "**/TestResults/**/*.trx"
             "**/TestResults/**/coverage.cobertura.xml"
 
+      - name: CLI / Dashboard を win-x64 向けにパブリッシュ（MSI ビルド検証用）
+        # windows-latest のみ実行（matrix.os が追加されても MSI は win-x64 専用）
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          dotnet publish src/CloudMigrator.Cli/CloudMigrator.Cli.csproj `
+            --configuration Release --runtime win-x64 --self-contained true `
+            -p:PublishSingleFile=true -p:Version=0.0.0-ci --output publish/win-x64
+          dotnet publish src/CloudMigrator.Dashboard/CloudMigrator.Dashboard.csproj `
+            --configuration Release --runtime win-x64 --self-contained false `
+            -p:Version=0.0.0-ci --output "publish/win-x64"
+
+      - name: バイナリをアーティファクトに保存（MSI ビルド検証用）
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-publish-win-x64
+          path: publish/win-x64/
+          retention-days: 1
+
   quality-gate:
     name: Quality Gate
     runs-on: windows-latest
@@ -119,3 +139,45 @@ jobs:
       - name: セキュリティスキャン
         run: dotnet run --project src/CloudMigrator.Cli/CloudMigrator.Cli.csproj --configuration Release -- security-scan
 
+  msi-check:
+    name: MSI ビルド検証（WiX 回帰防止）
+    runs-on: windows-latest
+    needs: build-test
+    env:
+      HUSKY: 0
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: WiX Toolset v5 インストール
+        run: dotnet tool install wix --version 5.0.2 --global
+
+      - name: バイナリをダウンロード
+        uses: actions/download-artifact@v8
+        with:
+          name: ci-publish-win-x64
+          path: published/win-x64
+
+      - name: MSI ビルド（WiX スキーマ・変数定義の検証）
+        shell: pwsh
+        run: |
+          # WiX 5.0.2 は Files/Exclude 未サポートのため DepsDir を使用
+          $binDir  = "${{ github.workspace }}/published/win-x64"
+          $depsDir = "${{ github.workspace }}/published/win-x64-deps"
+          Copy-Item -Path $binDir -Destination $depsDir -Recurse -Force
+          Get-ChildItem $depsDir -Recurse -Filter "*.exe" | Remove-Item -Force
+          Get-ChildItem $depsDir -Recurse -Filter "*.pdb" | Remove-Item -Force
+
+          wix build installer/wix/Product.wxs `
+            -arch x64 `
+            -d Version=0.0.0 `
+            -d "BinDir=$binDir" `
+            -d "DepsDir=$depsDir" `
+            -o cloud-migrator-ci.msi
+
+      - name: MSI をアーティファクトに保存
+        uses: actions/upload-artifact@v7
+        with:
+          name: msi-ci
+          path: cloud-migrator-ci.msi
+          retention-days: 7


### PR DESCRIPTION
## 概要

WiX の回帰（スキーマエラー・変数未定義等）をリリース前の PR 段階で検出できるよう、
`msi-check` ジョブを `ci.yml` に追加する。

## 変更内容

### `build-test` ジョブに追加
- win-x64 向け CLI / Dashboard をパブリッシュ
- バイナリを `ci-publish-win-x64` アーティファクトに保存（retention: 1 日）

### 新規 `msi-check` ジョブ
- `build-test` 完了後に起動（`needs: build-test`）
- WiX 5.0.2 をインストールし `wix build` を実行
- ビルド成功した MSI を `msi-ci` アーティファクトに保存（retention: 7 日）

## 効果

- PR 段階で WiX エラーを検出 → タグ削除・再発行の手戻りがなくなる
- アーティファクトからインストーラーをダウンロードして開発段階でも手動テスト可能