### PR TITLE
fix: Dashboard設定変更時のConfigHashChecker追加＋転送ルート情報表示

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@
 
 ### Added
 
+- **Dashboard: 設定ページに転送ルート情報カードを追加**
+  - `SettingsPage.razor` にウィザード設定済みの転送元フォルダ・転送先フォルダ・移行ルートを読み取り専用で表示。
+  - ウィザード未完了の場合は「ウィザードが未完了です」メッセージを表示。
+
+### Fixed
+
+- **Dashboard: 設定変更時にフルリビルドが発動しない問題を修正**
+  - `App.xaml.cs` の `MigrationWork` が `ConfigHashChecker` を呼ばずに直接パイプラインを起動しており、
+    Dashboard から設定を変更しても次回転送でフルリビルドにならない問題があった。
+  - CLI の `TransferCommand` と同等のハッシュ確認ロジック（`ComputeHash` → `HasChangedAsync` → `ClearAll` → `ResetAllAsync`）を追加。
+
 - **CI: MSI ビルド回帰防止ジョブを追加** (#141)
   - `publish-win` ジョブ（PR 時のみ）: win-x64 バイナリをパブリッシュしアーティファクト保存。
   - `msi-check` ジョブ（PR 時のみ）: WiX 5.0.2 で `Product.wxs` をビルド検証し `msi-ci` アーティファクトを保存（7 日保持）。

--- a/src/CloudMigrator.Dashboard/App.xaml.cs
+++ b/src/CloudMigrator.Dashboard/App.xaml.cs
@@ -144,6 +144,8 @@ public partial class App : Application
                     hashLogger.LogWarning("設定変更を検知しました。キャッシュと skip_list をクリアします。");
                     ConfigHashChecker.ClearAll(opts.Paths, hashLogger);
                     await ConfigHashChecker.SaveHashAsync(opts.Paths.ConfigHash, configHash, ct).ConfigureAwait(false);
+                    // stateDb は DI シングルトンであり、以下のパイプラインにも同一インスタンスを渡す。
+                    // つまり「パイプラインが使う DB と同じ DB をリセットする」ため、誤ったDBへの操作は発生しない。
                     await stateDb.ResetAllAsync(ct).ConfigureAwait(false);
                 }
 

--- a/src/CloudMigrator.Dashboard/App.xaml.cs
+++ b/src/CloudMigrator.Dashboard/App.xaml.cs
@@ -134,6 +134,19 @@ public partial class App : Application
                     activateController = ctrl => Volatile.Write(ref activeCtrl, ctrl ?? concurrencyController);
                 }
 
+                // 設定変更検知（FR-10）: CLI の TransferCommand と同等のハッシュ確認を行う
+                var configHash = ConfigHashChecker.ComputeHash(opts);
+                bool hashChanged = await ConfigHashChecker.HasChangedAsync(opts.Paths.ConfigHash, configHash, ct)
+                    .ConfigureAwait(false);
+                if (hashChanged)
+                {
+                    var hashLogger = loggerFactory2.CreateLogger("MigrationWork");
+                    hashLogger.LogWarning("設定変更を検知しました。キャッシュと skip_list をクリアします。");
+                    ConfigHashChecker.ClearAll(opts.Paths, hashLogger);
+                    await ConfigHashChecker.SaveHashAsync(opts.Paths.ConfigHash, configHash, ct).ConfigureAwait(false);
+                    await stateDb.ResetAllAsync(ct).ConfigureAwait(false);
+                }
+
                 try
                 {
                     var graphClient = GraphClientFactory.Create(

--- a/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
@@ -29,14 +29,19 @@ else
                 <MudGrid Spacing="1">
                     <MudItem xs="12" sm="4">
                         <MudText Typo="Typo.overline" Color="Color.Secondary">移行ルート</MudText>
-                        <MudText Typo="Typo.body2">@_discovery.MigrationRoute</MudText>
+                        <MudText Typo="Typo.body2">@(_discovery.MigrationRoute switch
+                        {
+                            "OneDriveToSharePoint" => "OneDrive → SharePoint",
+                            null or "" => "未設定",
+                            _ => "未設定"
+                        })</MudText>
                     </MudItem>
                     <MudItem xs="12" sm="4">
-                        <MudText Typo="Typo.overline" Color="Color.Secondary">転送元フォルダー</MudText>
+                        <MudText Typo="Typo.overline" Color="Color.Secondary">転送元フォルダ</MudText>
                         <MudText Typo="Typo.body2" Style="word-break: break-all;">@(_discovery.OneDriveSourceFolderPath is { Length: > 0 } p ? p : "未設定")</MudText>
                     </MudItem>
                     <MudItem xs="12" sm="4">
-                        <MudText Typo="Typo.overline" Color="Color.Secondary">転送先フォルダー</MudText>
+                        <MudText Typo="Typo.overline" Color="Color.Secondary">転送先フォルダ</MudText>
                         <MudText Typo="Typo.body2" Style="word-break: break-all;">@(_discovery.SharePointDestFolderPath is { Length: > 0 } q ? q : "未設定")</MudText>
                     </MudItem>
                 </MudGrid>
@@ -239,8 +244,13 @@ else
                 ? null
                 : d;
         }
-        catch
+        catch (OperationCanceledException)
         {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Discovery 設定の読み込みに失敗したため、未設定として扱います。");
             _discovery = null;
         }
     }

--- a/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
@@ -12,6 +12,38 @@
 }
 else
 {
+    @* ── 転送ルート情報（読み取り専用） *@
+    <MudCard Elevation="2" Style="max-width: 600px;" Class="mb-4">
+        <MudCardHeader>
+            <CardHeaderContent>
+                <MudText Typo="Typo.subtitle1">転送ルート情報</MudText>
+            </CardHeaderContent>
+        </MudCardHeader>
+        <MudCardContent>
+            @if (_discovery is null)
+            {
+                <MudText Typo="Typo.body2" Color="Color.Secondary">ウィザードが未完了です。セットアップウィザードで転送元・転送先を設定してください。</MudText>
+            }
+            else
+            {
+                <MudGrid Spacing="1">
+                    <MudItem xs="12" sm="4">
+                        <MudText Typo="Typo.overline" Color="Color.Secondary">移行ルート</MudText>
+                        <MudText Typo="Typo.body2">@_discovery.MigrationRoute</MudText>
+                    </MudItem>
+                    <MudItem xs="12" sm="4">
+                        <MudText Typo="Typo.overline" Color="Color.Secondary">転送元フォルダー</MudText>
+                        <MudText Typo="Typo.body2" Style="word-break: break-all;">@(_discovery.OneDriveSourceFolderPath is { Length: > 0 } p ? p : "未設定")</MudText>
+                    </MudItem>
+                    <MudItem xs="12" sm="4">
+                        <MudText Typo="Typo.overline" Color="Color.Secondary">転送先フォルダー</MudText>
+                        <MudText Typo="Typo.body2" Style="word-break: break-all;">@(_discovery.SharePointDestFolderPath is { Length: > 0 } q ? q : "未設定")</MudText>
+                    </MudItem>
+                </MudGrid>
+            }
+        </MudCardContent>
+    </MudCard>
+
     <MudCard Elevation="2" Style="max-width: 600px;">
         <MudCardContent>
             <MudGrid>
@@ -171,6 +203,7 @@ else
 </MudMessageBox>
 @code {
     private ConfigDto? _config;
+    private DiscoveryConfigDto? _discovery;
     private bool _isRebuilding;
     private MudMessageBox? _confirmBox;
 
@@ -191,6 +224,25 @@ else
     protected override async Task OnInitializedAsync()
     {
         await LoadConfigAsync();
+        await LoadDiscoveryAsync();
+    }
+
+    private async Task LoadDiscoveryAsync()
+    {
+        try
+        {
+            var d = await ConfigService.GetDiscoveryConfigAsync();
+            // ウィザード未完了の場合はすべてのパスフィールドが空
+            _discovery = (string.IsNullOrEmpty(d.OneDriveSourceFolderPath) &&
+                          string.IsNullOrEmpty(d.SharePointDestFolderPath) &&
+                          string.IsNullOrEmpty(d.MigrationRoute))
+                ? null
+                : d;
+        }
+        catch
+        {
+            _discovery = null;
+        }
     }
 
     private async Task LoadConfigAsync()


### PR DESCRIPTION
## 概要\n\n操作検証中に発見された2件の問題を修正します。\n\n## 変更内容\n\n### Fix: Dashboard で設定変更してもフルリビルドが発動しない\n\n**原因:** `App.xaml.cs` の `MigrationWork` が `ConfigHashChecker` を通さずに `SharePointMigrationPipeline.RunAsync()` を直接呼び出していた。CLI の `TransferCommand.cs` だけがハッシュ確認を行っており、Dashboard 経由では FR-10 の設定変更検知が機能していなかった。\n\n**修正:** `MigrationWork` に CLI と同等のハッシュ確認ロジックを追加:\n1. `ConfigHashChecker.ComputeHash(opts)` でハッシュ計算\n2. `HasChangedAsync` で前回からの差分確認\n3. 変更検知時: `ClearAll` + `SaveHashAsync` + `stateDb.ResetAllAsync` でフルリビルドを発動\n\n### Add: 設定ページに転送ルート情報カードを追加\n\nウィザードで設定済みの以下の情報を `SettingsPage` 上部に読み取り専用カードとして表示:\n- 移行ルート (例: `OneDrive → SharePoint`)\n- 転送元フォルダパス\n- 転送先フォルダパス\n\nウィザード未完了（全フィールドが空）の場合は「ウィザードが未完了です」メッセージを表示。\n\n## テスト方法\n\n1. Dashboard で設定を変更して「保存」\n2. 転送開始 → ログに「設定変更を検知しました」が出力され DB がリセットされることを確認\n3. 設定ページで転送ルート情報カードが表示されることを確認