### PR TITLE
Phase5: v0.5.0 UI 未実装分 - レート制御エンジン切り替え設定 & ダッシュボード観測パネル

### DIFF
--- a/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
@@ -191,9 +191,9 @@ public sealed class ConfigurationService : IConfigurationService
             rcLongWindowSec = GetInt(rcProp, "longWindowSec", 30);
             // emergencyThreshold / slowdownThreshold は JSON に 0–1 で保存、UI では 0–100 (%) で表示
             if (rcProp.TryGetProperty("emergencyThreshold", out var etProp) && etProp.TryGetDouble(out var et))
-                rcEmergencyThresholdPct = Math.Clamp((int)Math.Round(et * 100), 1, 100);
+                rcEmergencyThresholdPct = Math.Clamp((int)Math.Round(et * 100), 0, 100);
             if (rcProp.TryGetProperty("slowdownThreshold", out var stProp) && stProp.TryGetDouble(out var st))
-                rcSlowdownThresholdPct = Math.Clamp((int)Math.Round(st * 100), 1, 100);
+                rcSlowdownThresholdPct = Math.Clamp((int)Math.Round(st * 100), 0, 100);
             if (rcProp.TryGetProperty("decayK", out var dkProp) && dkProp.TryGetDouble(out var dk))
                 rcDecayK = dk;
             if (rcProp.TryGetProperty("minDecayFactor", out var minDfProp) && minDfProp.TryGetDouble(out var minDf))

--- a/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
@@ -19,7 +19,18 @@ public sealed record ConfigDto(
     bool AdaptiveConcurrencyEnabled = false,
     int AdaptiveConcurrencyInitialDegree = 0,
     int AdaptiveConcurrencyDecreasePercent = 50,
-    int AdaptiveConcurrencyIncreaseIntervalSec = 60);
+    int AdaptiveConcurrencyIncreaseIntervalSec = 60,
+    // ── RateControl 設定（v0.5.0: RateControlledTransferController 用）──
+    bool UseRateControl = false,
+    int RcShortWindowSec = 5,
+    int RcLongWindowSec = 30,
+    int RcEmergencyThresholdPct = 10,
+    int RcSlowdownThresholdPct = 3,
+    double RcDecayK = 5.0,
+    double RcMinDecayFactor = 0.3,
+    double RcMaxDecayFactor = 0.9,
+    int RcInFlightThreshold = 32,
+    int RcMaxConcurrency = 16);
 
 /// <summary>
 /// PUT /api/config で受け取るマージ更新 DTO。null フィールドは上書きしない。
@@ -36,7 +47,18 @@ public sealed record ConfigUpdateDto(
     bool? AdaptiveConcurrencyEnabled = null,
     int? AdaptiveConcurrencyInitialDegree = null,
     int? AdaptiveConcurrencyDecreasePercent = null,
-    int? AdaptiveConcurrencyIncreaseIntervalSec = null);
+    int? AdaptiveConcurrencyIncreaseIntervalSec = null,
+    // ── RateControl 設定（v0.5.0: RateControlledTransferController 用）──
+    bool? UseRateControl = null,
+    int? RcShortWindowSec = null,
+    int? RcLongWindowSec = null,
+    int? RcEmergencyThresholdPct = null,
+    int? RcSlowdownThresholdPct = null,
+    double? RcDecayK = null,
+    double? RcMinDecayFactor = null,
+    double? RcMaxDecayFactor = null,
+    int? RcInFlightThreshold = null,
+    int? RcMaxConcurrency = null);
 
 /// <summary>
 /// Graph プロバイダー設定 DTO（シークレット除外済み）。
@@ -151,6 +173,37 @@ public sealed class ConfigurationService : IConfigurationService
             }
         }
 
+        // rateControl セクションを読み取る
+        var useRateControl = false;
+        var rcShortWindowSec = 5;
+        var rcLongWindowSec = 30;
+        var rcEmergencyThresholdPct = 10;
+        var rcSlowdownThresholdPct = 3;
+        var rcDecayK = 5.0;
+        var rcMinDecayFactor = 0.3;
+        var rcMaxDecayFactor = 0.9;
+        var rcInFlightThreshold = 32;
+        var rcMaxConcurrency = 16;
+        if (m.TryGetProperty("rateControl", out var rcProp) && rcProp.ValueKind == JsonValueKind.Object)
+        {
+            useRateControl = rcProp.TryGetProperty("useRateControl", out var urProp) && urProp.ValueKind == JsonValueKind.True;
+            rcShortWindowSec = GetInt(rcProp, "shortWindowSec", 5);
+            rcLongWindowSec = GetInt(rcProp, "longWindowSec", 30);
+            // emergencyThreshold / slowdownThreshold は JSON に 0–1 で保存、UI では 0–100 (%) で表示
+            if (rcProp.TryGetProperty("emergencyThreshold", out var etProp) && etProp.TryGetDouble(out var et))
+                rcEmergencyThresholdPct = Math.Clamp((int)Math.Round(et * 100), 1, 100);
+            if (rcProp.TryGetProperty("slowdownThreshold", out var stProp) && stProp.TryGetDouble(out var st))
+                rcSlowdownThresholdPct = Math.Clamp((int)Math.Round(st * 100), 1, 100);
+            if (rcProp.TryGetProperty("decayK", out var dkProp) && dkProp.TryGetDouble(out var dk))
+                rcDecayK = dk;
+            if (rcProp.TryGetProperty("minDecayFactor", out var minDfProp) && minDfProp.TryGetDouble(out var minDf))
+                rcMinDecayFactor = minDf;
+            if (rcProp.TryGetProperty("maxDecayFactor", out var maxDfProp) && maxDfProp.TryGetDouble(out var maxDf))
+                rcMaxDecayFactor = maxDf;
+            rcInFlightThreshold = GetInt(rcProp, "inFlightThreshold", 32);
+            rcMaxConcurrency = GetInt(rcProp, "maxConcurrency", 16);
+        }
+
         return new ConfigDto(
             MaxParallelTransfers: GetInt(m, "maxParallelTransfers", 4),
             MaxParallelFolderCreations: GetInt(m, "maxParallelFolderCreations", 4),
@@ -163,7 +216,17 @@ public sealed class ConfigurationService : IConfigurationService
             AdaptiveConcurrencyEnabled: adaptiveEnabled,
             AdaptiveConcurrencyInitialDegree: adaptiveInitialDegree,
             AdaptiveConcurrencyDecreasePercent: adaptiveDecreasePercent,
-            AdaptiveConcurrencyIncreaseIntervalSec: adaptiveIncreaseIntervalSec);
+            AdaptiveConcurrencyIncreaseIntervalSec: adaptiveIncreaseIntervalSec,
+            UseRateControl: useRateControl,
+            RcShortWindowSec: rcShortWindowSec,
+            RcLongWindowSec: rcLongWindowSec,
+            RcEmergencyThresholdPct: rcEmergencyThresholdPct,
+            RcSlowdownThresholdPct: rcSlowdownThresholdPct,
+            RcDecayK: rcDecayK,
+            RcMinDecayFactor: rcMinDecayFactor,
+            RcMaxDecayFactor: rcMaxDecayFactor,
+            RcInFlightThreshold: rcInFlightThreshold,
+            RcMaxConcurrency: rcMaxConcurrency);
     }
 
     /// <inheritdoc />
@@ -215,6 +278,33 @@ public sealed class ConfigurationService : IConfigurationService
                     spAcObj["decreaseMultiplier"] = update.AdaptiveConcurrencyDecreasePercent.Value / 100.0;
                 if (update.AdaptiveConcurrencyIncreaseIntervalSec.HasValue)
                     spAcObj["increaseIntervalSec"] = update.AdaptiveConcurrencyIncreaseIntervalSec.Value;
+            }
+
+            // rateControl セクションを更新
+            if (update.UseRateControl.HasValue || update.RcShortWindowSec.HasValue
+                || update.RcLongWindowSec.HasValue || update.RcEmergencyThresholdPct.HasValue
+                || update.RcSlowdownThresholdPct.HasValue || update.RcDecayK.HasValue
+                || update.RcMinDecayFactor.HasValue || update.RcMaxDecayFactor.HasValue
+                || update.RcInFlightThreshold.HasValue || update.RcMaxConcurrency.HasValue)
+            {
+                if (m["rateControl"] is not JsonObject rcObj)
+                {
+                    rcObj = new JsonObject();
+                    m["rateControl"] = rcObj;
+                }
+                if (update.UseRateControl.HasValue) rcObj["useRateControl"] = update.UseRateControl.Value;
+                if (update.RcShortWindowSec.HasValue) rcObj["shortWindowSec"] = update.RcShortWindowSec.Value;
+                if (update.RcLongWindowSec.HasValue) rcObj["longWindowSec"] = update.RcLongWindowSec.Value;
+                // UI 側は % (0–100)、JSON 側は 0–1 に変換して保存
+                if (update.RcEmergencyThresholdPct.HasValue)
+                    rcObj["emergencyThreshold"] = update.RcEmergencyThresholdPct.Value / 100.0;
+                if (update.RcSlowdownThresholdPct.HasValue)
+                    rcObj["slowdownThreshold"] = update.RcSlowdownThresholdPct.Value / 100.0;
+                if (update.RcDecayK.HasValue) rcObj["decayK"] = update.RcDecayK.Value;
+                if (update.RcMinDecayFactor.HasValue) rcObj["minDecayFactor"] = update.RcMinDecayFactor.Value;
+                if (update.RcMaxDecayFactor.HasValue) rcObj["maxDecayFactor"] = update.RcMaxDecayFactor.Value;
+                if (update.RcInFlightThreshold.HasValue) rcObj["inFlightThreshold"] = update.RcInFlightThreshold.Value;
+                if (update.RcMaxConcurrency.HasValue) rcObj["maxConcurrency"] = update.RcMaxConcurrency.Value;
             }
 
             // アトミック書き込み: 一時ファイルに書き込んでからリネーム

--- a/src/CloudMigrator.Core/Transfer/RateControlledTransferController.cs
+++ b/src/CloudMigrator.Core/Transfer/RateControlledTransferController.cs
@@ -190,9 +190,10 @@ public sealed class RateControlledTransferController : ITransferRateController, 
 
         double newRate;
         string action;
+        int stateCode;
         lock (_rateLock)
         {
-            (newRate, action) = AdjustRate(_currentRate, shortSnap, longSnap);
+            (newRate, action, stateCode) = AdjustRate(_currentRate, shortSnap, longSnap);
             _currentRate = newRate;
         }
 
@@ -219,11 +220,7 @@ public sealed class RateControlledTransferController : ITransferRateController, 
         _metricsBuffer.Enqueue("avg_latency_ms", longSnap.AvgLatencyMs);
         _metricsBuffer.Enqueue("current_rate_limit", newRate);
         _metricsBuffer.Enqueue("current_in_flight", inFlight);
-        // ヒステリシス状態コード: 0=安定, 1=加速, 2=緩減速, 3=緊急減速（Controller が決定）
-        int stateCode = action.StartsWith("緊急", StringComparison.Ordinal) ? 3
-            : action.StartsWith("緩", StringComparison.Ordinal) ? 2
-            : action == "加速" ? 1
-            : 0;
+        // ヒステリシス状態コード: 0=安定, 1=加速, 2=緩減速, 3=緊急減速（AdjustRate が直接返す）
         Volatile.Write(ref _hysteresisStateCode, stateCode);
         _metricsBuffer.Enqueue("hysteresis_state_code", stateCode);
 
@@ -235,19 +232,20 @@ public sealed class RateControlledTransferController : ITransferRateController, 
     /// <summary>
     /// ヒステリシス制御 + 可変減衰でレートを調整する。
     /// </summary>
-    private (double newRate, string action) AdjustRate(
+    private (double newRate, string action, int stateCode) AdjustRate(
         double currentRate, MetricsSnapshot shortSnap, MetricsSnapshot longSnap)
     {
         var maxRate = _settings.MaxConcurrency; // req/sec の上限は MaxConcurrency と同値
 
         // ── ヒステリシス制御（3 段階）──────────────────────────────────
+        // stateCode: 0=安定, 1=加速, 2=緩減速, 3=緊急減速
 
         // 緊急減速: 短期 429 率 > emergencyThreshold
         if (shortSnap.Rate429 > _settings.EmergencyThreshold)
         {
             var factor = ComputeDecayFactor(shortSnap.Rate429);
             var newRate = Math.Max(_settings.MinRatePerSec, currentRate * factor);
-            return (newRate, $"緊急減速(factor={factor:F2})");
+            return (newRate, $"緊急減速(factor={factor:F2})", 3);
         }
 
         // 緩減速: 中期 429 率 > slowdownThreshold
@@ -255,18 +253,18 @@ public sealed class RateControlledTransferController : ITransferRateController, 
         {
             var factor = ComputeDecayFactor(longSnap.Rate429);
             var newRate = Math.Max(_settings.MinRatePerSec, currentRate * factor);
-            return (newRate, $"緩減速(factor={factor:F2})");
+            return (newRate, $"緩減速(factor={factor:F2})", 2);
         }
 
         // 加速: 中期 429 率 = 0
         if (longSnap.Rate429 == 0)
         {
             var newRate = Math.Min(maxRate, currentRate * (1.0 + _settings.AccelerateRatio));
-            return (newRate, "加速");
+            return (newRate, "加速", 1);
         }
 
         // 安定域: 変更なし
-        return (currentRate, "維持");
+        return (currentRate, "維持", 0);
     }
 
     /// <summary>

--- a/src/CloudMigrator.Core/Transfer/RateControlledTransferController.cs
+++ b/src/CloudMigrator.Core/Transfer/RateControlledTransferController.cs
@@ -35,9 +35,6 @@ public sealed class RateControlledTransferController : ITransferRateController, 
     private double _currentRate;    // req/sec（lock で保護）
     private int _activeCount;       // 実行中リクエスト数
     private int _retryWaitingCount; // Retry 待ちリクエスト数
-    // ヒステリシス状態コード: 0=安定, 1=加速, 2=緩減速, 3=緊急減速（Controller が決定、UI は表示のみ）
-    private int _hysteresisStateCode;
-
     private readonly object _rateLock = new();
 
     // ── トークンバケット（レート制御・dispatch ゲート）──
@@ -221,7 +218,6 @@ public sealed class RateControlledTransferController : ITransferRateController, 
         _metricsBuffer.Enqueue("current_rate_limit", newRate);
         _metricsBuffer.Enqueue("current_in_flight", inFlight);
         // ヒステリシス状態コード: 0=安定, 1=加速, 2=緩減速, 3=緊急減速（AdjustRate が直接返す）
-        Volatile.Write(ref _hysteresisStateCode, stateCode);
         _metricsBuffer.Enqueue("hysteresis_state_code", stateCode);
 
         _logger.LogDebug(

--- a/src/CloudMigrator.Core/Transfer/RateControlledTransferController.cs
+++ b/src/CloudMigrator.Core/Transfer/RateControlledTransferController.cs
@@ -35,6 +35,8 @@ public sealed class RateControlledTransferController : ITransferRateController, 
     private double _currentRate;    // req/sec（lock で保護）
     private int _activeCount;       // 実行中リクエスト数
     private int _retryWaitingCount; // Retry 待ちリクエスト数
+    // ヒステリシス状態コード: 0=安定, 1=加速, 2=緩減速, 3=緊急減速（Controller が決定、UI は表示のみ）
+    private int _hysteresisStateCode;
 
     private readonly object _rateLock = new();
 
@@ -217,6 +219,13 @@ public sealed class RateControlledTransferController : ITransferRateController, 
         _metricsBuffer.Enqueue("avg_latency_ms", longSnap.AvgLatencyMs);
         _metricsBuffer.Enqueue("current_rate_limit", newRate);
         _metricsBuffer.Enqueue("current_in_flight", inFlight);
+        // ヒステリシス状態コード: 0=安定, 1=加速, 2=緩減速, 3=緊急減速（Controller が決定）
+        int stateCode = action.StartsWith("緊急", StringComparison.Ordinal) ? 3
+            : action.StartsWith("緩", StringComparison.Ordinal) ? 2
+            : action == "加速" ? 1
+            : 0;
+        Volatile.Write(ref _hysteresisStateCode, stateCode);
+        _metricsBuffer.Enqueue("hysteresis_state_code", stateCode);
 
         _logger.LogDebug(
             "制御サイクル: レート={Rate:F2} req/sec, 429率短期={Short:P1}/中期={Long:P1}, インフライト={InFlight}, アクション={Action}",

--- a/src/CloudMigrator.Dashboard/App.xaml.cs
+++ b/src/CloudMigrator.Dashboard/App.xaml.cs
@@ -74,6 +74,12 @@ public partial class App : Application
         services.AddLogging();
 
         // ── Application services ─────────────────────────────────────────────
+        // 実効設定（環境変数 > config.json > デフォルト優先）を DI に登録
+        // Dashboard コンポーネントが UseRateControl 等の実効値を参照できるようにする
+        var effectiveConfiguration = AppConfiguration.Build();
+        var effectiveOptions = effectiveConfiguration.GetSection(MigratorOptions.SectionName).Get<MigratorOptions>() ?? new MigratorOptions();
+        services.AddSingleton(effectiveOptions);
+
         services.AddSingleton<IConfigurationService, ConfigurationService>();
         services.AddSingleton<ITransferJobService>(sp =>
         {

--- a/src/CloudMigrator.Dashboard/App.xaml.cs
+++ b/src/CloudMigrator.Dashboard/App.xaml.cs
@@ -74,11 +74,13 @@ public partial class App : Application
         services.AddLogging();
 
         // ── Application services ─────────────────────────────────────────────
-        // 実効設定（環境変数 > config.json > デフォルト優先）を DI に登録
-        // Dashboard コンポーネントが UseRateControl 等の実効値を参照できるようにする
-        var effectiveConfiguration = AppConfiguration.Build();
-        var effectiveOptions = effectiveConfiguration.GetSection(MigratorOptions.SectionName).Get<MigratorOptions>() ?? new MigratorOptions();
-        services.AddSingleton(effectiveOptions);
+        // 実効設定ファクトリを DI 登録（呼ぶたびに AppConfiguration.Build() で最新設定を取得）
+        // singleton ではなくファクトリにすることで、設定変更後も UI が古い値を参照し続けない
+        // ジョブ実行側（MigrationWork）も都度 AppConfiguration.Build() するため動作が一致する
+        services.AddSingleton<Func<MigratorOptions>>(_ =>
+            () => AppConfiguration.Build()
+                .GetSection(MigratorOptions.SectionName)
+                .Get<MigratorOptions>() ?? new MigratorOptions());
 
         services.AddSingleton<IConfigurationService, ConfigurationService>();
         services.AddSingleton<ITransferJobService>(sp =>

--- a/src/CloudMigrator.Dashboard/App.xaml.cs
+++ b/src/CloudMigrator.Dashboard/App.xaml.cs
@@ -92,7 +92,7 @@ public partial class App : Application
                 var auth = new GraphAuthenticator(opts.Graph.ClientId, opts.Graph.TenantId, clientSecret);
 
                 // AdaptiveConcurrencyController の初期化（config.json の AdaptiveConcurrency.sharepoint.Enabled = true で有効）
-                // Dashboard では UseRateControl=false 時のみ ACC を使用する（RateControlledTransferController の UI は未実装）
+                // UseRateControl=false 時のみ ACC を使用する
                 var adaptiveOpts = opts.GetAdaptiveConcurrency("sharepoint");
                 AdaptiveConcurrencyController? accMain = null;        // Dispose + onRateLimit 用に保持
                 AdaptiveConcurrencyController? accFolder = null;      // Dispose + onRateLimit 用に保持
@@ -139,6 +139,30 @@ public partial class App : Application
                     // 参照一致で folderCreationController（Phase C 用）か concurrencyController（Phase D 用）かを判別する
                     activateController = ctrl =>
                         Volatile.Write(ref activeCtrl, ReferenceEquals(ctrl, folderCreationController) ? accFolder : accMain);
+                }
+
+                // UseRateControl=true 時は RateControlledTransferController を構築する
+                // （TransferCommand と同等の組み立てパターン）
+                RateControlledTransferController? rateController = null;
+                MetricsBuffer? rateMetricsBuffer = null;
+                if (opts.RateControl.UseRateControl)
+                {
+                    var aggregator = new TransferMetricsAggregator();
+                    rateMetricsBuffer = new MetricsBuffer(
+                        stateDb,
+                        opts.RateControl.MetricsFlushIntervalSec,
+                        loggerFactory2.CreateLogger<MetricsBuffer>());
+                    rateController = new RateControlledTransferController(
+                        aggregator,
+                        opts.RateControl,
+                        rateMetricsBuffer,
+                        loggerFactory2.CreateLogger<RateControlledTransferController>());
+                    // 429 発生時に RateControlledTransferController へ通知する
+                    onRateLimit = retryAfter => rateController.NotifyRateLimit(retryAfter);
+                    concurrencyController = rateController;
+                    loggerFactory2.CreateLogger("MigrationWork").LogInformation(
+                        "RateControlledTransferController を構築しました（初期レート: {Rate:F1} req/sec）",
+                        opts.RateControl.InitialRatePerSec);
                 }
 
                 // 設定変更検知（FR-10）: CLI の TransferCommand と同等のハッシュ確認を行う
@@ -199,6 +223,11 @@ public partial class App : Application
                     // AdaptiveConcurrencyControllerAdapter は内部 ACC を所有しないため ACC を直接 Dispose する
                     accMain?.Dispose();
                     accFolder?.Dispose();
+                    // RateControlledTransferController と MetricsBuffer を Dispose
+                    if (rateController is not null)
+                        await rateController.DisposeAsync().ConfigureAwait(false);
+                    if (rateMetricsBuffer is not null)
+                        await rateMetricsBuffer.DisposeAsync().ConfigureAwait(false);
                 }
             }
 

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -1,7 +1,9 @@
 @inject ITransferStateDb TransferStateDb
 @inject ITransferJobService JobService
 @inject IConfigurationService ConfigService
+@inject MigratorOptions AppOptions
 @inject ILogger<DashboardPage> Logger
+@using CloudMigrator.Core.Configuration
 @implements IDisposable
 
 <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-4" Spacing="2">
@@ -490,19 +492,12 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        // UseRateControl フラグを初回読み込み（次回ジョブ開始時に反映される設定）
-        try
-        {
-            var cfg = await ConfigService.GetConfigAsync();
-            _useRateControl = cfg.UseRateControl;
-            // 429率色分け用の閾値を Config から取得（0–1 スケールに戻す）
-            _rcSlowdownThreshold  = cfg.RcSlowdownThresholdPct  / 100.0;
-            _rcEmergencyThreshold = cfg.RcEmergencyThresholdPct / 100.0;
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex, "UseRateControl 設定の読み込みに失敗しました。デフォルト false で動作します。");
-        }
+        // 実効設定（環境変数 > config.json > デフォルト優先）から UseRateControl を取得
+        // ConfigService.GetConfigAsync() は config.json 直読みのため環境変数オーバーライドが反映されない
+        // AppOptions は BuildServiceProvider で AppConfiguration.Build() から構築した実効設定
+        _useRateControl = AppOptions.RateControl.UseRateControl;
+        _rcSlowdownThreshold  = AppOptions.RateControl.SlowdownThreshold;
+        _rcEmergencyThreshold = AppOptions.RateControl.EmergencyThreshold;
 
         await RefreshAllAsync(CancellationToken.None);
         _refreshCts = new CancellationTokenSource();

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -273,13 +273,13 @@ else
                             </MudItem>
                             <MudItem xs="6" sm="3">
                                 <MudText Typo="Typo.overline" Color="Color.Secondary">短期 429 率</MudText>
-                                <MudText Typo="Typo.body1" Color="@(_rcRate429Short > 0.03 ? Color.Warning : Color.Success)">
+                                <MudText Typo="Typo.body1" Color="@(_rcRate429Short >= _rcEmergencyThreshold && _rcRate429Short >= 0 ? Color.Error : _rcRate429Short >= _rcSlowdownThreshold && _rcRate429Short >= 0 ? Color.Warning : Color.Success)">
                                     <b>@(_rcRate429Short >= 0 ? (_rcRate429Short * 100).ToString("F1") + "%" : "—")</b>
                                 </MudText>
                             </MudItem>
                             <MudItem xs="6" sm="3">
                                 <MudText Typo="Typo.overline" Color="Color.Secondary">中期 429 率</MudText>
-                                <MudText Typo="Typo.body1" Color="@(_rcRate429Long > 0.03 ? Color.Warning : Color.Success)">
+                                <MudText Typo="Typo.body1" Color="@(_rcRate429Long >= _rcEmergencyThreshold && _rcRate429Long >= 0 ? Color.Error : _rcRate429Long >= _rcSlowdownThreshold && _rcRate429Long >= 0 ? Color.Warning : Color.Success)">
                                     <b>@(_rcRate429Long >= 0 ? (_rcRate429Long * 100).ToString("F1") + "%" : "—")</b>
                                 </MudText>
                             </MudItem>
@@ -447,14 +447,18 @@ else
     private double _rcInFlight = -1;
     private double _rcRate429Short = -1;
     private double _rcRate429Long = -1;
-    private int _rcHysteresisStateCode; // 0=安定, 1=加速, 2=緩減速, 3=緊急減速
+    private int _rcHysteresisStateCode = -1; // -1=未取得, 0=安定, 1=加速, 2=緩減速, 3=緊急減速
+    // Config から読み込んだ閾値（429率色分けに使用）
+    private double _rcSlowdownThreshold;    // 0–1 スケール
+    private double _rcEmergencyThreshold;   // 0–1 スケール
 
     private string HysteresisLabel => _rcHysteresisStateCode switch
     {
         3 => "緊急減速",
         2 => "緩減速",
         1 => "加速",
-        _ => "安定"
+        0 => "安定",
+        _ => "—"
     };
 
     private Color HysteresisColor => _rcHysteresisStateCode switch
@@ -462,6 +466,7 @@ else
         3 => Color.Error,
         2 => Color.Warning,
         1 => Color.Success,
+        0 => Color.Default,
         _ => Color.Default
     };
     private string _eta = "—";
@@ -490,6 +495,9 @@ else
         {
             var cfg = await ConfigService.GetConfigAsync();
             _useRateControl = cfg.UseRateControl;
+            // 429率色分け用の閾値を Config から取得（0–1 スケールに戻す）
+            _rcSlowdownThreshold  = cfg.RcSlowdownThresholdPct  / 100.0;
+            _rcEmergencyThreshold = cfg.RcEmergencyThresholdPct / 100.0;
         }
         catch (Exception ex)
         {
@@ -585,7 +593,7 @@ else
             if (inflightData.Count > 0) _rcInFlight     = inflightData[^1].Value;
             if (short429Data.Count > 0) _rcRate429Short = short429Data[^1].Value;
             if (long429Data.Count > 0)  _rcRate429Long  = long429Data[^1].Value;
-            if (stateData.Count > 0)    _rcHysteresisStateCode = (int)Math.Round(stateData[^1].Value);
+            if (stateData.Count > 0)    _rcHysteresisStateCode = (int)Math.Round(stateData[^1].Value); // 0–3
         }
         catch (OperationCanceledException)
         {

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -1,7 +1,6 @@
 @inject ITransferStateDb TransferStateDb
 @inject ITransferJobService JobService
-@inject IConfigurationService ConfigService
-@inject MigratorOptions AppOptions
+@inject Func<MigratorOptions> OptionsFactory
 @inject ILogger<DashboardPage> Logger
 @using CloudMigrator.Core.Configuration
 @implements IDisposable
@@ -492,13 +491,6 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        // 実効設定（環境変数 > config.json > デフォルト優先）から UseRateControl を取得
-        // ConfigService.GetConfigAsync() は config.json 直読みのため環境変数オーバーライドが反映されない
-        // AppOptions は BuildServiceProvider で AppConfiguration.Build() から構築した実効設定
-        _useRateControl = AppOptions.RateControl.UseRateControl;
-        _rcSlowdownThreshold  = AppOptions.RateControl.SlowdownThreshold;
-        _rcEmergencyThreshold = AppOptions.RateControl.EmergencyThreshold;
-
         await RefreshAllAsync(CancellationToken.None);
         _refreshCts = new CancellationTokenSource();
         var token = _refreshCts.Token;
@@ -520,6 +512,13 @@ else
 
     private async Task RefreshAllAsync(CancellationToken ct)
     {
+        // 実効設定を都度取得（環境変数 > config.json > デフォルト優先）
+        // ファクトリ経由で毎回 AppConfiguration.Build() を呼ぶため、設定変更後も最新値を反映する
+        var opts = OptionsFactory();
+        _useRateControl = opts.RateControl.UseRateControl;
+        _rcSlowdownThreshold  = opts.RateControl.SlowdownThreshold;
+        _rcEmergencyThreshold = opts.RateControl.EmergencyThreshold;
+
         try { _summary = await TransferStateDb.GetSummaryAsync(ct); }
         catch (Exception ex) { Logger.LogError(ex, "RefreshAllAsync: GetSummaryAsync 失敗"); _summary ??= new TransferDbSummary(); }
         if (_summary is null) return;

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -273,13 +273,13 @@ else
                             </MudItem>
                             <MudItem xs="6" sm="3">
                                 <MudText Typo="Typo.overline" Color="Color.Secondary">短期 429 率</MudText>
-                                <MudText Typo="Typo.body1" Color="@(_rcRate429Short < 0 ? Color.Default : _rcRate429Short >= _rcEmergencyThreshold ? Color.Error : _rcRate429Short >= _rcSlowdownThreshold ? Color.Warning : Color.Success)">
+                                <MudText Typo="Typo.body1" Color="@(_rcRate429Short < 0 ? Color.Default : _rcRate429Short > _rcEmergencyThreshold ? Color.Error : Color.Success)">
                                     <b>@(_rcRate429Short >= 0 ? (_rcRate429Short * 100).ToString("F1") + "%" : "—")</b>
                                 </MudText>
                             </MudItem>
                             <MudItem xs="6" sm="3">
                                 <MudText Typo="Typo.overline" Color="Color.Secondary">中期 429 率</MudText>
-                                <MudText Typo="Typo.body1" Color="@(_rcRate429Long < 0 ? Color.Default : _rcRate429Long >= _rcEmergencyThreshold ? Color.Error : _rcRate429Long >= _rcSlowdownThreshold ? Color.Warning : Color.Success)">
+                                <MudText Typo="Typo.body1" Color="@(_rcRate429Long < 0 ? Color.Default : _rcRate429Long > _rcSlowdownThreshold ? Color.Warning : Color.Success)">
                                     <b>@(_rcRate429Long >= 0 ? (_rcRate429Long * 100).ToString("F1") + "%" : "—")</b>
                                 </MudText>
                             </MudItem>

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -264,7 +264,7 @@ else
                     <MudCardContent>
                         <MudGrid Spacing="1">
                             <MudItem xs="6" sm="3">
-                                <MudText Typo="Typo.overline" Color="Color.Secondary">現在レート</MudText>
+                                <MudText Typo="Typo.overline" Color="Color.Secondary">現在レート上限（req/s）</MudText>
                                 <MudText Typo="Typo.body1"><b>@(_rcCurrentRate >= 0 ? _rcCurrentRate.ToString("F1") + " req/s" : "—")</b></MudText>
                             </MudItem>
                             <MudItem xs="6" sm="3">

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -265,7 +265,7 @@ else
                         <MudGrid Spacing="1">
                             <MudItem xs="6" sm="3">
                                 <MudText Typo="Typo.overline" Color="Color.Secondary">現在レート</MudText>
-                                <MudText Typo="Typo.body1"><b>@(_rcCurrentRate > 0 ? _rcCurrentRate.ToString("F1") + " req/s" : "—")</b></MudText>
+                                <MudText Typo="Typo.body1"><b>@(_rcCurrentRate >= 0 ? _rcCurrentRate.ToString("F1") + " req/s" : "—")</b></MudText>
                             </MudItem>
                             <MudItem xs="6" sm="3">
                                 <MudText Typo="Typo.overline" Color="Color.Secondary">インフライト数</MudText>
@@ -571,18 +571,30 @@ else
     private async Task RefreshRateControlMetricsAsync(CancellationToken ct)
     {
         // 直近 2 分間のメトリクスから最新値を取得する（Controller が 1 秒ごとにエンキューしている）
-        const int windowMinutes = 2;
-        var rateData    = await TransferStateDb.GetMetricsAsync("current_rate_limit",    windowMinutes, ct);
-        var inflightData= await TransferStateDb.GetMetricsAsync("current_in_flight",     windowMinutes, ct);
-        var short429Data= await TransferStateDb.GetMetricsAsync("rate_429_short",        windowMinutes, ct);
-        var long429Data = await TransferStateDb.GetMetricsAsync("rate_429_long",         windowMinutes, ct);
-        var stateData   = await TransferStateDb.GetMetricsAsync("hysteresis_state_code", windowMinutes, ct);
+        // 例外発生時はログに残してスキップ（PeriodicTimer ループが停止しないよう保護）
+        try
+        {
+            const int windowMinutes = 2;
+            var rateData    = await TransferStateDb.GetMetricsAsync("current_rate_limit",    windowMinutes, ct);
+            var inflightData= await TransferStateDb.GetMetricsAsync("current_in_flight",     windowMinutes, ct);
+            var short429Data= await TransferStateDb.GetMetricsAsync("rate_429_short",        windowMinutes, ct);
+            var long429Data = await TransferStateDb.GetMetricsAsync("rate_429_long",         windowMinutes, ct);
+            var stateData   = await TransferStateDb.GetMetricsAsync("hysteresis_state_code", windowMinutes, ct);
 
-        if (rateData.Count > 0)     _rcCurrentRate  = rateData[^1].Value;
-        if (inflightData.Count > 0) _rcInFlight     = inflightData[^1].Value;
-        if (short429Data.Count > 0) _rcRate429Short = short429Data[^1].Value;
-        if (long429Data.Count > 0)  _rcRate429Long  = long429Data[^1].Value;
-        if (stateData.Count > 0)    _rcHysteresisStateCode = (int)Math.Round(stateData[^1].Value);
+            if (rateData.Count > 0)     _rcCurrentRate  = rateData[^1].Value;
+            if (inflightData.Count > 0) _rcInFlight     = inflightData[^1].Value;
+            if (short429Data.Count > 0) _rcRate429Short = short429Data[^1].Value;
+            if (long429Data.Count > 0)  _rcRate429Long  = long429Data[^1].Value;
+            if (stateData.Count > 0)    _rcHysteresisStateCode = (int)Math.Round(stateData[^1].Value);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "RateControl メトリクスの取得に失敗しました。次回ポーリングまでスキップします。");
+        }
     }
 
     private async Task RefreshFolderProgressAsync(CancellationToken ct)

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -1,5 +1,6 @@
 @inject ITransferStateDb TransferStateDb
 @inject ITransferJobService JobService
+@inject IConfigurationService ConfigService
 @inject ILogger<DashboardPage> Logger
 @implements IDisposable
 
@@ -247,6 +248,47 @@ else
             </MudItem>
         }
 
+        <!-- レートベース制御エンジン 観測パネル（UseRateControl=true 時のみ表示） -->
+        @if (_useRateControl)
+        {
+            <MudItem xs="12">
+                <MudCard Elevation="2">
+                    <MudCardHeader>
+                        <CardHeaderContent>
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                                <MudText Typo="Typo.subtitle1">レートベース制御 リアルタイムモニター</MudText>
+                                <MudChip T="string" Color="@HysteresisColor" Size="Size.Small">@HysteresisLabel</MudChip>
+                            </MudStack>
+                        </CardHeaderContent>
+                    </MudCardHeader>
+                    <MudCardContent>
+                        <MudGrid Spacing="1">
+                            <MudItem xs="6" sm="3">
+                                <MudText Typo="Typo.overline" Color="Color.Secondary">現在レート</MudText>
+                                <MudText Typo="Typo.body1"><b>@(_rcCurrentRate > 0 ? _rcCurrentRate.ToString("F1") + " req/s" : "—")</b></MudText>
+                            </MudItem>
+                            <MudItem xs="6" sm="3">
+                                <MudText Typo="Typo.overline" Color="Color.Secondary">インフライト数</MudText>
+                                <MudText Typo="Typo.body1"><b>@(_rcInFlight >= 0 ? _rcInFlight.ToString("N0") : "—")</b></MudText>
+                            </MudItem>
+                            <MudItem xs="6" sm="3">
+                                <MudText Typo="Typo.overline" Color="Color.Secondary">短期 429 率</MudText>
+                                <MudText Typo="Typo.body1" Color="@(_rcRate429Short > 0.03 ? Color.Warning : Color.Success)">
+                                    <b>@(_rcRate429Short >= 0 ? (_rcRate429Short * 100).ToString("F1") + "%" : "—")</b>
+                                </MudText>
+                            </MudItem>
+                            <MudItem xs="6" sm="3">
+                                <MudText Typo="Typo.overline" Color="Color.Secondary">中期 429 率</MudText>
+                                <MudText Typo="Typo.body1" Color="@(_rcRate429Long > 0.03 ? Color.Warning : Color.Success)">
+                                    <b>@(_rcRate429Long >= 0 ? (_rcRate429Long * 100).ToString("F1") + "%" : "—")</b>
+                                </MudText>
+                            </MudItem>
+                        </MudGrid>
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+        }
+
         <!-- メトリクスグラフ（データが蓄積されたら表示） -->
         @if (_filesSeries.Count > 0)
         {
@@ -398,6 +440,30 @@ else
     private double _latestFilesPerMin;
     private string _elapsed = "—";        // 総経過時間（壁時計時間）
     private string _workingElapsed = "—"; // 実稼働時間（DB記録の累積秒数）
+
+    // ── RateControl 観測パネル ─────────────────────────────────────────────────
+    private bool _useRateControl;
+    private double _rcCurrentRate = -1;
+    private double _rcInFlight = -1;
+    private double _rcRate429Short = -1;
+    private double _rcRate429Long = -1;
+    private int _rcHysteresisStateCode; // 0=安定, 1=加速, 2=緩減速, 3=緊急減速
+
+    private string HysteresisLabel => _rcHysteresisStateCode switch
+    {
+        3 => "緊急減速",
+        2 => "緩減速",
+        1 => "加速",
+        _ => "安定"
+    };
+
+    private Color HysteresisColor => _rcHysteresisStateCode switch
+    {
+        3 => Color.Error,
+        2 => Color.Warning,
+        1 => Color.Success,
+        _ => Color.Default
+    };
     private string _eta = "—";
     private DateTimeOffset? _completedAt;
 
@@ -419,6 +485,17 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        // UseRateControl フラグを初回読み込み（次回ジョブ開始時に反映される設定）
+        try
+        {
+            var cfg = await ConfigService.GetConfigAsync();
+            _useRateControl = cfg.UseRateControl;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "UseRateControl 設定の読み込みに失敗しました。デフォルト false で動作します。");
+        }
+
         await RefreshAllAsync(CancellationToken.None);
         _refreshCts = new CancellationTokenSource();
         var token = _refreshCts.Token;
@@ -455,6 +532,7 @@ else
         await RefreshMetricsAsync(ct);
         await UpdateElapsedAndEtaAsync(ct);
         await RefreshFolderProgressAsync(ct);
+        if (_useRateControl) await RefreshRateControlMetricsAsync(ct);
     }
 
     private async Task RefreshPhaseAsync(CancellationToken ct)
@@ -488,6 +566,23 @@ else
 
         var folderCreationDone = await TransferStateDb.GetCheckpointAsync("folder_creation_complete", ct);
         _phase = folderCreationDone == "true" ? "transferring" : "folder_creation";
+    }
+
+    private async Task RefreshRateControlMetricsAsync(CancellationToken ct)
+    {
+        // 直近 2 分間のメトリクスから最新値を取得する（Controller が 1 秒ごとにエンキューしている）
+        const int windowMinutes = 2;
+        var rateData    = await TransferStateDb.GetMetricsAsync("current_rate_limit",    windowMinutes, ct);
+        var inflightData= await TransferStateDb.GetMetricsAsync("current_in_flight",     windowMinutes, ct);
+        var short429Data= await TransferStateDb.GetMetricsAsync("rate_429_short",        windowMinutes, ct);
+        var long429Data = await TransferStateDb.GetMetricsAsync("rate_429_long",         windowMinutes, ct);
+        var stateData   = await TransferStateDb.GetMetricsAsync("hysteresis_state_code", windowMinutes, ct);
+
+        if (rateData.Count > 0)     _rcCurrentRate  = rateData[^1].Value;
+        if (inflightData.Count > 0) _rcInFlight     = inflightData[^1].Value;
+        if (short429Data.Count > 0) _rcRate429Short = short429Data[^1].Value;
+        if (long429Data.Count > 0)  _rcRate429Long  = long429Data[^1].Value;
+        if (stateData.Count > 0)    _rcHysteresisStateCode = (int)Math.Round(stateData[^1].Value);
     }
 
     private async Task RefreshFolderProgressAsync(CancellationToken ct)

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -273,13 +273,13 @@ else
                             </MudItem>
                             <MudItem xs="6" sm="3">
                                 <MudText Typo="Typo.overline" Color="Color.Secondary">短期 429 率</MudText>
-                                <MudText Typo="Typo.body1" Color="@(_rcRate429Short >= _rcEmergencyThreshold && _rcRate429Short >= 0 ? Color.Error : _rcRate429Short >= _rcSlowdownThreshold && _rcRate429Short >= 0 ? Color.Warning : Color.Success)">
+                                <MudText Typo="Typo.body1" Color="@(_rcRate429Short < 0 ? Color.Default : _rcRate429Short >= _rcEmergencyThreshold ? Color.Error : _rcRate429Short >= _rcSlowdownThreshold ? Color.Warning : Color.Success)">
                                     <b>@(_rcRate429Short >= 0 ? (_rcRate429Short * 100).ToString("F1") + "%" : "—")</b>
                                 </MudText>
                             </MudItem>
                             <MudItem xs="6" sm="3">
                                 <MudText Typo="Typo.overline" Color="Color.Secondary">中期 429 率</MudText>
-                                <MudText Typo="Typo.body1" Color="@(_rcRate429Long >= _rcEmergencyThreshold && _rcRate429Long >= 0 ? Color.Error : _rcRate429Long >= _rcSlowdownThreshold && _rcRate429Long >= 0 ? Color.Warning : Color.Success)">
+                                <MudText Typo="Typo.body1" Color="@(_rcRate429Long < 0 ? Color.Default : _rcRate429Long >= _rcEmergencyThreshold ? Color.Error : _rcRate429Long >= _rcSlowdownThreshold ? Color.Warning : Color.Success)">
                                     <b>@(_rcRate429Long >= 0 ? (_rcRate429Long * 100).ToString("F1") + "%" : "—")</b>
                                 </MudText>
                             </MudItem>

--- a/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
@@ -103,7 +103,7 @@ else
                                        Color="Color.Primary" />
                             <MudText Typo="Typo.caption" Color="Color.Secondary">
                                 ON: レート（req/s）主体の新エンジン（RateControlledTransferController）を使用します。
-                                OFF: 旧来の並列数ベースエンジン（AdaptiveConcurrencyController）を使用します。
+                                OFF: 旧来の並列数ベースエンジンを使用します。動的並列制御（ACC）の有効/無効は下の設定で切り替えられます。
                                 設定変更は次回ジョブ開始時に反映されます。
                             </MudText>
                         </MudItem>
@@ -176,10 +176,10 @@ else
                             </MudItem>
                             <MudItem xs="12" sm="6">
                                 <MudNumericField @bind-Value="_editRcMaxConcurrency"
-                                                 Label="最大並行数（安全キャップ）"
+                                                 Label="最大並行数 / レート上限（安全キャップ）"
                                                  Min="1" Max="256"
                                                  Variant="Variant.Outlined"
-                                                 HelperText="レートが低くてもこの並列数を超えない。レート制御の補助上限。デフォルト: 16" />
+                                                 HelperText="並列数の上限であると同時に、req/sec のレート上限としても使用されます。デフォルト: 16" />
                             </MudItem>
                         }
                         else

--- a/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
@@ -135,16 +135,16 @@ else
                             <MudItem xs="12" sm="6">
                                 <MudNumericField @bind-Value="_editRcEmergencyThresholdPct"
                                                  Label="緊急減速閾値 (429 率 %)"
-                                                 Min="1" Max="100"
+                                                 Min="0" Max="100"
                                                  Variant="Variant.Outlined"
-                                                 HelperText="短期窓 429 率がこの値を超えると緊急減速。デフォルト: 10" />
+                                                 HelperText="短期窓 429 率がこの値を超えると緊急減速。0 = 常時緊急減速（無効化には 100 を推奨）。デフォルト: 10" />
                             </MudItem>
                             <MudItem xs="12" sm="6">
                                 <MudNumericField @bind-Value="_editRcSlowdownThresholdPct"
                                                  Label="緩減速閾値 (429 率 %)"
-                                                 Min="1" Max="100"
+                                                 Min="0" Max="100"
                                                  Variant="Variant.Outlined"
-                                                 HelperText="中期窓 429 率がこの値を超えると緩やかに減速。デフォルト: 3" />
+                                                 HelperText="中期窓 429 率がこの値を超えると緩やかに減速。0 = 常時緩減速。デフォルト: 3" />
                             </MudItem>
                             <MudItem xs="12" sm="6">
                                 <MudNumericField @bind-Value="_editRcDecayK"

--- a/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
@@ -144,7 +144,7 @@ else
                                                  Label="緩減速閾値 (429 率 %)"
                                                  Min="0" Max="100"
                                                  Variant="Variant.Outlined"
-                                                 HelperText="中期窓 429 率がこの値を超えると緩やかに減速。0 = 常時緩減速。デフォルト: 3" />
+                                                 HelperText="中期窓 429 率がこの値を超えると緩やかに減速。0% = 429 が 1 件でも発生すると緩減速（無効化には 100 を設定）。デフォルト: 3" />
                             </MudItem>
                             <MudItem xs="12" sm="6">
                                 <MudNumericField @bind-Value="_editRcDecayK"
@@ -426,7 +426,7 @@ else
             Snackbar.Add("増速インターバルは 30 / 60 / 90 / 120 秒から選択してください。", Severity.Warning);
             return;
         }
-        if (!_editUseRateControl && _editAdaptiveConcurrencyInitialDegree is < 0 or > 256)
+        if (!_editUseRateControl && _editAdaptiveConcurrencyEnabled && _editAdaptiveConcurrencyInitialDegree is < 0 or > 256)
         {
             Snackbar.Add("初期並列数は 0〜256 の範囲で入力してください。", Severity.Warning);
             return;

--- a/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
@@ -434,6 +434,7 @@ else
 
         try
         {
+            // 表示/非表示に関わらず常に _edit* 値を送信（トグル切替後も編集値を保持するため）
             var update = new ConfigUpdateDto(
                 MaxParallelTransfers: _editMaxParallelTransfers,
                 MaxParallelFolderCreations: _editMaxParallelFolderCreations,
@@ -441,23 +442,23 @@ else
                 LargeFileThresholdMb: _editLargeFileThresholdMb,
                 RetryCount: _editRetryCount,
                 TimeoutSec: _editTimeoutSec,
-                // UseRateControl=ON 時は ACC セクションは非表示なので現在設定値をそのまま保持、OFF 時は RC セクションを保持
-                AdaptiveConcurrencyEnabled: _editUseRateControl ? (_config?.AdaptiveConcurrencyEnabled ?? false) : _editAdaptiveConcurrencyEnabled,
-                AdaptiveConcurrencyInitialDegree: _editUseRateControl ? (_config?.AdaptiveConcurrencyInitialDegree ?? 0) : _editAdaptiveConcurrencyInitialDegree,
-                AdaptiveConcurrencyDecreasePercent: _editUseRateControl ? (_config?.AdaptiveConcurrencyDecreasePercent ?? 50) : _editAdaptiveConcurrencyDecreasePercent,
-                AdaptiveConcurrencyIncreaseIntervalSec: _editUseRateControl ? (_config?.AdaptiveConcurrencyIncreaseIntervalSec ?? 60) : _editAdaptiveConcurrencyIncreaseIntervalSec,
+                AdaptiveConcurrencyEnabled: _editAdaptiveConcurrencyEnabled,
+                AdaptiveConcurrencyInitialDegree: _editAdaptiveConcurrencyInitialDegree,
+                AdaptiveConcurrencyDecreasePercent: _editAdaptiveConcurrencyDecreasePercent,
+                AdaptiveConcurrencyIncreaseIntervalSec: _editAdaptiveConcurrencyIncreaseIntervalSec,
                 UseRateControl: _editUseRateControl,
-                RcShortWindowSec: _editUseRateControl ? _editRcShortWindowSec : (_config?.RcShortWindowSec ?? 5),
-                RcLongWindowSec: _editUseRateControl ? _editRcLongWindowSec : (_config?.RcLongWindowSec ?? 30),
-                RcEmergencyThresholdPct: _editUseRateControl ? _editRcEmergencyThresholdPct : (_config?.RcEmergencyThresholdPct ?? 10),
-                RcSlowdownThresholdPct: _editUseRateControl ? _editRcSlowdownThresholdPct : (_config?.RcSlowdownThresholdPct ?? 3),
-                RcDecayK: _editUseRateControl ? _editRcDecayK : (_config?.RcDecayK ?? 5.0),
-                RcMinDecayFactor: _editUseRateControl ? _editRcMinDecayFactor : (_config?.RcMinDecayFactor ?? 0.3),
-                RcMaxDecayFactor: _editUseRateControl ? _editRcMaxDecayFactor : (_config?.RcMaxDecayFactor ?? 0.9),
-                RcInFlightThreshold: _editUseRateControl ? _editRcInFlightThreshold : (_config?.RcInFlightThreshold ?? 32),
-                RcMaxConcurrency: _editUseRateControl ? _editRcMaxConcurrency : (_config?.RcMaxConcurrency ?? 16));
+                RcShortWindowSec: _editRcShortWindowSec,
+                RcLongWindowSec: _editRcLongWindowSec,
+                RcEmergencyThresholdPct: _editRcEmergencyThresholdPct,
+                RcSlowdownThresholdPct: _editRcSlowdownThresholdPct,
+                RcDecayK: _editRcDecayK,
+                RcMinDecayFactor: _editRcMinDecayFactor,
+                RcMaxDecayFactor: _editRcMaxDecayFactor,
+                RcInFlightThreshold: _editRcInFlightThreshold,
+                RcMaxConcurrency: _editRcMaxConcurrency);
             await ConfigService.UpdateConfigAsync(update);
             _config = await ConfigService.GetConfigAsync();
+            CopyToEditFields(_config);
             Snackbar.Add("設定を保存しました。", Severity.Success);
         }
         catch (Exception ex)

--- a/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
@@ -416,17 +416,17 @@ else
             Snackbar.Add("タイムアウトは 30〜3600 秒の範囲で入力してください。", Severity.Warning);
             return;
         }
-        if (_editAdaptiveConcurrencyEnabled && _editAdaptiveConcurrencyDecreasePercent is < 1 or > 99)
+        if (!_editUseRateControl && _editAdaptiveConcurrencyEnabled && _editAdaptiveConcurrencyDecreasePercent is < 1 or > 99)
         {
             Snackbar.Add("減速率は 1〜99 の範囲で入力してください。", Severity.Warning);
             return;
         }
-        if (_editAdaptiveConcurrencyEnabled && _editAdaptiveConcurrencyIncreaseIntervalSec is not (30 or 60 or 90 or 120))
+        if (!_editUseRateControl && _editAdaptiveConcurrencyEnabled && _editAdaptiveConcurrencyIncreaseIntervalSec is not (30 or 60 or 90 or 120))
         {
             Snackbar.Add("増速インターバルは 30 / 60 / 90 / 120 秒から選択してください。", Severity.Warning);
             return;
         }
-        if (_editAdaptiveConcurrencyInitialDegree is < 0 or > 256)
+        if (!_editUseRateControl && _editAdaptiveConcurrencyInitialDegree is < 0 or > 256)
         {
             Snackbar.Add("初期並列数は 0〜256 の範囲で入力してください。", Severity.Warning);
             return;

--- a/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
@@ -434,7 +434,9 @@ else
 
         try
         {
-            // 表示/非表示に関わらず常に _edit* 値を送信（トグル切替後も編集値を保持するため）
+            // 非表示セクションは null（UpdateConfigAsync が null フィールドをスキップするため現在値を維持）
+            // UseRateControl=ON: ACC フィールドを null → バリデーションと保存対象を一致させる
+            // UseRateControl=OFF: RC フィールドを null  → 同上
             var update = new ConfigUpdateDto(
                 MaxParallelTransfers: _editMaxParallelTransfers,
                 MaxParallelFolderCreations: _editMaxParallelFolderCreations,
@@ -442,20 +444,20 @@ else
                 LargeFileThresholdMb: _editLargeFileThresholdMb,
                 RetryCount: _editRetryCount,
                 TimeoutSec: _editTimeoutSec,
-                AdaptiveConcurrencyEnabled: _editAdaptiveConcurrencyEnabled,
-                AdaptiveConcurrencyInitialDegree: _editAdaptiveConcurrencyInitialDegree,
-                AdaptiveConcurrencyDecreasePercent: _editAdaptiveConcurrencyDecreasePercent,
-                AdaptiveConcurrencyIncreaseIntervalSec: _editAdaptiveConcurrencyIncreaseIntervalSec,
+                AdaptiveConcurrencyEnabled: _editUseRateControl ? null : _editAdaptiveConcurrencyEnabled,
+                AdaptiveConcurrencyInitialDegree: _editUseRateControl ? null : _editAdaptiveConcurrencyInitialDegree,
+                AdaptiveConcurrencyDecreasePercent: _editUseRateControl ? null : _editAdaptiveConcurrencyDecreasePercent,
+                AdaptiveConcurrencyIncreaseIntervalSec: _editUseRateControl ? null : _editAdaptiveConcurrencyIncreaseIntervalSec,
                 UseRateControl: _editUseRateControl,
-                RcShortWindowSec: _editRcShortWindowSec,
-                RcLongWindowSec: _editRcLongWindowSec,
-                RcEmergencyThresholdPct: _editRcEmergencyThresholdPct,
-                RcSlowdownThresholdPct: _editRcSlowdownThresholdPct,
-                RcDecayK: _editRcDecayK,
-                RcMinDecayFactor: _editRcMinDecayFactor,
-                RcMaxDecayFactor: _editRcMaxDecayFactor,
-                RcInFlightThreshold: _editRcInFlightThreshold,
-                RcMaxConcurrency: _editRcMaxConcurrency);
+                RcShortWindowSec: _editUseRateControl ? _editRcShortWindowSec : null,
+                RcLongWindowSec: _editUseRateControl ? _editRcLongWindowSec : null,
+                RcEmergencyThresholdPct: _editUseRateControl ? _editRcEmergencyThresholdPct : null,
+                RcSlowdownThresholdPct: _editUseRateControl ? _editRcSlowdownThresholdPct : null,
+                RcDecayK: _editUseRateControl ? _editRcDecayK : null,
+                RcMinDecayFactor: _editUseRateControl ? _editRcMinDecayFactor : null,
+                RcMaxDecayFactor: _editUseRateControl ? _editRcMaxDecayFactor : null,
+                RcInFlightThreshold: _editUseRateControl ? _editRcInFlightThreshold : null,
+                RcMaxConcurrency: _editUseRateControl ? _editRcMaxConcurrency : null);
             await ConfigService.UpdateConfigAsync(update);
             _config = await ConfigService.GetConfigAsync();
             CopyToEditFields(_config);

--- a/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
@@ -95,45 +95,138 @@ else
                         @* ── 動的並列制御 ────────────────────────────────── *@
                         <MudItem xs="12">
                             <MudDivider Class="my-2" />
-                            <MudText Typo="Typo.subtitle2" Class="mb-2">動的並列制御（レート制限対応）</MudText>
+                            <MudText Typo="Typo.subtitle2" Class="mb-2">転送制御エンジン</MudText>
                         </MudItem>
                         <MudItem xs="12">
-                            <MudSwitch @bind-Value="_editAdaptiveConcurrencyEnabled"
-                                       Label="動的並列制御を有効にする"
+                            <MudSwitch @bind-Value="_editUseRateControl"
+                                       Label="レートベース制御エンジンを使用する（推奨）"
                                        Color="Color.Primary" />
                             <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                Graph API から 429 を受信したとき、自動的に並列数を減らして再加速します。
-                                無効時は「最大並行転送数」の固定値で動作します。
+                                ON: レート（req/s）主体の新エンジン（RateControlledTransferController）を使用します。
+                                OFF: 旧来の並列数ベースエンジン（AdaptiveConcurrencyController）を使用します。
+                                設定変更は次回ジョブ開始時に反映されます。
                             </MudText>
                         </MudItem>
-                        @if (_editAdaptiveConcurrencyEnabled)
+
+                        @if (_editUseRateControl)
                         {
+                            @* ── レートベース制御パラメーター ──────────────────── *@
+                            <MudItem xs="12">
+                                <MudDivider Class="my-2" />
+                                <MudText Typo="Typo.subtitle2" Class="mb-2">レートベース制御パラメーター</MudText>
+                                <MudAlert Severity="Severity.Info" Dense="true" Class="mb-2">
+                                    すべての値は UI から変更可能です。変更は次回ジョブ開始時に反映されます。
+                                </MudAlert>
+                            </MudItem>
                             <MudItem xs="12" sm="6">
-                                <MudNumericField @bind-Value="_editAdaptiveConcurrencyInitialDegree"
-                                                 Label="初期並列数（0 = 最大と同じ）"
-                                                 Min="0" Max="256"
+                                <MudNumericField @bind-Value="_editRcShortWindowSec"
+                                                 Label="短期ウィンドウ (秒)"
+                                                 Min="1" Max="60"
                                                  Variant="Variant.Outlined"
-                                                 HelperText="0: 最大並行転送数から開始（スロースタートなし）。1〜n: その数から徐々に増加（スロースタート）。" />
+                                                 HelperText="スパイク検知・緊急減速のトリガーに使用。デフォルト: 5" />
                             </MudItem>
                             <MudItem xs="12" sm="6">
-                                <MudNumericField @bind-Value="_editAdaptiveConcurrencyDecreasePercent"
-                                                 Label="429 減速率 (%)"
-                                                 Min="1" Max="99"
+                                <MudNumericField @bind-Value="_editRcLongWindowSec"
+                                                 Label="中期ウィンドウ (秒)"
+                                                 Min="5" Max="300"
                                                  Variant="Variant.Outlined"
-                                                 HelperText="429 発生時に並列度をこの割合に削減します。例: 50 = 半減（MinDegree 下限）。デフォルト: 50" />
+                                                 HelperText="安定判断・レート調整のベース。デフォルト: 30" />
                             </MudItem>
                             <MudItem xs="12" sm="6">
-                                <MudSelect T="int"
-                                           @bind-Value="_editAdaptiveConcurrencyIncreaseIntervalSec"
-                                           Label="増速インターバル (秒)"
-                                           Variant="Variant.Outlined"
-                                           HelperText="429 後に並列度の回復を開始するまでの待機時間。デフォルト: 60 秒">
-                                    <MudSelectItem Value="30">30 秒</MudSelectItem>
-                                    <MudSelectItem Value="60">60 秒</MudSelectItem>
-                                    <MudSelectItem Value="90">90 秒</MudSelectItem>
-                                    <MudSelectItem Value="120">120 秒</MudSelectItem>
-                                </MudSelect>
+                                <MudNumericField @bind-Value="_editRcEmergencyThresholdPct"
+                                                 Label="緊急減速閾値 (429 率 %)"
+                                                 Min="1" Max="100"
+                                                 Variant="Variant.Outlined"
+                                                 HelperText="短期窓 429 率がこの値を超えると緊急減速。デフォルト: 10" />
                             </MudItem>
+                            <MudItem xs="12" sm="6">
+                                <MudNumericField @bind-Value="_editRcSlowdownThresholdPct"
+                                                 Label="緩減速閾値 (429 率 %)"
+                                                 Min="1" Max="100"
+                                                 Variant="Variant.Outlined"
+                                                 HelperText="中期窓 429 率がこの値を超えると緩やかに減速。デフォルト: 3" />
+                            </MudItem>
+                            <MudItem xs="12" sm="6">
+                                <MudNumericField @bind-Value="_editRcDecayK"
+                                                 Label="減衰係数 K"
+                                                 Min="0.1" Max="20.0" Step="0.5"
+                                                 Variant="Variant.Outlined"
+                                                 HelperText="factor = clamp(1 - K × 429率, min, max)。デフォルト: 5.0" />
+                            </MudItem>
+                            <MudItem xs="12" sm="6">
+                                <MudNumericField @bind-Value="_editRcMinDecayFactor"
+                                                 Label="最小減衰率"
+                                                 Min="0.05" Max="0.95" Step="0.05"
+                                                 Variant="Variant.Outlined"
+                                                 HelperText="減衰係数の下限（最大の減速）。デフォルト: 0.3" />
+                            </MudItem>
+                            <MudItem xs="12" sm="6">
+                                <MudNumericField @bind-Value="_editRcMaxDecayFactor"
+                                                 Label="最大減衰率"
+                                                 Min="0.05" Max="0.99" Step="0.05"
+                                                 Variant="Variant.Outlined"
+                                                 HelperText="減衰係数の上限（最小の減速）。デフォルト: 0.9" />
+                            </MudItem>
+                            <MudItem xs="12" sm="6">
+                                <MudNumericField @bind-Value="_editRcInFlightThreshold"
+                                                 Label="インフライト閾値"
+                                                 Min="1" Max="256"
+                                                 Variant="Variant.Outlined"
+                                                 HelperText="この値を超えると dispatch を一時停止（安全キャップ）。デフォルト: 32" />
+                            </MudItem>
+                            <MudItem xs="12" sm="6">
+                                <MudNumericField @bind-Value="_editRcMaxConcurrency"
+                                                 Label="最大並行数（安全キャップ）"
+                                                 Min="1" Max="256"
+                                                 Variant="Variant.Outlined"
+                                                 HelperText="レートが低くてもこの並列数を超えない。レート制御の補助上限。デフォルト: 16" />
+                            </MudItem>
+                        }
+                        else
+                        {
+                            @* ── 旧来の動的並列制御 ──────────────────────────── *@
+                            <MudItem xs="12">
+                                <MudDivider Class="my-2" />
+                                <MudText Typo="Typo.subtitle2" Class="mb-2">動的並列制御（レート制限対応）</MudText>
+                            </MudItem>
+                            <MudItem xs="12">
+                                <MudSwitch @bind-Value="_editAdaptiveConcurrencyEnabled"
+                                           Label="動的並列制御を有効にする"
+                                           Color="Color.Primary" />
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                    Graph API から 429 を受信したとき、自動的に並列数を減らして再加速します。
+                                    無効時は「最大並行転送数」の固定値で動作します。
+                                </MudText>
+                            </MudItem>
+                            @if (_editAdaptiveConcurrencyEnabled)
+                            {
+                                <MudItem xs="12" sm="6">
+                                    <MudNumericField @bind-Value="_editAdaptiveConcurrencyInitialDegree"
+                                                     Label="初期並列数（0 = 最大と同じ）"
+                                                     Min="0" Max="256"
+                                                     Variant="Variant.Outlined"
+                                                     HelperText="0: 最大並行転送数から開始（スロースタートなし）。1〜n: その数から徐々に増加（スロースタート）。" />
+                                </MudItem>
+                                <MudItem xs="12" sm="6">
+                                    <MudNumericField @bind-Value="_editAdaptiveConcurrencyDecreasePercent"
+                                                     Label="429 減速率 (%)"
+                                                     Min="1" Max="99"
+                                                     Variant="Variant.Outlined"
+                                                     HelperText="429 発生時に並列度をこの割合に削減します。例: 50 = 半減（MinDegree 下限）。デフォルト: 50" />
+                                </MudItem>
+                                <MudItem xs="12" sm="6">
+                                    <MudSelect T="int"
+                                               @bind-Value="_editAdaptiveConcurrencyIncreaseIntervalSec"
+                                               Label="増速インターバル (秒)"
+                                               Variant="Variant.Outlined"
+                                               HelperText="429 後に並列度の回復を開始するまでの待機時間。デフォルト: 60 秒">
+                                        <MudSelectItem Value="30">30 秒</MudSelectItem>
+                                        <MudSelectItem Value="60">60 秒</MudSelectItem>
+                                        <MudSelectItem Value="90">90 秒</MudSelectItem>
+                                        <MudSelectItem Value="120">120 秒</MudSelectItem>
+                                    </MudSelect>
+                                </MudItem>
+                            }
                         }
                     </MudGrid>
                 </MudExpansionPanel>
@@ -212,6 +305,17 @@ else
     private int _editAdaptiveConcurrencyInitialDegree;
     private int _editAdaptiveConcurrencyDecreasePercent;
     private int _editAdaptiveConcurrencyIncreaseIntervalSec;
+    // RateControl 編集フィールド
+    private bool _editUseRateControl;
+    private int _editRcShortWindowSec;
+    private int _editRcLongWindowSec;
+    private int _editRcEmergencyThresholdPct;
+    private int _editRcSlowdownThresholdPct;
+    private double _editRcDecayK;
+    private double _editRcMinDecayFactor;
+    private double _editRcMaxDecayFactor;
+    private int _editRcInFlightThreshold;
+    private int _editRcMaxConcurrency;
 
     protected override async Task OnInitializedAsync()
     {
@@ -267,6 +371,16 @@ else
         _editAdaptiveConcurrencyInitialDegree = cfg.AdaptiveConcurrencyInitialDegree;
         _editAdaptiveConcurrencyDecreasePercent = cfg.AdaptiveConcurrencyDecreasePercent;
         _editAdaptiveConcurrencyIncreaseIntervalSec = cfg.AdaptiveConcurrencyIncreaseIntervalSec;
+        _editUseRateControl = cfg.UseRateControl;
+        _editRcShortWindowSec = cfg.RcShortWindowSec;
+        _editRcLongWindowSec = cfg.RcLongWindowSec;
+        _editRcEmergencyThresholdPct = cfg.RcEmergencyThresholdPct;
+        _editRcSlowdownThresholdPct = cfg.RcSlowdownThresholdPct;
+        _editRcDecayK = cfg.RcDecayK;
+        _editRcMinDecayFactor = cfg.RcMinDecayFactor;
+        _editRcMaxDecayFactor = cfg.RcMaxDecayFactor;
+        _editRcInFlightThreshold = cfg.RcInFlightThreshold;
+        _editRcMaxConcurrency = cfg.RcMaxConcurrency;
     }
 
     private async Task SaveAsync()
@@ -330,7 +444,17 @@ else
                 AdaptiveConcurrencyEnabled: _editAdaptiveConcurrencyEnabled,
                 AdaptiveConcurrencyInitialDegree: _editAdaptiveConcurrencyInitialDegree,
                 AdaptiveConcurrencyDecreasePercent: _editAdaptiveConcurrencyDecreasePercent,
-                AdaptiveConcurrencyIncreaseIntervalSec: _editAdaptiveConcurrencyIncreaseIntervalSec);
+                AdaptiveConcurrencyIncreaseIntervalSec: _editAdaptiveConcurrencyIncreaseIntervalSec,
+                UseRateControl: _editUseRateControl,
+                RcShortWindowSec: _editRcShortWindowSec,
+                RcLongWindowSec: _editRcLongWindowSec,
+                RcEmergencyThresholdPct: _editRcEmergencyThresholdPct,
+                RcSlowdownThresholdPct: _editRcSlowdownThresholdPct,
+                RcDecayK: _editRcDecayK,
+                RcMinDecayFactor: _editRcMinDecayFactor,
+                RcMaxDecayFactor: _editRcMaxDecayFactor,
+                RcInFlightThreshold: _editRcInFlightThreshold,
+                RcMaxConcurrency: _editRcMaxConcurrency);
             await ConfigService.UpdateConfigAsync(update);
             _config = await ConfigService.GetConfigAsync();
             Snackbar.Add("設定を保存しました。", Severity.Success);

--- a/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
@@ -137,7 +137,7 @@ else
                                                  Label="緊急減速閾値 (429 率 %)"
                                                  Min="0" Max="100"
                                                  Variant="Variant.Outlined"
-                                                 HelperText="短期窓 429 率がこの値を超えると緊急減速。0 = 常時緊急減速（無効化には 100 を推奨）。デフォルト: 10" />
+                                                 HelperText="短期窓 429 率がこの値を超えると緊急減速。0% = 429 が 1 件でも発生すると緊急減速（無効化には 100 を設定）。デフォルト: 10" />
                             </MudItem>
                             <MudItem xs="12" sm="6">
                                 <MudNumericField @bind-Value="_editRcSlowdownThresholdPct"
@@ -441,20 +441,21 @@ else
                 LargeFileThresholdMb: _editLargeFileThresholdMb,
                 RetryCount: _editRetryCount,
                 TimeoutSec: _editTimeoutSec,
-                AdaptiveConcurrencyEnabled: _editAdaptiveConcurrencyEnabled,
-                AdaptiveConcurrencyInitialDegree: _editAdaptiveConcurrencyInitialDegree,
-                AdaptiveConcurrencyDecreasePercent: _editAdaptiveConcurrencyDecreasePercent,
-                AdaptiveConcurrencyIncreaseIntervalSec: _editAdaptiveConcurrencyIncreaseIntervalSec,
+                // UseRateControl=ON 時は ACC セクションは非表示なので現在設定値をそのまま保持、OFF 時は RC セクションを保持
+                AdaptiveConcurrencyEnabled: _editUseRateControl ? (_config?.AdaptiveConcurrencyEnabled ?? false) : _editAdaptiveConcurrencyEnabled,
+                AdaptiveConcurrencyInitialDegree: _editUseRateControl ? (_config?.AdaptiveConcurrencyInitialDegree ?? 0) : _editAdaptiveConcurrencyInitialDegree,
+                AdaptiveConcurrencyDecreasePercent: _editUseRateControl ? (_config?.AdaptiveConcurrencyDecreasePercent ?? 25) : _editAdaptiveConcurrencyDecreasePercent,
+                AdaptiveConcurrencyIncreaseIntervalSec: _editUseRateControl ? (_config?.AdaptiveConcurrencyIncreaseIntervalSec ?? 60) : _editAdaptiveConcurrencyIncreaseIntervalSec,
                 UseRateControl: _editUseRateControl,
-                RcShortWindowSec: _editRcShortWindowSec,
-                RcLongWindowSec: _editRcLongWindowSec,
-                RcEmergencyThresholdPct: _editRcEmergencyThresholdPct,
-                RcSlowdownThresholdPct: _editRcSlowdownThresholdPct,
-                RcDecayK: _editRcDecayK,
-                RcMinDecayFactor: _editRcMinDecayFactor,
-                RcMaxDecayFactor: _editRcMaxDecayFactor,
-                RcInFlightThreshold: _editRcInFlightThreshold,
-                RcMaxConcurrency: _editRcMaxConcurrency);
+                RcShortWindowSec: _editUseRateControl ? _editRcShortWindowSec : (_config?.RcShortWindowSec ?? 5),
+                RcLongWindowSec: _editUseRateControl ? _editRcLongWindowSec : (_config?.RcLongWindowSec ?? 30),
+                RcEmergencyThresholdPct: _editUseRateControl ? _editRcEmergencyThresholdPct : (_config?.RcEmergencyThresholdPct ?? 10),
+                RcSlowdownThresholdPct: _editUseRateControl ? _editRcSlowdownThresholdPct : (_config?.RcSlowdownThresholdPct ?? 3),
+                RcDecayK: _editUseRateControl ? _editRcDecayK : (_config?.RcDecayK ?? 5.0),
+                RcMinDecayFactor: _editUseRateControl ? _editRcMinDecayFactor : (_config?.RcMinDecayFactor ?? 0.3),
+                RcMaxDecayFactor: _editUseRateControl ? _editRcMaxDecayFactor : (_config?.RcMaxDecayFactor ?? 1.0),
+                RcInFlightThreshold: _editUseRateControl ? _editRcInFlightThreshold : (_config?.RcInFlightThreshold ?? 32),
+                RcMaxConcurrency: _editUseRateControl ? _editRcMaxConcurrency : (_config?.RcMaxConcurrency ?? 16));
             await ConfigService.UpdateConfigAsync(update);
             _config = await ConfigService.GetConfigAsync();
             Snackbar.Add("設定を保存しました。", Severity.Success);

--- a/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
@@ -444,7 +444,7 @@ else
                 // UseRateControl=ON 時は ACC セクションは非表示なので現在設定値をそのまま保持、OFF 時は RC セクションを保持
                 AdaptiveConcurrencyEnabled: _editUseRateControl ? (_config?.AdaptiveConcurrencyEnabled ?? false) : _editAdaptiveConcurrencyEnabled,
                 AdaptiveConcurrencyInitialDegree: _editUseRateControl ? (_config?.AdaptiveConcurrencyInitialDegree ?? 0) : _editAdaptiveConcurrencyInitialDegree,
-                AdaptiveConcurrencyDecreasePercent: _editUseRateControl ? (_config?.AdaptiveConcurrencyDecreasePercent ?? 25) : _editAdaptiveConcurrencyDecreasePercent,
+                AdaptiveConcurrencyDecreasePercent: _editUseRateControl ? (_config?.AdaptiveConcurrencyDecreasePercent ?? 50) : _editAdaptiveConcurrencyDecreasePercent,
                 AdaptiveConcurrencyIncreaseIntervalSec: _editUseRateControl ? (_config?.AdaptiveConcurrencyIncreaseIntervalSec ?? 60) : _editAdaptiveConcurrencyIncreaseIntervalSec,
                 UseRateControl: _editUseRateControl,
                 RcShortWindowSec: _editUseRateControl ? _editRcShortWindowSec : (_config?.RcShortWindowSec ?? 5),
@@ -453,7 +453,7 @@ else
                 RcSlowdownThresholdPct: _editUseRateControl ? _editRcSlowdownThresholdPct : (_config?.RcSlowdownThresholdPct ?? 3),
                 RcDecayK: _editUseRateControl ? _editRcDecayK : (_config?.RcDecayK ?? 5.0),
                 RcMinDecayFactor: _editUseRateControl ? _editRcMinDecayFactor : (_config?.RcMinDecayFactor ?? 0.3),
-                RcMaxDecayFactor: _editUseRateControl ? _editRcMaxDecayFactor : (_config?.RcMaxDecayFactor ?? 1.0),
+                RcMaxDecayFactor: _editUseRateControl ? _editRcMaxDecayFactor : (_config?.RcMaxDecayFactor ?? 0.9),
                 RcInFlightThreshold: _editUseRateControl ? _editRcInFlightThreshold : (_config?.RcInFlightThreshold ?? 32),
                 RcMaxConcurrency: _editUseRateControl ? _editRcMaxConcurrency : (_config?.RcMaxConcurrency ?? 16));
             await ConfigService.UpdateConfigAsync(update);


### PR DESCRIPTION
Closes #149

## 概要

v0.5.0 で実装された `RateControlledTransferController` の UI 側が未実装だった部分を補完します。

## 変更内容

### `ConfigurationService.cs`
- `ConfigDto` / `ConfigUpdateDto` に `rateControl` セクション対応の 10 フィールドを追加
  - `UseRateControl`, `RcShortWindowSec`, `RcLongWindowSec`, `RcEmergencyThresholdPct`, `RcSlowdownThresholdPct`, `RcDecayK`, `RcMinDecayFactor`, `RcMaxDecayFactor`, `RcInFlightThreshold`, `RcMaxConcurrency`
- `GetConfigAsync` / `UpdateConfigAsync` で `config.json` の `migrator.rateControl` セクションを読み書き
  - `emergencyThreshold` / `slowdownThreshold` は JSON: 0-1 ↔ UI: 0-100% の変換あり

### `RateControlledTransferController.cs`
- `AdjustRate` の戻り値を `(double newRate, string action, int stateCode)` に変更し、各分岐でヒステリシス状態コード（0=安定/1=加速/2=緩減速/3=緊急減速）を直接返す
- stateCode を `hysteresis_state_code` として `MetricsBuffer` に書き込む

### `SettingsPage.razor`
- エンジン切り替えトグル（`UseRateControl`）を設定画面に追加
- `UseRateControl=ON` 時に RateControl パラメーター 9 個（ShortWindowSec, LongWindowSec, EmergencyThreshold%, SlowdownThreshold%, DecayK, MinDecayFactor, MaxDecayFactor, InFlightThreshold, MaxConcurrency）の編集 UI を表示
- `UseRateControl=OFF` 時は既存の AdaptiveConcurrency セクションを表示
- 全フィールドに「設定変更は次回ジョブ開始時に反映されます。」の案内を追加

### `App.xaml.cs`
- `Func<MigratorOptions>` ファクトリを DI に singleton 登録
  - 呼ぶたびに `AppConfiguration.Build()`（環境変数 > config.json > デフォルト優先）で最新設定を取得
  - config.json 破損等で例外が発生した場合は `new MigratorOptions()` にフォールバック
- `MigrationWork` で `UseRateControl=true` のとき `RateControlledTransferController` / `MetricsBuffer` を構築してパイプラインに渡す

### `DashboardPage.razor`
- `Func<MigratorOptions> OptionsFactory` を DI インジェクト
- `RefreshAllAsync`（5 秒ポーリング）の先頭で `OptionsFactory()` を呼び出し、`UseRateControl` フラグ・閾値を毎回最新設定から取得（環境変数オーバーライドにも対応）
  - `OptionsFactory()` 呼び出しは try/catch で保護し、失敗時は前回値を維持して `LogWarning` に記録
- `UseRateControl=true` 時のみ表示する **レートベース制御 リアルタイムモニターパネル** を追加
  - 現在レート上限 (req/s)
  - インフライト数
  - 短期 429 率 (%)
  - 中期 429 率 (%)
  - ヒステリシス状態バッジ（安定/加速/緩減速/緊急減速）
- `RefreshRateControlMetricsAsync` メソッドを追加し、5 秒ポーリングで DB から最新メトリクスを取得

## 設計上の注意

- **設定変更は次回ジョブ開始時に反映** — 実行中ジョブへのホットリロードは行わない
- ヒステリシス状態は `ITransferRateController` インターフェースには追加せず、`MetricsBuffer → DB → TransferStateDb.GetMetricsAsync` の既存パイプライン経由で取得する
- Dashboard のポーリングは `Func<MigratorOptions>` ファクトリ経由で設定を都度解決するため、SettingsPage での設定変更が 5 秒以内に観測パネル表示に追従する