### PR TITLE
fix: PR #150 レビュー defer 回収 - RateControl バリデーション・テスト・DB 最適化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,9 @@ publish/
 .store/
 .husky-bin/
 
+# Claude Code
+.claude/
+
 # 実行時生成ファイル
 logs/
 .env

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <!--
+            カバレッジ計測対象外のコード（UI 層・インフラ層）:
+            - Blazor Razor コンポーネント: bUnit なしではユニットテスト不可
+            - WPF ブートストラップ / ウィンドウ: WPF ランタイム依存
+            - CLI エントリポイント / 合成ルート: 実行環境依存
+          -->
+          <ExcludeByFile>
+            **/CloudMigrator.Dashboard/Components/**,
+            **/CloudMigrator.Dashboard/App.xaml.cs,
+            **/CloudMigrator.Dashboard/MainWindow.xaml.cs,
+            **/CloudMigrator.Dashboard/WpfDialogService.cs,
+            **/CloudMigrator.Dashboard/obj/**,
+            **/CloudMigrator.Cli/CliServices.cs,
+            **/CloudMigrator.Cli/Commands/DashboardCommand.cs,
+            **/CloudMigrator.Cli/Program.cs,
+            **/CloudMigrator.Setup.Cli/Program.cs
+          </ExcludeByFile>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
@@ -232,6 +232,32 @@ public sealed class ConfigurationService : IConfigurationService
     /// <inheritdoc />
     public async Task UpdateConfigAsync(ConfigUpdateDto update, CancellationToken ct = default)
     {
+        // rateControl バリデーション（保存前に検証し、無効値が config.json に書き込まれるのを防ぐ）
+        if (update.RcShortWindowSec.HasValue && update.RcShortWindowSec.Value < 1)
+            throw new ArgumentException("RcShortWindowSec は 1 以上である必要があります。", nameof(update));
+        if (update.RcLongWindowSec.HasValue && update.RcLongWindowSec.Value < 5)
+            throw new ArgumentException("RcLongWindowSec は 5 以上である必要があります。", nameof(update));
+        if (update.RcShortWindowSec.HasValue && update.RcLongWindowSec.HasValue
+            && update.RcShortWindowSec.Value >= update.RcLongWindowSec.Value)
+            throw new ArgumentException(
+                "RcShortWindowSec は RcLongWindowSec より小さい値にしてください。", nameof(update));
+        if (update.RcEmergencyThresholdPct.HasValue && update.RcEmergencyThresholdPct.Value is < 0 or > 100)
+            throw new ArgumentException("RcEmergencyThresholdPct は 0〜100 の範囲で入力してください。", nameof(update));
+        if (update.RcSlowdownThresholdPct.HasValue && update.RcSlowdownThresholdPct.Value is < 0 or > 100)
+            throw new ArgumentException("RcSlowdownThresholdPct は 0〜100 の範囲で入力してください。", nameof(update));
+        if (update.RcMinDecayFactor.HasValue && update.RcMinDecayFactor.Value is < 0 or > 1)
+            throw new ArgumentException("RcMinDecayFactor は 0〜1 の範囲で入力してください。", nameof(update));
+        if (update.RcMaxDecayFactor.HasValue && update.RcMaxDecayFactor.Value is < 0 or > 1)
+            throw new ArgumentException("RcMaxDecayFactor は 0〜1 の範囲で入力してください。", nameof(update));
+        if (update.RcMinDecayFactor.HasValue && update.RcMaxDecayFactor.HasValue
+            && update.RcMinDecayFactor.Value >= update.RcMaxDecayFactor.Value)
+            throw new ArgumentException(
+                "RcMinDecayFactor は RcMaxDecayFactor より小さい値にしてください。", nameof(update));
+        if (update.RcInFlightThreshold.HasValue && update.RcInFlightThreshold.Value < 1)
+            throw new ArgumentException("RcInFlightThreshold は 1 以上である必要があります。", nameof(update));
+        if (update.RcMaxConcurrency.HasValue && update.RcMaxConcurrency.Value < 1)
+            throw new ArgumentException("RcMaxConcurrency は 1 以上である必要があります。", nameof(update));
+
         await _writeLock.WaitAsync(ct).ConfigureAwait(false);
         try
         {

--- a/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
@@ -232,15 +232,11 @@ public sealed class ConfigurationService : IConfigurationService
     /// <inheritdoc />
     public async Task UpdateConfigAsync(ConfigUpdateDto update, CancellationToken ct = default)
     {
-        // rateControl バリデーション（保存前に検証し、無効値が config.json に書き込まれるのを防ぐ）
+        // 単一フィールド範囲チェック（ロック外でフェイルファスト）
         if (update.RcShortWindowSec.HasValue && update.RcShortWindowSec.Value < 1)
             throw new ArgumentException("RcShortWindowSec は 1 以上である必要があります。", nameof(update));
         if (update.RcLongWindowSec.HasValue && update.RcLongWindowSec.Value < 5)
             throw new ArgumentException("RcLongWindowSec は 5 以上である必要があります。", nameof(update));
-        if (update.RcShortWindowSec.HasValue && update.RcLongWindowSec.HasValue
-            && update.RcShortWindowSec.Value >= update.RcLongWindowSec.Value)
-            throw new ArgumentException(
-                "RcShortWindowSec は RcLongWindowSec より小さい値にしてください。", nameof(update));
         if (update.RcEmergencyThresholdPct.HasValue && update.RcEmergencyThresholdPct.Value is < 0 or > 100)
             throw new ArgumentException("RcEmergencyThresholdPct は 0〜100 の範囲で入力してください。", nameof(update));
         if (update.RcSlowdownThresholdPct.HasValue && update.RcSlowdownThresholdPct.Value is < 0 or > 100)
@@ -249,10 +245,6 @@ public sealed class ConfigurationService : IConfigurationService
             throw new ArgumentException("RcMinDecayFactor は 0〜1 の範囲で入力してください。", nameof(update));
         if (update.RcMaxDecayFactor.HasValue && update.RcMaxDecayFactor.Value is < 0 or > 1)
             throw new ArgumentException("RcMaxDecayFactor は 0〜1 の範囲で入力してください。", nameof(update));
-        if (update.RcMinDecayFactor.HasValue && update.RcMaxDecayFactor.HasValue
-            && update.RcMinDecayFactor.Value >= update.RcMaxDecayFactor.Value)
-            throw new ArgumentException(
-                "RcMinDecayFactor は RcMaxDecayFactor より小さい値にしてください。", nameof(update));
         if (update.RcInFlightThreshold.HasValue && update.RcInFlightThreshold.Value < 1)
             throw new ArgumentException("RcInFlightThreshold は 1 以上である必要があります。", nameof(update));
         if (update.RcMaxConcurrency.HasValue && update.RcMaxConcurrency.Value < 1)
@@ -266,6 +258,31 @@ public sealed class ConfigurationService : IConfigurationService
                 ?? throw new InvalidOperationException("config.json のパースに失敗しました。");
             var m = root["migrator"]?.AsObject()
                 ?? throw new InvalidOperationException("config.json に migrator セクションが存在しません。");
+
+            // クロスフィールドバリデーション: update と現在の config.json をマージした「実際に保存される値」で検証する
+            // 片方だけ更新するケースでも既存値との組み合わせが不正にならないよう保護する
+            if (update.RcShortWindowSec.HasValue || update.RcLongWindowSec.HasValue)
+            {
+                var rcForValidation = m["rateControl"] as JsonObject;
+                var effectiveShort = update.RcShortWindowSec
+                    ?? (rcForValidation?["shortWindowSec"] is JsonNode sn ? sn.GetValue<int>() : 5);
+                var effectiveLong = update.RcLongWindowSec
+                    ?? (rcForValidation?["longWindowSec"] is JsonNode ln ? ln.GetValue<int>() : 30);
+                if (effectiveShort >= effectiveLong)
+                    throw new ArgumentException(
+                        "RcShortWindowSec は RcLongWindowSec より小さい値にしてください。", nameof(update));
+            }
+            if (update.RcMinDecayFactor.HasValue || update.RcMaxDecayFactor.HasValue)
+            {
+                var rcForValidation = m["rateControl"] as JsonObject;
+                var effectiveMin = update.RcMinDecayFactor
+                    ?? (rcForValidation?["minDecayFactor"] is JsonNode mn ? mn.GetValue<double>() : 0.3);
+                var effectiveMax = update.RcMaxDecayFactor
+                    ?? (rcForValidation?["maxDecayFactor"] is JsonNode mx ? mx.GetValue<double>() : 0.9);
+                if (effectiveMin >= effectiveMax)
+                    throw new ArgumentException(
+                        "RcMinDecayFactor は RcMaxDecayFactor より小さい値にしてください。", nameof(update));
+            }
 
             if (update.MaxParallelTransfers.HasValue) m["maxParallelTransfers"] = update.MaxParallelTransfers.Value;
             if (update.MaxParallelFolderCreations.HasValue) m["maxParallelFolderCreations"] = update.MaxParallelFolderCreations.Value;

--- a/src/CloudMigrator.Core/State/ITransferStateDb.cs
+++ b/src/CloudMigrator.Core/State/ITransferStateDb.cs
@@ -92,6 +92,13 @@ public interface ITransferStateDb : IAsyncDisposable
     Task<IReadOnlyList<MetricPoint>> GetMetricsAsync(string name, int recentMinutes, CancellationToken ct);
 
     /// <summary>
+    /// 複数メトリクスの最新値を一括取得する（1 クエリ）。
+    /// 直近 <paramref name="recentMinutes"/> 分以内のデータが対象。存在しない名前のエントリは結果に含まれない。
+    /// </summary>
+    Task<IReadOnlyDictionary<string, double>> GetLatestMetricsAsync(
+        IEnumerable<string> names, int recentMinutes, CancellationToken ct);
+
+    /// <summary>
     /// 全テーブルのデータを削除してリセットする（--full-rebuild / 設定変更時）。
     /// ファイル削除ではなく SQL で消去するため、ダッシュボードが DB を開いたままでも実行可能。
     /// テーブル定義は保持される。

--- a/src/CloudMigrator.Core/State/NullTransferStateDb.cs
+++ b/src/CloudMigrator.Core/State/NullTransferStateDb.cs
@@ -28,6 +28,7 @@ public sealed class NullTransferStateDb : ITransferStateDb
     public Task RecordMetricAsync(string name, double value, CancellationToken ct) => Task.CompletedTask;
     public Task RecordMetricsBatchAsync(IEnumerable<(string Name, double Value, DateTimeOffset Timestamp)> snapshots, CancellationToken ct) => Task.CompletedTask;
     public Task<IReadOnlyList<MetricPoint>> GetMetricsAsync(string name, int recentMinutes, CancellationToken ct) => Task.FromResult<IReadOnlyList<MetricPoint>>([]);
+    public Task<IReadOnlyDictionary<string, double>> GetLatestMetricsAsync(IEnumerable<string> names, int recentMinutes, CancellationToken ct) => Task.FromResult<IReadOnlyDictionary<string, double>>(new Dictionary<string, double>());
     public Task ResetAllAsync(CancellationToken ct) => Task.CompletedTask;
     public Task<bool> InsertPendingIfNewAsync(StorageItem item, CancellationToken ct) => Task.FromResult(false);
     public Task InsertDoneIfNotExistsAsync(string path, string name, CancellationToken ct) => Task.CompletedTask;

--- a/src/CloudMigrator.Core/State/SqliteTransferStateDb.cs
+++ b/src/CloudMigrator.Core/State/SqliteTransferStateDb.cs
@@ -684,6 +684,50 @@ public sealed class SqliteTransferStateDb : ITransferStateDb
         }
     }
 
+    /// <inheritdoc/>
+    public async Task<IReadOnlyDictionary<string, double>> GetLatestMetricsAsync(
+        IEnumerable<string> names, int recentMinutes, CancellationToken ct)
+    {
+        var nameList = names.ToList();
+        if (nameList.Count == 0)
+            return new Dictionary<string, double>();
+
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await using var cmd = _conn.CreateCommand();
+            var cutoff = DateTimeOffset.UtcNow.AddMinutes(-recentMinutes).ToString("O");
+            var paramNames = nameList.Select((_, i) => $"@n{i}").ToList();
+
+            cmd.CommandText = $"""
+                SELECT m.name, m.value
+                FROM metrics m
+                INNER JOIN (
+                    SELECT name, MAX(timestamp) AS latest_ts
+                    FROM metrics
+                    WHERE name IN ({string.Join(", ", paramNames)})
+                      AND timestamp >= @cutoff
+                    GROUP BY name
+                ) latest ON m.name = latest.name AND m.timestamp = latest.latest_ts
+                """;
+
+            for (var i = 0; i < nameList.Count; i++)
+                cmd.Parameters.AddWithValue($"@n{i}", nameList[i]);
+            cmd.Parameters.AddWithValue("@cutoff", cutoff);
+
+            var results = new Dictionary<string, double>(nameList.Count);
+            await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+                results[reader.GetString(0)] = reader.GetDouble(1);
+
+            return results;
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
     internal static TransferStatus ParseStatus(string status) => status switch
     {
         "pending" => TransferStatus.Pending,

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -714,28 +714,9 @@ else
         _                   => Color.Default,
     };
 
-    private static string FormatDuration(double seconds)
-    {
-        var sec = (int)Math.Round(Math.Abs(seconds));
-        if (sec < 60) return $"{sec}秒";
-        if (sec < 3600) return $"{sec / 60}m{sec % 60:D2}s";
-        return $"{sec / 3600}h{sec % 3600 / 60:D2}m";
-    }
-
-    private static string FormatBytes(long bytes) => bytes switch
-    {
-        >= 1_073_741_824 => $"{bytes / 1_073_741_824.0:F1} GB",
-        >= 1_048_576     => $"{bytes / 1_048_576.0:F1} MB",
-        >= 1_024         => $"{bytes / 1_024.0:F1} KB",
-        _                => $"{bytes} B",
-    };
-
-    private static string FormatBytesPerSec(double v) => v switch
-    {
-        >= 1_048_576 => $"{v / 1_048_576:F1} MB/s",
-        >= 1_024     => $"{v / 1_024:F1} KB/s",
-        _            => $"{v:F0} B/s",
-    };
+    private static string FormatDuration(double seconds)    => DashboardFormatHelper.FormatDuration(seconds);
+    private static string FormatBytes(long bytes)           => DashboardFormatHelper.FormatBytes(bytes);
+    private static string FormatBytesPerSec(double v)       => DashboardFormatHelper.FormatBytesPerSec(v);
 
     public void Dispose()
     {

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -572,22 +572,20 @@ else
 
     private async Task RefreshRateControlMetricsAsync(CancellationToken ct)
     {
-        // 直近 2 分間のメトリクスから最新値を取得する（Controller が 1 秒ごとにエンキューしている）
+        // 直近 2 分間のメトリクスから最新値を 1 クエリで一括取得する
         // 例外発生時はログに残してスキップ（PeriodicTimer ループが停止しないよう保護）
         try
         {
             const int windowMinutes = 2;
-            var rateData    = await TransferStateDb.GetMetricsAsync("current_rate_limit",    windowMinutes, ct);
-            var inflightData= await TransferStateDb.GetMetricsAsync("current_in_flight",     windowMinutes, ct);
-            var short429Data= await TransferStateDb.GetMetricsAsync("rate_429_short",        windowMinutes, ct);
-            var long429Data = await TransferStateDb.GetMetricsAsync("rate_429_long",         windowMinutes, ct);
-            var stateData   = await TransferStateDb.GetMetricsAsync("hysteresis_state_code", windowMinutes, ct);
+            var latest = await TransferStateDb.GetLatestMetricsAsync(
+                ["current_rate_limit", "current_in_flight", "rate_429_short", "rate_429_long", "hysteresis_state_code"],
+                windowMinutes, ct);
 
-            if (rateData.Count > 0)     _rcCurrentRate  = rateData[^1].Value;
-            if (inflightData.Count > 0) _rcInFlight     = inflightData[^1].Value;
-            if (short429Data.Count > 0) _rcRate429Short = short429Data[^1].Value;
-            if (long429Data.Count > 0)  _rcRate429Long  = long429Data[^1].Value;
-            if (stateData.Count > 0)    _rcHysteresisStateCode = (int)Math.Round(stateData[^1].Value); // 0–3
+            if (latest.TryGetValue("current_rate_limit",    out var rate))    _rcCurrentRate         = rate;
+            if (latest.TryGetValue("current_in_flight",     out var inFlight))_rcInFlight            = inFlight;
+            if (latest.TryGetValue("rate_429_short",        out var s429))    _rcRate429Short        = s429;
+            if (latest.TryGetValue("rate_429_long",         out var l429))    _rcRate429Long         = l429;
+            if (latest.TryGetValue("hysteresis_state_code", out var state))   _rcHysteresisStateCode = (int)Math.Round(state); // 0–3
         }
         catch (OperationCanceledException)
         {

--- a/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
@@ -385,60 +385,22 @@ else
 
     private async Task SaveAsync()
     {
-        // 保存前バリデーション
-        if (_editMaxParallelTransfers is < 1 or > 256)
+        // 保存前バリデーション（SettingsValidation に委譲）
+        var err =
+            SettingsValidation.ValidateMaxParallelTransfers(_editMaxParallelTransfers) ??
+            SettingsValidation.ValidateMaxParallelFolderCreations(_editMaxParallelFolderCreations) ??
+            SettingsValidation.ValidateChunkSizeMb(_editChunkSizeMb) ??
+            SettingsValidation.ValidateLargeFileThresholdMb(_editLargeFileThresholdMb) ??
+            SettingsValidation.ValidateRetryCount(_editRetryCount) ??
+            SettingsValidation.ValidateTimeoutSec(_editTimeoutSec) ??
+            SettingsValidation.ValidateRcWindowSecs(_editUseRateControl, _editRcShortWindowSec, _editRcLongWindowSec) ??
+            SettingsValidation.ValidateRcDecayFactors(_editUseRateControl, _editRcMinDecayFactor, _editRcMaxDecayFactor) ??
+            SettingsValidation.ValidateAdaptiveDecreasePercent(_editUseRateControl, _editAdaptiveConcurrencyEnabled, _editAdaptiveConcurrencyDecreasePercent) ??
+            SettingsValidation.ValidateAdaptiveIncreaseIntervalSec(_editUseRateControl, _editAdaptiveConcurrencyEnabled, _editAdaptiveConcurrencyIncreaseIntervalSec) ??
+            SettingsValidation.ValidateAdaptiveInitialDegree(_editUseRateControl, _editAdaptiveConcurrencyEnabled, _editAdaptiveConcurrencyInitialDegree);
+        if (err is not null)
         {
-            Snackbar.Add("最大並行転送数は 1〜256 の範囲で入力してください。", Severity.Warning);
-            return;
-        }
-        if (_editMaxParallelFolderCreations is < 1 or > 32)
-        {
-            Snackbar.Add("最大並行フォルダ作成数は 1〜32 の範囲で入力してください。", Severity.Warning);
-            return;
-        }
-        if (_editChunkSizeMb is < 1 or > 100)
-        {
-            Snackbar.Add("チャンクサイズは 1〜100 MB の範囲で入力してください。", Severity.Warning);
-            return;
-        }
-        if (_editLargeFileThresholdMb is < 1 or > 100)
-        {
-            Snackbar.Add("大ファイル閾値は 1〜100 MB の範囲で入力してください。", Severity.Warning);
-            return;
-        }
-        if (_editRetryCount is < 0 or > 10)
-        {
-            Snackbar.Add("リトライ回数は 0〜10 の範囲で入力してください。", Severity.Warning);
-            return;
-        }
-        if (_editTimeoutSec is < 30 or > 3600)
-        {
-            Snackbar.Add("タイムアウトは 30〜3600 秒の範囲で入力してください。", Severity.Warning);
-            return;
-        }
-        if (_editUseRateControl && _editRcShortWindowSec >= _editRcLongWindowSec)
-        {
-            Snackbar.Add("短期ウィンドウ (秒) は中期ウィンドウ (秒) より小さい値にしてください。", Severity.Warning);
-            return;
-        }
-        if (_editUseRateControl && _editRcMinDecayFactor >= _editRcMaxDecayFactor)
-        {
-            Snackbar.Add("最小減衰率は最大減衰率より小さい値にしてください。", Severity.Warning);
-            return;
-        }
-        if (!_editUseRateControl && _editAdaptiveConcurrencyEnabled && _editAdaptiveConcurrencyDecreasePercent is < 1 or > 99)
-        {
-            Snackbar.Add("減速率は 1〜99 の範囲で入力してください。", Severity.Warning);
-            return;
-        }
-        if (!_editUseRateControl && _editAdaptiveConcurrencyEnabled && _editAdaptiveConcurrencyIncreaseIntervalSec is not (30 or 60 or 90 or 120))
-        {
-            Snackbar.Add("増速インターバルは 30 / 60 / 90 / 120 秒から選択してください。", Severity.Warning);
-            return;
-        }
-        if (!_editUseRateControl && _editAdaptiveConcurrencyEnabled && _editAdaptiveConcurrencyInitialDegree is < 0 or > 256)
-        {
-            Snackbar.Add("初期並列数は 0〜256 の範囲で入力してください。", Severity.Warning);
+            Snackbar.Add(err, Severity.Warning);
             return;
         }
 

--- a/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
@@ -416,6 +416,16 @@ else
             Snackbar.Add("タイムアウトは 30〜3600 秒の範囲で入力してください。", Severity.Warning);
             return;
         }
+        if (_editUseRateControl && _editRcShortWindowSec >= _editRcLongWindowSec)
+        {
+            Snackbar.Add("短期ウィンドウ (秒) は中期ウィンドウ (秒) より小さい値にしてください。", Severity.Warning);
+            return;
+        }
+        if (_editUseRateControl && _editRcMinDecayFactor >= _editRcMaxDecayFactor)
+        {
+            Snackbar.Add("最小減衰率は最大減衰率より小さい値にしてください。", Severity.Warning);
+            return;
+        }
         if (!_editUseRateControl && _editAdaptiveConcurrencyEnabled && _editAdaptiveConcurrencyDecreasePercent is < 1 or > 99)
         {
             Snackbar.Add("減速率は 1〜99 の範囲で入力してください。", Severity.Warning);

--- a/src/CloudMigrator.Dashboard/DashboardFormatHelper.cs
+++ b/src/CloudMigrator.Dashboard/DashboardFormatHelper.cs
@@ -1,0 +1,31 @@
+namespace CloudMigrator.Dashboard;
+
+/// <summary>
+/// ダッシュボード表示用の純粋なフォーマット補助メソッド群。
+/// Blazor コンポーネントから分離することでユニットテスト可能にする。
+/// </summary>
+public static class DashboardFormatHelper
+{
+    public static string FormatDuration(double seconds)
+    {
+        var sec = (int)Math.Round(Math.Abs(seconds));
+        if (sec < 60) return $"{sec}秒";
+        if (sec < 3600) return $"{sec / 60}m{sec % 60:D2}s";
+        return $"{sec / 3600}h{sec % 3600 / 60:D2}m";
+    }
+
+    public static string FormatBytes(long bytes) => bytes switch
+    {
+        >= 1_073_741_824 => $"{bytes / 1_073_741_824.0:F1} GB",
+        >= 1_048_576 => $"{bytes / 1_048_576.0:F1} MB",
+        >= 1_024 => $"{bytes / 1_024.0:F1} KB",
+        _ => $"{bytes} B",
+    };
+
+    public static string FormatBytesPerSec(double v) => v switch
+    {
+        >= 1_048_576 => $"{v / 1_048_576:F1} MB/s",
+        >= 1_024 => $"{v / 1_024:F1} KB/s",
+        _ => $"{v:F0} B/s",
+    };
+}

--- a/src/CloudMigrator.Dashboard/SettingsValidation.cs
+++ b/src/CloudMigrator.Dashboard/SettingsValidation.cs
@@ -1,0 +1,51 @@
+namespace CloudMigrator.Dashboard;
+
+/// <summary>
+/// SettingsPage の保存前バリデーションを UI から分離した純粋な検証クラス。
+/// 各メソッドはエラーメッセージを返し、null は検証通過を表す。
+/// </summary>
+public static class SettingsValidation
+{
+    public static string? ValidateMaxParallelTransfers(int v) =>
+        v is < 1 or > 256 ? "最大並行転送数は 1〜256 の範囲で入力してください。" : null;
+
+    public static string? ValidateMaxParallelFolderCreations(int v) =>
+        v is < 1 or > 32 ? "最大並行フォルダ作成数は 1〜32 の範囲で入力してください。" : null;
+
+    public static string? ValidateChunkSizeMb(int v) =>
+        v is < 1 or > 100 ? "チャンクサイズは 1〜100 MB の範囲で入力してください。" : null;
+
+    public static string? ValidateLargeFileThresholdMb(int v) =>
+        v is < 1 or > 100 ? "大ファイル閾値は 1〜100 MB の範囲で入力してください。" : null;
+
+    public static string? ValidateRetryCount(int v) =>
+        v is < 0 or > 10 ? "リトライ回数は 0〜10 の範囲で入力してください。" : null;
+
+    public static string? ValidateTimeoutSec(int v) =>
+        v is < 30 or > 3600 ? "タイムアウトは 30〜3600 秒の範囲で入力してください。" : null;
+
+    public static string? ValidateRcWindowSecs(bool useRateControl, int shortWindowSec, int longWindowSec) =>
+        useRateControl && shortWindowSec >= longWindowSec
+            ? "短期ウィンドウ (秒) は中期ウィンドウ (秒) より小さい値にしてください。"
+            : null;
+
+    public static string? ValidateRcDecayFactors(bool useRateControl, double minDecayFactor, double maxDecayFactor) =>
+        useRateControl && minDecayFactor >= maxDecayFactor
+            ? "最小減衰率は最大減衰率より小さい値にしてください。"
+            : null;
+
+    public static string? ValidateAdaptiveDecreasePercent(bool useRateControl, bool adaptiveEnabled, int decreasePercent) =>
+        !useRateControl && adaptiveEnabled && decreasePercent is < 1 or > 99
+            ? "減速率は 1〜99 の範囲で入力してください。"
+            : null;
+
+    public static string? ValidateAdaptiveIncreaseIntervalSec(bool useRateControl, bool adaptiveEnabled, int intervalSec) =>
+        !useRateControl && adaptiveEnabled && intervalSec is not (30 or 60 or 90 or 120)
+            ? "増速インターバルは 30 / 60 / 90 / 120 秒から選択してください。"
+            : null;
+
+    public static string? ValidateAdaptiveInitialDegree(bool useRateControl, bool adaptiveEnabled, int initialDegree) =>
+        !useRateControl && adaptiveEnabled && initialDegree is < 0 or > 256
+            ? "初期並列数は 0〜256 の範囲で入力してください。"
+            : null;
+}

--- a/tests/unit/ConfigurationServiceTests.cs
+++ b/tests/unit/ConfigurationServiceTests.cs
@@ -363,6 +363,266 @@ public sealed class ConfigurationServiceTests : IDisposable
         result.AdaptiveConcurrencyDecreasePercent.Should().Be(expectedPercent);
     }
 
+    // ── RateControl（GetConfigAsync 経由）────────────────────────────────
+
+    [Fact]
+    public async Task GetConfigAsync_WhenRateControlSectionAbsent_ReturnsDefaults()
+    {
+        // 検証対象: GetConfigAsync（rateControl なし）
+        // 目的: rateControl セクションが存在しないとき、デフォルト値を返すこと
+        var svc = new ConfigurationService(_configPath);
+
+        var result = await svc.GetConfigAsync();
+
+        result.UseRateControl.Should().BeFalse();
+        result.RcShortWindowSec.Should().Be(5);
+        result.RcLongWindowSec.Should().Be(30);
+        result.RcEmergencyThresholdPct.Should().Be(10);
+        result.RcSlowdownThresholdPct.Should().Be(3);
+        result.RcMinDecayFactor.Should().Be(0.3);
+        result.RcMaxDecayFactor.Should().Be(0.9);
+        result.RcInFlightThreshold.Should().Be(32);
+        result.RcMaxConcurrency.Should().Be(16);
+    }
+
+    [Theory]
+    [InlineData(0.10, 10)]
+    [InlineData(0.03, 3)]
+    [InlineData(0.01, 1)]
+    public async Task GetConfigAsync_RateControl_EmergencyThresholdConvertedToPct(double jsonValue, int expectedPct)
+    {
+        // 検証対象: GetConfigAsync（emergencyThreshold 変換）
+        // 目的: JSON 0–1 の値が UI 用 % (0–100) に変換されること
+        WriteConfig(new
+        {
+            migrator = new
+            {
+                maxParallelTransfers = 4,
+                chunkSizeMb = 5,
+                largeFileThresholdMb = 4,
+                retryCount = 3,
+                timeoutSec = 300,
+                destinationRoot = string.Empty,
+                destinationProvider = "sharepoint",
+                rateControl = new { emergencyThreshold = jsonValue }
+            }
+        });
+        var svc = new ConfigurationService(_configPath);
+
+        var result = await svc.GetConfigAsync();
+
+        result.RcEmergencyThresholdPct.Should().Be(expectedPct);
+    }
+
+    [Theory]
+    [InlineData(0.0, 0)]
+    [InlineData(1.0, 100)]
+    public async Task GetConfigAsync_RateControl_EmergencyThresholdBoundary(double jsonValue, int expectedPct)
+    {
+        // 検証対象: GetConfigAsync（emergencyThreshold 境界値）
+        // 目的: 0.0 → 0%、1.0 → 100% に変換されること
+        WriteConfig(new
+        {
+            migrator = new
+            {
+                maxParallelTransfers = 4,
+                chunkSizeMb = 5,
+                largeFileThresholdMb = 4,
+                retryCount = 3,
+                timeoutSec = 300,
+                destinationRoot = string.Empty,
+                destinationProvider = "sharepoint",
+                rateControl = new { emergencyThreshold = jsonValue }
+            }
+        });
+        var svc = new ConfigurationService(_configPath);
+
+        var result = await svc.GetConfigAsync();
+
+        result.RcEmergencyThresholdPct.Should().Be(expectedPct);
+    }
+
+    [Fact]
+    public async Task GetConfigAsync_RateControl_WhenEmergencyThresholdMissing_ReturnsDefault()
+    {
+        // 検証対象: GetConfigAsync（emergencyThreshold 欠損）
+        // 目的: rateControl セクションはあるが emergencyThreshold が欠損している場合、デフォルト値を返すこと
+        WriteConfig(new
+        {
+            migrator = new
+            {
+                maxParallelTransfers = 4,
+                chunkSizeMb = 5,
+                largeFileThresholdMb = 4,
+                retryCount = 3,
+                timeoutSec = 300,
+                destinationRoot = string.Empty,
+                destinationProvider = "sharepoint",
+                rateControl = new { useRateControl = true }
+            }
+        });
+        var svc = new ConfigurationService(_configPath);
+
+        var result = await svc.GetConfigAsync();
+
+        result.RcEmergencyThresholdPct.Should().Be(10);
+    }
+
+    [Theory]
+    [InlineData(0.10, 10)]
+    [InlineData(0.03, 3)]
+    public async Task GetConfigAsync_RateControl_SlowdownThresholdConvertedToPct(double jsonValue, int expectedPct)
+    {
+        // 検証対象: GetConfigAsync（slowdownThreshold 変換）
+        // 目的: JSON 0–1 の値が UI 用 % に変換されること
+        WriteConfig(new
+        {
+            migrator = new
+            {
+                maxParallelTransfers = 4,
+                chunkSizeMb = 5,
+                largeFileThresholdMb = 4,
+                retryCount = 3,
+                timeoutSec = 300,
+                destinationRoot = string.Empty,
+                destinationProvider = "sharepoint",
+                rateControl = new { slowdownThreshold = jsonValue }
+            }
+        });
+        var svc = new ConfigurationService(_configPath);
+
+        var result = await svc.GetConfigAsync();
+
+        result.RcSlowdownThresholdPct.Should().Be(expectedPct);
+    }
+
+    // ── RateControl（UpdateConfigAsync 経由）────────────────────────────
+
+    [Fact]
+    public async Task UpdateConfigAsync_RateControl_EmergencyThresholdPctSavedAsRatio()
+    {
+        // 検証対象: UpdateConfigAsync（emergencyThreshold 変換）
+        // 目的: UI の % 値 (10) が config.json には 0–1 (0.10) で保存されること
+        var svc = new ConfigurationService(_configPath);
+
+        await svc.UpdateConfigAsync(new ConfigUpdateDto(RcEmergencyThresholdPct: 10));
+
+        var json = await File.ReadAllTextAsync(_configPath);
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("migrator")
+            .GetProperty("rateControl")
+            .GetProperty("emergencyThreshold")
+            .GetDouble()
+            .Should().BeApproximately(0.10, 0.0001);
+    }
+
+    [Fact]
+    public async Task UpdateConfigAsync_RateControl_SlowdownThresholdPctSavedAsRatio()
+    {
+        // 検証対象: UpdateConfigAsync（slowdownThreshold 変換）
+        // 目的: UI の % 値 (3) が config.json には 0–1 (0.03) で保存されること
+        var svc = new ConfigurationService(_configPath);
+
+        await svc.UpdateConfigAsync(new ConfigUpdateDto(RcSlowdownThresholdPct: 3));
+
+        var json = await File.ReadAllTextAsync(_configPath);
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("migrator")
+            .GetProperty("rateControl")
+            .GetProperty("slowdownThreshold")
+            .GetDouble()
+            .Should().BeApproximately(0.03, 0.0001);
+    }
+
+    [Fact]
+    public async Task UpdateConfigAsync_RateControl_RoundTrip_EmergencyThreshold()
+    {
+        // 検証対象: GetConfigAsync + UpdateConfigAsync（往復変換）
+        // 目的: % で保存した値を読み直すと同じ % 値が返ること
+        var svc = new ConfigurationService(_configPath);
+
+        await svc.UpdateConfigAsync(new ConfigUpdateDto(RcEmergencyThresholdPct: 15));
+        var result = await svc.GetConfigAsync();
+
+        result.RcEmergencyThresholdPct.Should().Be(15);
+    }
+
+    // ── UpdateConfigAsync バリデーション ────────────────────────────────
+
+    [Fact]
+    public async Task UpdateConfigAsync_RateControl_ThrowsWhenMinDecayFactorGeqMaxDecayFactor()
+    {
+        // 検証対象: UpdateConfigAsync バリデーション
+        // 目的: RcMinDecayFactor >= RcMaxDecayFactor の場合に ArgumentException が発生すること
+        var svc = new ConfigurationService(_configPath);
+
+        var act = async () => await svc.UpdateConfigAsync(new ConfigUpdateDto(
+            RcMinDecayFactor: 0.9, RcMaxDecayFactor: 0.5));
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*RcMinDecayFactor*RcMaxDecayFactor*");
+    }
+
+    [Fact]
+    public async Task UpdateConfigAsync_RateControl_ThrowsWhenShortWindowGeqLongWindow()
+    {
+        // 検証対象: UpdateConfigAsync バリデーション
+        // 目的: RcShortWindowSec >= RcLongWindowSec の場合に ArgumentException が発生すること
+        var svc = new ConfigurationService(_configPath);
+
+        var act = async () => await svc.UpdateConfigAsync(new ConfigUpdateDto(
+            RcShortWindowSec: 30, RcLongWindowSec: 30));
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*RcShortWindowSec*");
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(101)]
+    public async Task UpdateConfigAsync_RateControl_ThrowsWhenEmergencyThresholdOutOfRange(int pct)
+    {
+        // 検証対象: UpdateConfigAsync バリデーション
+        // 目的: RcEmergencyThresholdPct が 0–100 外の場合に ArgumentException が発生すること
+        var svc = new ConfigurationService(_configPath);
+
+        var act = async () => await svc.UpdateConfigAsync(new ConfigUpdateDto(RcEmergencyThresholdPct: pct));
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(101)]
+    public async Task UpdateConfigAsync_RateControl_ThrowsWhenSlowdownThresholdOutOfRange(int pct)
+    {
+        // 検証対象: UpdateConfigAsync バリデーション
+        // 目的: RcSlowdownThresholdPct が 0–100 外の場合に ArgumentException が発生すること
+        var svc = new ConfigurationService(_configPath);
+
+        var act = async () => await svc.UpdateConfigAsync(new ConfigUpdateDto(RcSlowdownThresholdPct: pct));
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task UpdateConfigAsync_RateControl_ValidValuesDoNotThrow()
+    {
+        // 検証対象: UpdateConfigAsync バリデーション
+        // 目的: 有効な組み合わせでは例外が発生しないこと
+        var svc = new ConfigurationService(_configPath);
+
+        var act = async () => await svc.UpdateConfigAsync(new ConfigUpdateDto(
+            RcShortWindowSec: 5,
+            RcLongWindowSec: 30,
+            RcEmergencyThresholdPct: 10,
+            RcSlowdownThresholdPct: 3,
+            RcMinDecayFactor: 0.3,
+            RcMaxDecayFactor: 0.9));
+
+        await act.Should().NotThrowAsync();
+    }
+
     // ── ヘルパー ────────────────────────────────────────────────────────
 
     private void WriteConfig(object data)

--- a/tests/unit/DashboardFormatHelperTests.cs
+++ b/tests/unit/DashboardFormatHelperTests.cs
@@ -1,0 +1,67 @@
+using CloudMigrator.Dashboard;
+using FluentAssertions;
+
+namespace CloudMigrator.Tests.Unit;
+
+public class DashboardFormatHelperTests
+{
+    // ── FormatDuration ─────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0, "0秒")]
+    [InlineData(1, "1秒")]
+    [InlineData(59, "59秒")]
+    [InlineData(60, "1m00s")]
+    [InlineData(61, "1m01s")]
+    [InlineData(90, "1m30s")]
+    [InlineData(3599, "59m59s")]
+    [InlineData(3600, "1h00m")]
+    [InlineData(3661, "1h01m")]
+    [InlineData(7322, "2h02m")]
+    public void FormatDuration_VariousInputs_ReturnsExpected(double seconds, string expected)
+    {
+        DashboardFormatHelper.FormatDuration(seconds).Should().Be(expected);
+    }
+
+    [Fact]
+    public void FormatDuration_NegativeValue_TreatedAsAbsolute()
+    {
+        // 絶対値で処理されるため負値は正値と同じ結果になる
+        DashboardFormatHelper.FormatDuration(-90).Should().Be("1m30s");
+    }
+
+    // ── FormatBytes ────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0L, "0 B")]
+    [InlineData(512L, "512 B")]
+    [InlineData(1_023L, "1023 B")]
+    [InlineData(1_024L, "1.0 KB")]
+    [InlineData(1_536L, "1.5 KB")]
+    [InlineData(1_048_575L, "1024.0 KB")]
+    [InlineData(1_048_576L, "1.0 MB")]
+    [InlineData(1_572_864L, "1.5 MB")]
+    [InlineData(1_073_741_823L, "1024.0 MB")]
+    [InlineData(1_073_741_824L, "1.0 GB")]
+    [InlineData(2_147_483_648L, "2.0 GB")]
+    public void FormatBytes_VariousInputs_ReturnsExpected(long bytes, string expected)
+    {
+        DashboardFormatHelper.FormatBytes(bytes).Should().Be(expected);
+    }
+
+    // ── FormatBytesPerSec ──────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0.0, "0 B/s")]
+    [InlineData(512.0, "512 B/s")]
+    [InlineData(1_023.0, "1023 B/s")]
+    [InlineData(1_024.0, "1.0 KB/s")]
+    [InlineData(1_536.0, "1.5 KB/s")]
+    [InlineData(1_047_552.0, "1023.0 KB/s")]
+    [InlineData(1_048_576.0, "1.0 MB/s")]
+    [InlineData(2_097_152.0, "2.0 MB/s")]
+    public void FormatBytesPerSec_VariousInputs_ReturnsExpected(double v, string expected)
+    {
+        DashboardFormatHelper.FormatBytesPerSec(v).Should().Be(expected);
+    }
+}

--- a/tests/unit/RateControlledTransferControllerTests.cs
+++ b/tests/unit/RateControlledTransferControllerTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Runtime.CompilerServices;
 using CloudMigrator.Core.Configuration;
 using CloudMigrator.Core.State;
 using CloudMigrator.Core.Transfer;
@@ -299,11 +298,23 @@ public class RateControlledTransferControllerTests : IAsyncDisposable
         _mockAggregator.Setup(a => a.GetSnapshot(It.IsAny<TimeSpan>()))
             .Returns(new MetricsSnapshot(Rps: 5, Rate429: rate429, AvgLatencyMs: 50, Timestamp: DateTimeOffset.UtcNow));
 
-        var buffer = new MetricsBuffer(capturingDb, flushIntervalSec: 3600, NullLogger<MetricsBuffer>.Instance);
+        // flushIntervalSec: 1 = MetricsBuffer の最小フラッシュ間隔。ポーリングで検出可能にする
+        var buffer = new MetricsBuffer(capturingDb, flushIntervalSec: 1, NullLogger<MetricsBuffer>.Instance);
         var sut = new RateControlledTransferController(
             _mockAggregator.Object, settings, buffer, NullLogger<RateControlledTransferController>.Instance);
 
         return (sut, buffer, capturingDb);
+    }
+
+    // 指定メトリクスが DB に書き込まれるまでポーリングする（CI での固定待ち起因フレークを防止）
+    private static async Task WaitForMetricAsync(CapturingDb db, string name, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (db.Metrics.Any(m => m.Name == name)) return;
+            await Task.Delay(100);
+        }
     }
 
     [Fact]
@@ -313,9 +324,9 @@ public class RateControlledTransferControllerTests : IAsyncDisposable
         // 目的: 短期 429 率 > emergencyThreshold (0.1) のとき stateCode = 3 が書き込まれること
         var (sut, buffer, db) = CreateSutForStateCodeTest(rate429: 0.5); // > 0.1
 
-        await Task.Delay(1200);
+        await WaitForMetricAsync(db, "hysteresis_state_code", TimeSpan.FromSeconds(5));
         await sut.DisposeAsync();
-        await buffer.DisposeAsync(); // Dispose 時の最終 Flush でキューを書き出す
+        await buffer.DisposeAsync();
 
         var stateCodes = db.Metrics.Where(m => m.Name == "hysteresis_state_code").ToList();
         stateCodes.Should().NotBeEmpty();
@@ -329,7 +340,7 @@ public class RateControlledTransferControllerTests : IAsyncDisposable
         // 目的: 短期 ≤ 0.1 かつ 中期 429 率 > slowdownThreshold (0.03) のとき stateCode = 2 が書き込まれること
         var (sut, buffer, db) = CreateSutForStateCodeTest(rate429: 0.05); // 0.03 < 0.05 ≤ 0.1
 
-        await Task.Delay(1200);
+        await WaitForMetricAsync(db, "hysteresis_state_code", TimeSpan.FromSeconds(5));
         await sut.DisposeAsync();
         await buffer.DisposeAsync();
 
@@ -345,7 +356,7 @@ public class RateControlledTransferControllerTests : IAsyncDisposable
         // 目的: 中期 429 率 = 0 のとき stateCode = 1 が書き込まれること
         var (sut, buffer, db) = CreateSutForStateCodeTest(rate429: 0); // = 0
 
-        await Task.Delay(1200);
+        await WaitForMetricAsync(db, "hysteresis_state_code", TimeSpan.FromSeconds(5));
         await sut.DisposeAsync();
         await buffer.DisposeAsync();
 
@@ -361,7 +372,7 @@ public class RateControlledTransferControllerTests : IAsyncDisposable
         // 目的: 短期 ≤ 0.1 かつ 0 < 中期 ≤ 0.03 のとき stateCode = 0（維持）が書き込まれること
         var (sut, buffer, db) = CreateSutForStateCodeTest(rate429: 0.02); // 0 < 0.02 ≤ 0.03
 
-        await Task.Delay(1200);
+        await WaitForMetricAsync(db, "hysteresis_state_code", TimeSpan.FromSeconds(5));
         await sut.DisposeAsync();
         await buffer.DisposeAsync();
 

--- a/tests/unit/RateControlledTransferControllerTests.cs
+++ b/tests/unit/RateControlledTransferControllerTests.cs
@@ -1,6 +1,9 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using CloudMigrator.Core.Configuration;
 using CloudMigrator.Core.State;
 using CloudMigrator.Core.Transfer;
+using CloudMigrator.Providers.Abstractions;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -230,6 +233,141 @@ public class RateControlledTransferControllerTests : IAsyncDisposable
             "429 率 50% → 緊急減速でレートが下がる");
         sut.CurrentRateLimit.Should().BeGreaterThanOrEqualTo(1,
             "MinRatePerSec = 1 以下にはならない");
+    }
+
+    // ── ヒステリシス stateCode 記録（MetricsBuffer 経由）────────────────────
+
+    // stateCode テスト専用: 実 DB 相当の捕捉クラスを使って Moq の tuple 型解決問題を回避する
+    private sealed class CapturingDb : ITransferStateDb
+    {
+        public readonly ConcurrentBag<(string Name, double Value)> Metrics = [];
+
+        public Task RecordMetricsBatchAsync(
+            IEnumerable<(string Name, double Value, DateTimeOffset Timestamp)> snapshots,
+            CancellationToken ct)
+        {
+            foreach (var s in snapshots) Metrics.Add((s.Name, s.Value));
+            return Task.CompletedTask;
+        }
+
+        // ── 残りのメソッドは stateCode テストでは使用しない（no-op / 空値）──
+        public Task InitializeAsync(CancellationToken ct) => Task.CompletedTask;
+        public Task<TransferStatus?> GetStatusAsync(string path, string name, CancellationToken ct) => Task.FromResult<TransferStatus?>(null);
+        public Task UpsertPendingAsync(StorageItem item, CancellationToken ct) => Task.CompletedTask;
+        public Task UpsertPendingIfNotTerminalAsync(StorageItem item, CancellationToken ct) => Task.CompletedTask;
+        public Task ResetProcessingAsync(CancellationToken ct) => Task.CompletedTask;
+        public Task<int> ResetPermanentFailedAsync(CancellationToken ct) => Task.FromResult(0);
+        public Task MarkProcessingAsync(string path, string name, CancellationToken ct) => Task.CompletedTask;
+        public Task MarkDoneAsync(string path, string name, CancellationToken ct) => Task.CompletedTask;
+        public Task MarkFailedAsync(string path, string name, string error, CancellationToken ct) => Task.CompletedTask;
+        public Task<string?> GetCheckpointAsync(string key, CancellationToken ct) => Task.FromResult<string?>(null);
+        public Task SaveCheckpointAsync(string key, string value, CancellationToken ct) => Task.CompletedTask;
+        public IAsyncEnumerable<TransferRecord> GetPendingStreamAsync(CancellationToken ct) => AsyncEnumerable.Empty<TransferRecord>();
+        public Task<TransferDbSummary> GetSummaryAsync(CancellationToken ct) => Task.FromResult(new TransferDbSummary());
+        public Task RecordMetricAsync(string name, double value, CancellationToken ct) => Task.CompletedTask;
+        public Task<IReadOnlyList<MetricPoint>> GetMetricsAsync(string name, int recentMinutes, CancellationToken ct) => Task.FromResult<IReadOnlyList<MetricPoint>>([]);
+        public Task<IReadOnlyDictionary<string, double>> GetLatestMetricsAsync(IEnumerable<string> names, int recentMinutes, CancellationToken ct) => Task.FromResult<IReadOnlyDictionary<string, double>>(new Dictionary<string, double>());
+        public Task ResetAllAsync(CancellationToken ct) => Task.CompletedTask;
+        public Task<bool> InsertPendingIfNewAsync(StorageItem item, CancellationToken ct) => Task.FromResult(false);
+        public Task InsertDoneIfNotExistsAsync(string path, string name, CancellationToken ct) => Task.CompletedTask;
+        public Task<IReadOnlyList<string>> GetDistinctFolderPathsAsync(CancellationToken ct) => Task.FromResult<IReadOnlyList<string>>([]);
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    // stateCode テスト用: CapturingDb + 指定した Rate429 でコントローラーを生成する
+    private (RateControlledTransferController Sut, MetricsBuffer Buffer, CapturingDb Db)
+        CreateSutForStateCodeTest(double rate429)
+    {
+        var capturingDb = new CapturingDb();
+        var settings = new RateControlSettings
+        {
+            UseRateControl = true,
+            InitialRatePerSec = 10,
+            MinRatePerSec = 1,
+            MaxConcurrency = 20,
+            InFlightThreshold = 100,
+            ShortWindowSec = 5,
+            LongWindowSec = 30,
+            EmergencyThreshold = 0.1,
+            SlowdownThreshold = 0.03,
+            MinDecayFactor = 0.5,
+            MaxDecayFactor = 0.9,
+            DecayK = 2.0,
+            AccelerateRatio = 0.1,
+            MetricsFlushIntervalSec = 3,
+        };
+        _mockAggregator.Setup(a => a.GetSnapshot(It.IsAny<TimeSpan>()))
+            .Returns(new MetricsSnapshot(Rps: 5, Rate429: rate429, AvgLatencyMs: 50, Timestamp: DateTimeOffset.UtcNow));
+
+        var buffer = new MetricsBuffer(capturingDb, flushIntervalSec: 3600, NullLogger<MetricsBuffer>.Instance);
+        var sut = new RateControlledTransferController(
+            _mockAggregator.Object, settings, buffer, NullLogger<RateControlledTransferController>.Instance);
+
+        return (sut, buffer, capturingDb);
+    }
+
+    [Fact]
+    public async Task AdjustRate_WhenShortRate429ExceedsEmergencyThreshold_RecordsStateCode3()
+    {
+        // 検証対象: AdjustRate（緊急減速）→ MetricsBuffer → DB
+        // 目的: 短期 429 率 > emergencyThreshold (0.1) のとき stateCode = 3 が書き込まれること
+        var (sut, buffer, db) = CreateSutForStateCodeTest(rate429: 0.5); // > 0.1
+
+        await Task.Delay(1200);
+        await sut.DisposeAsync();
+        await buffer.DisposeAsync(); // Dispose 時の最終 Flush でキューを書き出す
+
+        var stateCodes = db.Metrics.Where(m => m.Name == "hysteresis_state_code").ToList();
+        stateCodes.Should().NotBeEmpty();
+        stateCodes.Should().AllSatisfy(m => m.Value.Should().Be(3));
+    }
+
+    [Fact]
+    public async Task AdjustRate_WhenLongRate429ExceedsSlowdownThreshold_RecordsStateCode2()
+    {
+        // 検証対象: AdjustRate（緩減速）→ MetricsBuffer → DB
+        // 目的: 短期 ≤ 0.1 かつ 中期 429 率 > slowdownThreshold (0.03) のとき stateCode = 2 が書き込まれること
+        var (sut, buffer, db) = CreateSutForStateCodeTest(rate429: 0.05); // 0.03 < 0.05 ≤ 0.1
+
+        await Task.Delay(1200);
+        await sut.DisposeAsync();
+        await buffer.DisposeAsync();
+
+        var stateCodes = db.Metrics.Where(m => m.Name == "hysteresis_state_code").ToList();
+        stateCodes.Should().NotBeEmpty();
+        stateCodes.Should().AllSatisfy(m => m.Value.Should().Be(2));
+    }
+
+    [Fact]
+    public async Task AdjustRate_WhenLongRate429IsZero_RecordsStateCode1()
+    {
+        // 検証対象: AdjustRate（加速）→ MetricsBuffer → DB
+        // 目的: 中期 429 率 = 0 のとき stateCode = 1 が書き込まれること
+        var (sut, buffer, db) = CreateSutForStateCodeTest(rate429: 0); // = 0
+
+        await Task.Delay(1200);
+        await sut.DisposeAsync();
+        await buffer.DisposeAsync();
+
+        var stateCodes = db.Metrics.Where(m => m.Name == "hysteresis_state_code").ToList();
+        stateCodes.Should().NotBeEmpty();
+        stateCodes.Should().AllSatisfy(m => m.Value.Should().Be(1));
+    }
+
+    [Fact]
+    public async Task AdjustRate_WhenRate429InStableRange_RecordsStateCode0()
+    {
+        // 検証対象: AdjustRate（安定域）→ MetricsBuffer → DB
+        // 目的: 短期 ≤ 0.1 かつ 0 < 中期 ≤ 0.03 のとき stateCode = 0（維持）が書き込まれること
+        var (sut, buffer, db) = CreateSutForStateCodeTest(rate429: 0.02); // 0 < 0.02 ≤ 0.03
+
+        await Task.Delay(1200);
+        await sut.DisposeAsync();
+        await buffer.DisposeAsync();
+
+        var stateCodes = db.Metrics.Where(m => m.Name == "hysteresis_state_code").ToList();
+        stateCodes.Should().NotBeEmpty();
+        stateCodes.Should().AllSatisfy(m => m.Value.Should().Be(0));
     }
 
     // ── DisposeAsync ─────────────────────────────────────────────────────

--- a/tests/unit/SettingsValidationTests.cs
+++ b/tests/unit/SettingsValidationTests.cs
@@ -1,0 +1,191 @@
+using CloudMigrator.Dashboard;
+using FluentAssertions;
+
+namespace CloudMigrator.Tests.Unit;
+
+public class SettingsValidationTests
+{
+    // ── ValidateMaxParallelTransfers ──────────────────────────────────────────
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(128)]
+    [InlineData(256)]
+    public void ValidateMaxParallelTransfers_ValidRange_ReturnsNull(int v) =>
+        SettingsValidation.ValidateMaxParallelTransfers(v).Should().BeNull();
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(257)]
+    public void ValidateMaxParallelTransfers_OutOfRange_ReturnsError(int v) =>
+        SettingsValidation.ValidateMaxParallelTransfers(v).Should().NotBeNull();
+
+    // ── ValidateMaxParallelFolderCreations ────────────────────────────────────
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(16)]
+    [InlineData(32)]
+    public void ValidateMaxParallelFolderCreations_ValidRange_ReturnsNull(int v) =>
+        SettingsValidation.ValidateMaxParallelFolderCreations(v).Should().BeNull();
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(33)]
+    public void ValidateMaxParallelFolderCreations_OutOfRange_ReturnsError(int v) =>
+        SettingsValidation.ValidateMaxParallelFolderCreations(v).Should().NotBeNull();
+
+    // ── ValidateChunkSizeMb ───────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(50)]
+    [InlineData(100)]
+    public void ValidateChunkSizeMb_ValidRange_ReturnsNull(int v) =>
+        SettingsValidation.ValidateChunkSizeMb(v).Should().BeNull();
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(101)]
+    public void ValidateChunkSizeMb_OutOfRange_ReturnsError(int v) =>
+        SettingsValidation.ValidateChunkSizeMb(v).Should().NotBeNull();
+
+    // ── ValidateLargeFileThresholdMb ──────────────────────────────────────────
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(100)]
+    public void ValidateLargeFileThresholdMb_ValidRange_ReturnsNull(int v) =>
+        SettingsValidation.ValidateLargeFileThresholdMb(v).Should().BeNull();
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(101)]
+    public void ValidateLargeFileThresholdMb_OutOfRange_ReturnsError(int v) =>
+        SettingsValidation.ValidateLargeFileThresholdMb(v).Should().NotBeNull();
+
+    // ── ValidateRetryCount ────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(5)]
+    [InlineData(10)]
+    public void ValidateRetryCount_ValidRange_ReturnsNull(int v) =>
+        SettingsValidation.ValidateRetryCount(v).Should().BeNull();
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(11)]
+    public void ValidateRetryCount_OutOfRange_ReturnsError(int v) =>
+        SettingsValidation.ValidateRetryCount(v).Should().NotBeNull();
+
+    // ── ValidateTimeoutSec ────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(30)]
+    [InlineData(1800)]
+    [InlineData(3600)]
+    public void ValidateTimeoutSec_ValidRange_ReturnsNull(int v) =>
+        SettingsValidation.ValidateTimeoutSec(v).Should().BeNull();
+
+    [Theory]
+    [InlineData(29)]
+    [InlineData(3601)]
+    public void ValidateTimeoutSec_OutOfRange_ReturnsError(int v) =>
+        SettingsValidation.ValidateTimeoutSec(v).Should().NotBeNull();
+
+    // ── ValidateRcWindowSecs ──────────────────────────────────────────────────
+
+    [Fact]
+    public void ValidateRcWindowSecs_UseRateControlFalse_ReturnsNull() =>
+        SettingsValidation.ValidateRcWindowSecs(false, 30, 5).Should().BeNull();
+
+    [Fact]
+    public void ValidateRcWindowSecs_ShortLessThanLong_ReturnsNull() =>
+        SettingsValidation.ValidateRcWindowSecs(true, 5, 30).Should().BeNull();
+
+    [Theory]
+    [InlineData(30, 30)]
+    [InlineData(31, 30)]
+    public void ValidateRcWindowSecs_ShortGeqLong_ReturnsError(int shortSec, int longSec) =>
+        SettingsValidation.ValidateRcWindowSecs(true, shortSec, longSec).Should().NotBeNull();
+
+    // ── ValidateRcDecayFactors ────────────────────────────────────────────────
+
+    [Fact]
+    public void ValidateRcDecayFactors_UseRateControlFalse_ReturnsNull() =>
+        SettingsValidation.ValidateRcDecayFactors(false, 0.9, 0.3).Should().BeNull();
+
+    [Fact]
+    public void ValidateRcDecayFactors_MinLessThanMax_ReturnsNull() =>
+        SettingsValidation.ValidateRcDecayFactors(true, 0.3, 0.9).Should().BeNull();
+
+    [Theory]
+    [InlineData(0.5, 0.5)]
+    [InlineData(0.9, 0.3)]
+    public void ValidateRcDecayFactors_MinGeqMax_ReturnsError(double min, double max) =>
+        SettingsValidation.ValidateRcDecayFactors(true, min, max).Should().NotBeNull();
+
+    // ── ValidateAdaptiveDecreasePercent ───────────────────────────────────────
+
+    [Fact]
+    public void ValidateAdaptiveDecreasePercent_UseRateControlTrue_ReturnsNull() =>
+        SettingsValidation.ValidateAdaptiveDecreasePercent(true, true, 0).Should().BeNull();
+
+    [Fact]
+    public void ValidateAdaptiveDecreasePercent_AdaptiveDisabled_ReturnsNull() =>
+        SettingsValidation.ValidateAdaptiveDecreasePercent(false, false, 0).Should().BeNull();
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(50)]
+    [InlineData(99)]
+    public void ValidateAdaptiveDecreasePercent_ValidRange_ReturnsNull(int v) =>
+        SettingsValidation.ValidateAdaptiveDecreasePercent(false, true, v).Should().BeNull();
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(100)]
+    public void ValidateAdaptiveDecreasePercent_OutOfRange_ReturnsError(int v) =>
+        SettingsValidation.ValidateAdaptiveDecreasePercent(false, true, v).Should().NotBeNull();
+
+    // ── ValidateAdaptiveIncreaseIntervalSec ───────────────────────────────────
+
+    [Theory]
+    [InlineData(30)]
+    [InlineData(60)]
+    [InlineData(90)]
+    [InlineData(120)]
+    public void ValidateAdaptiveIncreaseIntervalSec_ValidValues_ReturnsNull(int v) =>
+        SettingsValidation.ValidateAdaptiveIncreaseIntervalSec(false, true, v).Should().BeNull();
+
+    [Theory]
+    [InlineData(15)]
+    [InlineData(45)]
+    [InlineData(180)]
+    public void ValidateAdaptiveIncreaseIntervalSec_InvalidValues_ReturnsError(int v) =>
+        SettingsValidation.ValidateAdaptiveIncreaseIntervalSec(false, true, v).Should().NotBeNull();
+
+    [Fact]
+    public void ValidateAdaptiveIncreaseIntervalSec_UseRateControlTrue_ReturnsNull() =>
+        SettingsValidation.ValidateAdaptiveIncreaseIntervalSec(true, true, 999).Should().BeNull();
+
+    // ── ValidateAdaptiveInitialDegree ─────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(256)]
+    public void ValidateAdaptiveInitialDegree_ValidRange_ReturnsNull(int v) =>
+        SettingsValidation.ValidateAdaptiveInitialDegree(false, true, v).Should().BeNull();
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(257)]
+    public void ValidateAdaptiveInitialDegree_OutOfRange_ReturnsError(int v) =>
+        SettingsValidation.ValidateAdaptiveInitialDegree(false, true, v).Should().NotBeNull();
+
+    [Fact]
+    public void ValidateAdaptiveInitialDegree_UseRateControlTrue_ReturnsNull() =>
+        SettingsValidation.ValidateAdaptiveInitialDegree(true, true, -999).Should().BeNull();
+}

--- a/tests/unit/SqliteTransferStateDbTests.cs
+++ b/tests/unit/SqliteTransferStateDbTests.cs
@@ -534,6 +534,77 @@ public class SqliteTransferStateDbTests : IAsyncDisposable
         results[0].Value.Should().Be(1.0);
     }
 
+    // ── GetLatestMetricsAsync ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetLatestMetricsAsync_ReturnsLatestValuePerName()
+    {
+        // 検証対象: GetLatestMetricsAsync  目的: 複数 name を渡したとき、各 name の最新値 1 件だけ返ること
+        await _db.InitializeAsync(CancellationToken.None);
+
+        await _db.RecordMetricAsync("metric_a", 1.0, CancellationToken.None);
+        await Task.Delay(10);
+        await _db.RecordMetricAsync("metric_a", 2.0, CancellationToken.None); // latest
+        await _db.RecordMetricAsync("metric_b", 10.0, CancellationToken.None);
+        await Task.Delay(10);
+        await _db.RecordMetricAsync("metric_b", 20.0, CancellationToken.None); // latest
+
+        var result = await _db.GetLatestMetricsAsync(["metric_a", "metric_b"], 60, CancellationToken.None);
+
+        result.Should().HaveCount(2);
+        result["metric_a"].Should().Be(2.0);
+        result["metric_b"].Should().Be(20.0);
+    }
+
+    [Fact]
+    public async Task GetLatestMetricsAsync_OldRecordsOutsideWindow_AreExcluded()
+    {
+        // 検証対象: GetLatestMetricsAsync  目的: cutoff (recentMinutes) より古いレコードは除外されること
+        await _db.InitializeAsync(CancellationToken.None);
+
+        // 2 時間前のレコードを直接 INSERT
+        await using var conn = new Microsoft.Data.Sqlite.SqliteConnection($"Data Source={_dbPath};");
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO metrics (timestamp, name, value)
+            VALUES (@ts, @name, @value);
+            """;
+        cmd.Parameters.AddWithValue("@ts", DateTimeOffset.UtcNow.AddHours(-2).ToString("O"));
+        cmd.Parameters.AddWithValue("@name", "old_metric");
+        cmd.Parameters.AddWithValue("@value", 999.0);
+        await cmd.ExecuteNonQueryAsync();
+
+        var result = await _db.GetLatestMetricsAsync(["old_metric"], 60, CancellationToken.None);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetLatestMetricsAsync_NonExistentName_NotInResult()
+    {
+        // 検証対象: GetLatestMetricsAsync  目的: 存在しない name のエントリは結果に含まれないこと
+        await _db.InitializeAsync(CancellationToken.None);
+
+        await _db.RecordMetricAsync("exists", 1.0, CancellationToken.None);
+
+        var result = await _db.GetLatestMetricsAsync(["exists", "not_exists"], 60, CancellationToken.None);
+
+        result.Should().ContainKey("exists");
+        result.Should().NotContainKey("not_exists");
+    }
+
+    [Fact]
+    public async Task GetLatestMetricsAsync_EmptyNames_ReturnsEmpty()
+    {
+        // 検証対象: GetLatestMetricsAsync  目的: names が空のとき空の辞書を返すこと
+        await _db.InitializeAsync(CancellationToken.None);
+
+        var result = await _db.GetLatestMetricsAsync([], 60, CancellationToken.None);
+
+        result.Should().BeEmpty();
+    }
+
     [Fact]
     public async Task RecordMetricAsync_Timestamp_IsStoredAsRoundtripFormat()
     {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes #151

PR #150 の Copilot レビューで defer した項目を一括回収します。

- **バリデーション（Service 層が最終防衛）**: `ConfigurationService.UpdateConfigAsync` に RateControl 設定値の検証を追加。`RcMinDecayFactor >= RcMaxDecayFactor`・`RcShortWindowSec >= RcLongWindowSec`・各フィールドの範囲外値で `ArgumentException` を throw
- **UI 補助バリデーション**: `SettingsPage.razor` の `SaveAsync` にクロスフィールドチェックを追加（Service 層依存で二重化しない）
- **DB クエリ最適化**: `ITransferStateDb` に `GetLatestMetricsAsync(names, recentMinutes, ct)` を追加し `DashboardPage.razor` の `RefreshRateControlMetricsAsync` を 5 クエリ→1 クエリに削減
- **ユニットテスト追加**:
  - `ConfigurationServiceTests`: rateControl 読み書き変換（JSON 0–1 ↔ UI %）・境界値・バリデーション例外
  - `RateControlledTransferControllerTests`: `hysteresis_state_code` DB 記録テスト（stateCode 0–3 の全パターン）

## Test plan

- [x] `dotnet test tests/unit` — 650 件全て通過
- [x] `dotnet build` — 警告 0・エラー 0
- [x] `dotnet-format` — フォーマットチェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)