### PR TITLE
feat(ui): レート制御時のスループット表示を制御窓ベースに変更 (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
 
 ### Added
 
+- **ウィンドウベースのスループット表示**（レート制御 ON 時）(#159)
+  - `ISlidingWindowMetrics.NotifySuccess(latency, bytes=0)` overload と `SlidingWindowSnapshot` 拡張（`FilesPerSec` / `BytesPerSec` / `WindowSeconds`）
+  - `HybridRateController` に `GetCurrentSnapshot()` を追加し、`NotifySuccess` でバイト数を内部メトリクスへ透過
+  - Dropbox / SharePoint パイプライン: `controller is HybridRateController` の場合、`throughput_files_per_min` / `throughput_bytes_per_sec` をウィンドウ集計値で上書きし、`throughput_window_sec` を併記
+  - Dashboard: HybridRateController 経路かつウィンドウ幅メトリクスがある場合、スループットカードのタイトルに「（直近 N 秒）」を付記
+  - `ITransferRateController.NotifySuccess` も `(latency, bytes=0)` overload に拡張（`AdaptiveConcurrencyControllerAdapter` / `RateControlledTransferController` は bytes を無視して既存挙動を維持）
+  - ユニットテスト 5 件追加（`SlidingWindowMetricsTests` / `HybridRateControllerTests`）
+
 - **v0.6.0 ハイブリッドレート制御（スループット主制御 + 並列数補助制御）** (#163)
   - `HybridRateController`: `WeightedTokenBucket`（ゲート A）+ `SemaphoreSlim`（ゲート B、動的 `max_inflight`）+ `AimdFeedbackController` + `SlidingWindowMetrics` を統合する `ITransferRateController` 実装。設計書 v2 §7 制御ループ + §4.3 並列数補助制御に対応
   - `AcquireAsync`: ゲート B（並列数）→ ゲート A（トークン）の 2 段取得

--- a/src/CloudMigrator.Core/Migration/DropboxMigrationPipeline.cs
+++ b/src/CloudMigrator.Core/Migration/DropboxMigrationPipeline.cs
@@ -341,7 +341,7 @@ public sealed class DropboxMigrationPipeline : IMigrationPipeline
                 Interlocked.Increment(ref _completedTransfers);
                 Interlocked.Add(ref _totalBytesTransferred, job.Source.SizeBytes ?? 0);
                 onSuccess();
-                controller?.NotifySuccess(telemetry.UploadWallElapsed);
+                controller?.NotifySuccess(telemetry.UploadWallElapsed, job.Source.SizeBytes ?? 0);
 
                 var elapsedSeconds = Math.Max(0.001, (DateTimeOffset.UtcNow - _pipelineStartTime).TotalSeconds);
                 var filesPerSec = Volatile.Read(ref _completedTransfers) / elapsedSeconds;
@@ -421,11 +421,24 @@ public sealed class DropboxMigrationPipeline : IMigrationPipeline
         var filesPerMin = elapsedSeconds > 0 ? totalNow / elapsedSeconds * 60.0 : 0.0;
         var bytesPerSec = elapsedSeconds > 0 ? Volatile.Read(ref _totalBytesTransferred) / elapsedSeconds : 0.0;
 
+        // #159: HybridRateController 経路ではウィンドウ集計値で上書きする（直近の実効スループット）。
+        // 旧経路は累積平均のまま。Snapshot 取得は制御ループと別タイミングで安全。
+        double? windowSeconds = null;
+        if (controller is HybridRateController hybrid)
+        {
+            var snap = hybrid.GetCurrentSnapshot();
+            filesPerMin = snap.FilesPerSec * 60.0;
+            bytesPerSec = snap.BytesPerSec;
+            windowSeconds = snap.WindowSeconds;
+        }
+
         try
         {
             await _stateDb.RecordMetricAsync("rate_limit_pct", pct, ct).ConfigureAwait(false);
             await _stateDb.RecordMetricAsync("throughput_files_per_min", filesPerMin, ct).ConfigureAwait(false);
             await _stateDb.RecordMetricAsync("throughput_bytes_per_sec", bytesPerSec, ct).ConfigureAwait(false);
+            if (windowSeconds.HasValue)
+                await _stateDb.RecordMetricAsync("throughput_window_sec", windowSeconds.Value, ct).ConfigureAwait(false);
             await _stateDb.RecordMetricAsync(
                 "current_parallelism",
                 (double)(int)Math.Round(controller?.CurrentRateLimit ?? _options.MaxParallelTransfers),

--- a/src/CloudMigrator.Core/Migration/SharePointMigrationPipeline.cs
+++ b/src/CloudMigrator.Core/Migration/SharePointMigrationPipeline.cs
@@ -417,7 +417,7 @@ public sealed class SharePointMigrationPipeline : IMigrationPipeline
                     Interlocked.Increment(ref success);
                     Interlocked.Add(ref _totalBytesTransferred, job.Source.SizeBytes ?? 0);
                     _logger.LogInformation("SharePoint 転送完了: {SkipKey}", job.Source.SkipKey);
-                    controller?.NotifySuccess(latency);
+                    controller?.NotifySuccess(latency, job.Source.SizeBytes ?? 0);
                 }
                 catch (OperationCanceledException)
                 {
@@ -486,11 +486,25 @@ public sealed class SharePointMigrationPipeline : IMigrationPipeline
                         var bytesPerSec = elapsedSeconds > 0
                             ? Volatile.Read(ref _totalBytesTransferred) / elapsedSeconds
                             : 0.0;
+
+                        // #159: HybridRateController 経路ではウィンドウ集計値で上書きする（直近の実効スループット）。
+                        // 旧経路は累積平均のまま。Snapshot 取得は制御ループと別タイミングで安全。
+                        double? windowSeconds = null;
+                        if (controller is HybridRateController hybrid)
+                        {
+                            var snap = hybrid.GetCurrentSnapshot();
+                            filesPerMin = snap.FilesPerSec * 60.0;
+                            bytesPerSec = snap.BytesPerSec;
+                            windowSeconds = snap.WindowSeconds;
+                        }
+
                         try
                         {
                             await _stateDb.RecordMetricAsync("rate_limit_pct", pct, itemCt).ConfigureAwait(false);
                             await _stateDb.RecordMetricAsync("throughput_files_per_min", filesPerMin, itemCt).ConfigureAwait(false);
                             await _stateDb.RecordMetricAsync("throughput_bytes_per_sec", bytesPerSec, itemCt).ConfigureAwait(false);
+                            if (windowSeconds.HasValue)
+                                await _stateDb.RecordMetricAsync("throughput_window_sec", windowSeconds.Value, itemCt).ConfigureAwait(false);
                             await _stateDb.RecordMetricAsync(
                                 "current_parallelism",
                                 (double)(int)Math.Round(controller?.CurrentRateLimit ?? _options.MaxParallelTransfers),

--- a/src/CloudMigrator.Core/Transfer/AdaptiveConcurrencyControllerAdapter.cs
+++ b/src/CloudMigrator.Core/Transfer/AdaptiveConcurrencyControllerAdapter.cs
@@ -40,8 +40,9 @@ public sealed class AdaptiveConcurrencyControllerAdapter : ITransferRateControll
     }
 
     /// <inheritdoc/>
-    public void NotifySuccess(TimeSpan latency)
+    public void NotifySuccess(TimeSpan latency, long bytes = 0)
     {
+        // 旧コントローラーはバイト数を扱わないため bytes は無視する。
         DecrementIfPositive(ref _activeCount);
         _inner.NotifySuccess();
     }

--- a/src/CloudMigrator.Core/Transfer/HybridRateController.cs
+++ b/src/CloudMigrator.Core/Transfer/HybridRateController.cs
@@ -162,11 +162,17 @@ public sealed class HybridRateController : ITransferRateController, IAsyncDispos
     }
 
     /// <inheritdoc/>
-    public void NotifySuccess(TimeSpan latency)
+    public void NotifySuccess(TimeSpan latency, long bytes = 0)
     {
         DecrementIfPositive(ref _activeCount);
-        _metrics.NotifySuccess(latency);
+        _metrics.NotifySuccess(latency, bytes);
     }
+
+    /// <summary>
+    /// 現在のウィンドウ集計スナップショットを返す（#159 ダッシュボード表示用）。
+    /// 制御ループ周期と独立に呼び出してよい。
+    /// </summary>
+    public SlidingWindowSnapshot GetCurrentSnapshot() => _metrics.GetSnapshot();
 
     /// <inheritdoc/>
     public void NotifyCompleted(TimeSpan latency)

--- a/src/CloudMigrator.Core/Transfer/ISlidingWindowMetrics.cs
+++ b/src/CloudMigrator.Core/Transfer/ISlidingWindowMetrics.cs
@@ -21,7 +21,11 @@ public interface ISlidingWindowMetrics
 
     /// <summary>転送成功時に呼び出す。レイテンシは平均 / P95 算出に使用する。</summary>
     /// <param name="latency">実測レイテンシ。</param>
-    void NotifySuccess(TimeSpan latency);
+    /// <param name="bytes">
+    /// 転送バイト数（#159 ウィンドウスループット集計用）。
+    /// バイト数を持たない呼び出し（フォルダ作成等）では 0 を渡す。
+    /// </param>
+    void NotifySuccess(TimeSpan latency, long bytes = 0);
 
     /// <summary>429 / 503（Retry-After 含む）を受信した際に呼び出す。</summary>
     /// <param name="retryAfter">サーバーから返された Retry-After（情報用、集計自体には未使用）。</param>

--- a/src/CloudMigrator.Core/Transfer/ITransferRateController.cs
+++ b/src/CloudMigrator.Core/Transfer/ITransferRateController.cs
@@ -21,7 +21,11 @@ public interface ITransferRateController
 
     /// <summary>転送成功時に呼び出す。</summary>
     /// <param name="latency">実際の転送レイテンシ。</param>
-    void NotifySuccess(TimeSpan latency);
+    /// <param name="bytes">
+    /// 転送バイト数（#159 ウィンドウスループット表示用）。
+    /// バイト数が無いケース（フォルダ作成等）は 0 を渡す。
+    /// </param>
+    void NotifySuccess(TimeSpan latency, long bytes = 0);
 
     /// <summary>
     /// キャンセル・非レート制限エラーなど、成功以外の完了時に呼び出す。

--- a/src/CloudMigrator.Core/Transfer/RateControlledTransferController.cs
+++ b/src/CloudMigrator.Core/Transfer/RateControlledTransferController.cs
@@ -104,8 +104,10 @@ public sealed class RateControlledTransferController : ITransferRateController, 
     }
 
     /// <inheritdoc/>
-    public void NotifySuccess(TimeSpan latency)
+    public void NotifySuccess(TimeSpan latency, long bytes = 0)
     {
+        // v0.5.0 の Aggregator はバイト数を扱わないため bytes は無視する。
+        // ウィンドウスループット表示は v0.6.0 ハイブリッド経路（HybridRateController）でのみ有効。
         DecrementIfPositive(ref _activeCount);
         _aggregator.NotifySuccess(latency);
     }

--- a/src/CloudMigrator.Core/Transfer/SlidingWindowMetrics.cs
+++ b/src/CloudMigrator.Core/Transfer/SlidingWindowMetrics.cs
@@ -133,17 +133,21 @@ public sealed class SlidingWindowMetrics : ISlidingWindowMetrics
             var avgLatency = latencies.Count > 0 ? Average(latencies) : 0.0;
             var p95Latency = latencies.Count > 0 ? Percentile(latencies, 0.95) : 0.0;
 
-            // ウィンドウ秒数: 時間モードでは設定値、件数モードでは最古〜最新成功イベントの実時間幅。
+            // ウィンドウ秒数:
+            //   - 時間モード: 設定 windowSec
+            //   - 件数モード: 成功 2 件以上あれば最古〜最新成功の実時間幅、それ以外は設定 windowSec にフォールバック
+            // 件数モードでも _windowTicks は設定 windowSec を秒換算した値が入っているため、設定窓幅として再利用できる。
             // 0 件 / 1 件のときに 0 除算しないよう最低 1 秒で下限する。
+            var configuredWindowSeconds = (double)_windowTicks / Stopwatch.Frequency;
             double windowSeconds;
             if (_mode == SlidingWindowMode.Time)
             {
-                windowSeconds = (double)_windowTicks / Stopwatch.Frequency;
+                windowSeconds = configuredWindowSeconds;
             }
             else
             {
                 var spanTicks = newestSuccessTicks - oldestSuccessTicks;
-                windowSeconds = spanTicks > 0 ? (double)spanTicks / Stopwatch.Frequency : 1.0;
+                windowSeconds = spanTicks > 0 ? (double)spanTicks / Stopwatch.Frequency : configuredWindowSeconds;
             }
             if (windowSeconds < 1.0) windowSeconds = 1.0;
 

--- a/src/CloudMigrator.Core/Transfer/SlidingWindowMetrics.cs
+++ b/src/CloudMigrator.Core/Transfer/SlidingWindowMetrics.cs
@@ -74,16 +74,16 @@ public sealed class SlidingWindowMetrics : ISlidingWindowMetrics
 
     /// <inheritdoc/>
     public void NotifyRequestSent() =>
-        Enqueue(new MetricEvent(Stopwatch.GetTimestamp(), EventKind.RequestSent, 0));
+        Enqueue(new MetricEvent(Stopwatch.GetTimestamp(), EventKind.RequestSent, 0, 0));
 
     /// <inheritdoc/>
-    public void NotifySuccess(TimeSpan latency) =>
-        Enqueue(new MetricEvent(Stopwatch.GetTimestamp(), EventKind.Success, latency.TotalMilliseconds));
+    public void NotifySuccess(TimeSpan latency, long bytes = 0) =>
+        Enqueue(new MetricEvent(Stopwatch.GetTimestamp(), EventKind.Success, latency.TotalMilliseconds, bytes));
 
     /// <inheritdoc/>
     public void NotifyRateLimit(TimeSpan? retryAfter) =>
         // retryAfter は現時点では未使用（集計対象外）。#162 AIMD クールダウン計算での活用を予定。
-        Enqueue(new MetricEvent(Stopwatch.GetTimestamp(), EventKind.RateLimit, 0));
+        Enqueue(new MetricEvent(Stopwatch.GetTimestamp(), EventKind.RateLimit, 0, 0));
 
     /// <inheritdoc/>
     public SlidingWindowSnapshot GetSnapshot()
@@ -93,6 +93,8 @@ public sealed class SlidingWindowMetrics : ISlidingWindowMetrics
             Evict();
 
             int requestCount = 0, successCount = 0, rateLimitCount = 0;
+            long totalBytes = 0;
+            long oldestSuccessTicks = 0, newestSuccessTicks = 0;
             // P95 用に成功レイテンシ列を抽出。allocation は制御ループ（1 秒周期）で十分許容範囲
             var latencies = new List<double>(_events.Count);
 
@@ -106,6 +108,11 @@ public sealed class SlidingWindowMetrics : ISlidingWindowMetrics
                     case EventKind.Success:
                         successCount++;
                         latencies.Add(e.LatencyMs);
+                        totalBytes += e.Bytes;
+                        if (oldestSuccessTicks == 0 || e.TimestampTicks < oldestSuccessTicks)
+                            oldestSuccessTicks = e.TimestampTicks;
+                        if (e.TimestampTicks > newestSuccessTicks)
+                            newestSuccessTicks = e.TimestampTicks;
                         break;
                     case EventKind.RateLimit:
                         rateLimitCount++;
@@ -126,6 +133,23 @@ public sealed class SlidingWindowMetrics : ISlidingWindowMetrics
             var avgLatency = latencies.Count > 0 ? Average(latencies) : 0.0;
             var p95Latency = latencies.Count > 0 ? Percentile(latencies, 0.95) : 0.0;
 
+            // ウィンドウ秒数: 時間モードでは設定値、件数モードでは最古〜最新成功イベントの実時間幅。
+            // 0 件 / 1 件のときに 0 除算しないよう最低 1 秒で下限する。
+            double windowSeconds;
+            if (_mode == SlidingWindowMode.Time)
+            {
+                windowSeconds = (double)_windowTicks / Stopwatch.Frequency;
+            }
+            else
+            {
+                var spanTicks = newestSuccessTicks - oldestSuccessTicks;
+                windowSeconds = spanTicks > 0 ? (double)spanTicks / Stopwatch.Frequency : 1.0;
+            }
+            if (windowSeconds < 1.0) windowSeconds = 1.0;
+
+            var filesPerSec = successCount > 0 ? successCount / windowSeconds : 0.0;
+            var bytesPerSec = successCount > 0 ? totalBytes / windowSeconds : 0.0;
+
             return new SlidingWindowSnapshot(
                 SampleCount: sampleCount,
                 HasMinSamples: sampleCount >= _minSamples,
@@ -133,6 +157,9 @@ public sealed class SlidingWindowMetrics : ISlidingWindowMetrics
                 SuccessRate: successRate,
                 AvgLatencyMs: avgLatency,
                 P95LatencyMs: p95Latency,
+                FilesPerSec: filesPerSec,
+                BytesPerSec: bytesPerSec,
+                WindowSeconds: windowSeconds,
                 Timestamp: DateTimeOffset.UtcNow);
         }
     }
@@ -210,5 +237,5 @@ public sealed class SlidingWindowMetrics : ISlidingWindowMetrics
         RateLimit,
     }
 
-    private readonly record struct MetricEvent(long TimestampTicks, EventKind Kind, double LatencyMs);
+    private readonly record struct MetricEvent(long TimestampTicks, EventKind Kind, double LatencyMs, long Bytes);
 }

--- a/src/CloudMigrator.Core/Transfer/SlidingWindowSnapshot.cs
+++ b/src/CloudMigrator.Core/Transfer/SlidingWindowSnapshot.cs
@@ -28,6 +28,19 @@ namespace CloudMigrator.Core.Transfer;
 /// 成功リクエストの P95 レイテンシ（ms）。成功が 0 件なら 0。
 /// AIMD のベースライン比悪化検知（§6.1）に使用する。
 /// </param>
+/// <param name="FilesPerSec">
+/// ウィンドウ内の成功ファイル数 / ウィンドウ秒数。#159 ダッシュボード表示用。
+/// 時間モードではウィンドウ幅を分母とし、件数モードでは <see cref="WindowSeconds"/>
+/// を <c>(最古〜最新成功イベントの時間幅)</c> から算出する。成功が 0 件なら 0。
+/// </param>
+/// <param name="BytesPerSec">
+/// ウィンドウ内の成功合計バイト数 / ウィンドウ秒数。#159 ダッシュボード表示用。
+/// バイト未指定で <see cref="ISlidingWindowMetrics.NotifySuccess"/> された分は 0 として加算される。
+/// </param>
+/// <param name="WindowSeconds">
+/// スループット算出に使った実効ウィンドウ秒数。時間モードでは設定値そのもの、
+/// 件数モードでは最古〜最新成功イベントの時間幅（最低でも 1 秒）。0 件のときは設定値（または 1）。
+/// </param>
 /// <param name="Timestamp">スナップショットを取得した時刻（UTC）。</param>
 public sealed record SlidingWindowSnapshot(
     int SampleCount,
@@ -36,4 +49,7 @@ public sealed record SlidingWindowSnapshot(
     double SuccessRate,
     double AvgLatencyMs,
     double P95LatencyMs,
+    double FilesPerSec,
+    double BytesPerSec,
+    double WindowSeconds,
     DateTimeOffset Timestamp);

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -296,7 +296,7 @@ else
             <MudItem xs="12" md="6">
                 <MudCard Elevation="2">
                     <MudCardHeader>
-                        <CardHeaderContent><MudText Typo="Typo.subtitle2">スループット (files/min)</MudText></CardHeaderContent>
+                        <CardHeaderContent><MudText Typo="Typo.subtitle2">スループット (files/min)@ThroughputWindowSuffix</MudText></CardHeaderContent>
                     </MudCardHeader>
                     <MudCardContent>
                         <MudChart ChartType="ChartType.Line"
@@ -313,7 +313,7 @@ else
             <MudItem xs="12" md="6">
                 <MudCard Elevation="2">
                     <MudCardHeader>
-                        <CardHeaderContent><MudText Typo="Typo.subtitle2">スループット (bytes/sec)</MudText></CardHeaderContent>
+                        <CardHeaderContent><MudText Typo="Typo.subtitle2">スループット (bytes/sec)@ThroughputWindowSuffix</MudText></CardHeaderContent>
                     </MudCardHeader>
                     <MudCardContent>
                         <MudChart ChartType="ChartType.Line"
@@ -444,6 +444,8 @@ else
 
     // ── RateControl 観測パネル ─────────────────────────────────────────────────
     private bool _useRateControl;
+    private bool _useHybridController;
+    private double _throughputWindowSec; // #159: HybridRateController 経路時のウィンドウ幅（秒）。0 のとき表示しない
     private double _rcCurrentRate = -1;
     private double _rcInFlight = -1;
     private double _rcRate429Short = -1;
@@ -452,6 +454,15 @@ else
     // Config から読み込んだ閾値（429率色分けに使用）
     private double _rcSlowdownThreshold;    // 0–1 スケール
     private double _rcEmergencyThreshold;   // 0–1 スケール
+
+    /// <summary>
+    /// #159: HybridRateController 経路でウィンドウ集計値が記録されている場合、
+    /// スループットカードのタイトルに「（直近 N 秒）」と付記する。
+    /// </summary>
+    private string ThroughputWindowSuffix =>
+        _useRateControl && _useHybridController && _throughputWindowSec > 0
+            ? $"（直近 {_throughputWindowSec:F0} 秒）"
+            : "";
 
     private string HysteresisLabel => _rcHysteresisStateCode switch
     {
@@ -516,6 +527,7 @@ else
         // ファクトリ経由で毎回 AppConfiguration.Build() を呼ぶため、設定変更後も最新値を反映する
         var opts = OptionsFactory();
         _useRateControl = opts.RateControl.UseRateControl;
+        _useHybridController = opts.RateControl.UseHybridController;
         _rcSlowdownThreshold  = opts.RateControl.SlowdownThreshold;
         _rcEmergencyThreshold = opts.RateControl.EmergencyThreshold;
 
@@ -651,6 +663,10 @@ else
         var bytesData = await TransferStateDb.GetMetricsAsync("throughput_bytes_per_sec", minutes, ct);
         var rlData    = await TransferStateDb.GetMetricsAsync("rate_limit_pct",            minutes, ct);
         var parData   = await TransferStateDb.GetMetricsAsync("current_parallelism",       minutes, ct);
+        // #159: HybridRateController 経路でのみ書き込まれるウィンドウ幅。
+        // 値が無いときは累積平均表示のままにする。
+        var winData   = await TransferStateDb.GetMetricsAsync("throughput_window_sec",     minutes, ct);
+        _throughputWindowSec = winData.Count > 0 ? winData[^1].Value : 0;
 
         if (filesData.Count > 0)
         {

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -444,7 +444,6 @@ else
 
     // ── RateControl 観測パネル ─────────────────────────────────────────────────
     private bool _useRateControl;
-    private bool _useHybridController;
     private double _throughputWindowSec; // #159: HybridRateController 経路時のウィンドウ幅（秒）。0 のとき表示しない
     private double _rcCurrentRate = -1;
     private double _rcInFlight = -1;
@@ -456,11 +455,12 @@ else
     private double _rcEmergencyThreshold;   // 0–1 スケール
 
     /// <summary>
-    /// #159: HybridRateController 経路でウィンドウ集計値が記録されている場合、
-    /// スループットカードのタイトルに「（直近 N 秒）」と付記する。
+    /// #159: ウィンドウ幅メトリクス（HybridRateController 経路でのみ書き込まれる）
+    /// が DB に記録されている場合、スループットカードのタイトルに「（直近 N 秒）」と付記する。
+    /// 設定値ではなく実際のメトリクス有無で判定するため、設定リアルタイム反映時のラベル不整合を防ぐ。
     /// </summary>
     private string ThroughputWindowSuffix =>
-        _useRateControl && _useHybridController && _throughputWindowSec > 0
+        _throughputWindowSec > 0
             ? $"（直近 {_throughputWindowSec:F0} 秒）"
             : "";
 
@@ -527,7 +527,6 @@ else
         // ファクトリ経由で毎回 AppConfiguration.Build() を呼ぶため、設定変更後も最新値を反映する
         var opts = OptionsFactory();
         _useRateControl = opts.RateControl.UseRateControl;
-        _useHybridController = opts.RateControl.UseHybridController;
         _rcSlowdownThreshold  = opts.RateControl.SlowdownThreshold;
         _rcEmergencyThreshold = opts.RateControl.EmergencyThreshold;
 

--- a/tests/unit/AimdFeedbackControllerTests.cs
+++ b/tests/unit/AimdFeedbackControllerTests.cs
@@ -30,7 +30,8 @@ public sealed class AimdFeedbackControllerTests
         double successRate = 1.0,
         double avgLatencyMs = 100.0,
         double p95LatencyMs = 100.0) =>
-        new(sampleCount, hasMinSamples, rate429, successRate, avgLatencyMs, p95LatencyMs, DateTimeOffset.UtcNow);
+        new(sampleCount, hasMinSamples, rate429, successRate, avgLatencyMs, p95LatencyMs,
+            FilesPerSec: 0.0, BytesPerSec: 0.0, WindowSeconds: 30.0, Timestamp: DateTimeOffset.UtcNow);
 
     private static AimdFeedbackSettings MakeSettings(Action<AimdFeedbackSettings>? configure = null)
     {
@@ -445,7 +446,8 @@ public sealed class AimdFeedbackControllerTests
         var clock = new FakeClock();
         var sut = new AimdFeedbackController(MakeSettings(), clock.Now);
         var fixedAt = new DateTimeOffset(2026, 4, 18, 12, 0, 0, TimeSpan.Zero);
-        var snapshot = new SlidingWindowSnapshot(20, true, 0.0, 1.0, 100.0, 100.0, fixedAt);
+        var snapshot = new SlidingWindowSnapshot(20, true, 0.0, 1.0, 100.0, 100.0,
+            FilesPerSec: 0.0, BytesPerSec: 0.0, WindowSeconds: 30.0, Timestamp: fixedAt);
 
         var r = sut.Evaluate(snapshot);
 

--- a/tests/unit/HybridRateControllerTests.cs
+++ b/tests/unit/HybridRateControllerTests.cs
@@ -50,10 +50,20 @@ public sealed class HybridRateControllerTests
             SuccessRate: 1.0,
             AvgLatencyMs: 100.0,
             P95LatencyMs: 100.0,
+            FilesPerSec: 0.0,
+            BytesPerSec: 0.0,
+            WindowSeconds: 30.0,
             Timestamp: DateTimeOffset.UtcNow);
 
+        public long LastBytes { get; private set; }
+        public int SuccessCalls { get; private set; }
+
         public void NotifyRequestSent() { }
-        public void NotifySuccess(TimeSpan latency) { }
+        public void NotifySuccess(TimeSpan latency, long bytes = 0)
+        {
+            SuccessCalls++;
+            LastBytes = bytes;
+        }
         public void NotifyRateLimit(TimeSpan? retryAfter) { }
         public SlidingWindowSnapshot GetSnapshot() => Snapshot;
     }
@@ -443,5 +453,52 @@ public sealed class HybridRateControllerTests
         controller.Release();
         await second.WaitAsync(TimeSpan.FromSeconds(2));
         controller.Release();
+    }
+
+    // ─── #159 ウィンドウスループット ─────────────────────────────
+
+    [Fact]
+    public async Task NotifySuccess_ForwardsBytes_ToSlidingWindowMetrics()
+    {
+        // 検証対象: bytes 透過  目的: HybridRateController が内部 ISlidingWindowMetrics に bytes を渡す
+        var aimd = new FakeAimd();
+        var metrics = new FakeMetrics();
+        var controller = Build(MakeSettings(), aimd, metrics, out _);
+        await using var _disposer = controller;
+
+        controller.NotifyRequestSent();
+        controller.NotifySuccess(TimeSpan.FromMilliseconds(50), bytes: 1024);
+
+        metrics.SuccessCalls.Should().Be(1);
+        metrics.LastBytes.Should().Be(1024);
+    }
+
+    [Fact]
+    public async Task GetCurrentSnapshot_ReturnsMetricsSnapshot()
+    {
+        // 検証対象: GetCurrentSnapshot  目的: ダッシュボード経路から最新スナップショットを取得できる
+        var aimd = new FakeAimd();
+        var metrics = new FakeMetrics
+        {
+            Snapshot = new SlidingWindowSnapshot(
+                SampleCount: 30,
+                HasMinSamples: true,
+                Rate429: 0.0,
+                SuccessRate: 1.0,
+                AvgLatencyMs: 50.0,
+                P95LatencyMs: 80.0,
+                FilesPerSec: 1.5,
+                BytesPerSec: 1500.0,
+                WindowSeconds: 30.0,
+                Timestamp: DateTimeOffset.UtcNow),
+        };
+        var controller = Build(MakeSettings(), aimd, metrics, out _);
+        await using var _disposer = controller;
+
+        var snap = controller.GetCurrentSnapshot();
+
+        snap.FilesPerSec.Should().Be(1.5);
+        snap.BytesPerSec.Should().Be(1500.0);
+        snap.WindowSeconds.Should().Be(30.0);
     }
 }

--- a/tests/unit/SlidingWindowMetricsTests.cs
+++ b/tests/unit/SlidingWindowMetricsTests.cs
@@ -311,4 +311,60 @@ public sealed class SlidingWindowMetricsTests
         // 呼び出し側のリストは破壊されない
         values.Should().Equal(5, 1, 4, 2, 3);
     }
+
+    // ─── #159 ウィンドウスループット ─────────────────────────────
+
+    [Fact]
+    public void GetSnapshot_TimeMode_FilesAndBytesPerSec_DividedByWindowSeconds()
+    {
+        // 検証対象: FilesPerSec / BytesPerSec  目的:
+        //   時間モードでは設定ウィンドウ秒（windowSec）を分母として算出する。
+        //   30 秒窓で 60 件成功なら 2 files/sec、合計 6000 bytes なら 200 bytes/sec。
+        var sut = new SlidingWindowMetrics(
+            mode: SlidingWindowMode.Time,
+            windowSec: 30,
+            minSamples: 1);
+
+        for (int i = 0; i < 60; i++)
+        {
+            sut.NotifyRequestSent();
+            sut.NotifySuccess(TimeSpan.FromMilliseconds(10), bytes: 100);
+        }
+
+        var snap = sut.GetSnapshot();
+
+        snap.WindowSeconds.Should().Be(30.0);
+        snap.FilesPerSec.Should().BeApproximately(2.0, 1e-9);
+        snap.BytesPerSec.Should().BeApproximately(200.0, 1e-9);
+    }
+
+    [Fact]
+    public void GetSnapshot_NoSuccess_FilesAndBytesPerSecZero()
+    {
+        // 検証対象: 成功 0 件時の表示  目的: 0 除算せず 0 を返す
+        var sut = new SlidingWindowMetrics(windowSec: 30, minSamples: 1);
+
+        sut.NotifyRequestSent();
+        sut.NotifyRateLimit(null);
+
+        var snap = sut.GetSnapshot();
+        snap.FilesPerSec.Should().Be(0.0);
+        snap.BytesPerSec.Should().Be(0.0);
+        // 設定ウィンドウ秒は維持される
+        snap.WindowSeconds.Should().Be(30.0);
+    }
+
+    [Fact]
+    public void NotifySuccess_DefaultBytes_IsZero()
+    {
+        // 検証対象: 後方互換  目的: 既存呼び出し（bytes 省略）はバイト数 0 として扱われる
+        var sut = new SlidingWindowMetrics(windowSec: 10, minSamples: 1);
+
+        sut.NotifyRequestSent();
+        sut.NotifySuccess(TimeSpan.FromMilliseconds(10));
+
+        var snap = sut.GetSnapshot();
+        snap.BytesPerSec.Should().Be(0.0);
+        snap.FilesPerSec.Should().BeApproximately(0.1, 1e-9); // 1 件 / 10 秒
+    }
 }

--- a/tests/unit/SlidingWindowMetricsTests.cs
+++ b/tests/unit/SlidingWindowMetricsTests.cs
@@ -367,4 +367,24 @@ public sealed class SlidingWindowMetricsTests
         snap.BytesPerSec.Should().Be(0.0);
         snap.FilesPerSec.Should().BeApproximately(0.1, 1e-9); // 1 件 / 10 秒
     }
+
+    [Fact]
+    public void GetSnapshot_CountMode_NoSuccess_WindowSecondsFallsBackToConfigured()
+    {
+        // 検証対象: 件数モードでの windowSeconds フォールバック  目的:
+        //   成功 2 件未満で実時間幅が決まらない場合、設定 windowSec を返す（XML コメントとの整合）。
+        var sut = new SlidingWindowMetrics(
+            mode: SlidingWindowMode.Count,
+            windowSec: 45,
+            maxCount: 100,
+            minSamples: 1);
+
+        sut.NotifyRequestSent();
+        sut.NotifyRateLimit(null);
+
+        var snap = sut.GetSnapshot();
+        snap.WindowSeconds.Should().Be(45.0);
+        snap.FilesPerSec.Should().Be(0.0);
+        snap.BytesPerSec.Should().Be(0.0);
+    }
 }


### PR DESCRIPTION
## Summary

Closes #159

レートベース制御（HybridRateController）が有効なときのスループット表示を、起動時からの累積平均ではなく **制御ウィンドウ（既定 30 秒）の集計値** へ切り替える。実効的な現在のスループットを把握しやすくする。

- `ISlidingWindowMetrics.NotifySuccess(latency, bytes=0)` overload と `SlidingWindowSnapshot` 拡張（`FilesPerSec` / `BytesPerSec` / `WindowSeconds`）
- `HybridRateController.GetCurrentSnapshot()` を追加し、`NotifySuccess` で bytes を内部メトリクスへ透過
- `ITransferRateController.NotifySuccess` も `(latency, bytes=0)` overload に拡張（旧コントローラーは bytes を無視して既存挙動維持）
- Dropbox / SharePoint パイプライン: `controller is HybridRateController` の場合、`throughput_files_per_min` / `throughput_bytes_per_sec` をウィンドウ集計値で上書きし、`throughput_window_sec` を併記
- Dashboard: HybridRateController 経路かつ window メトリクスがある場合、スループットカードのタイトルに「（直近 N 秒）」を付記
- ユニットテスト 5 件追加（合計 890 件 PASS）

## 設計判断

- **拡張方式（案 A）を採用**: 既存 `ISlidingWindowMetrics` を拡張してバイト数を保持。パイプライン側にローリング窓を新設する案と比べ、AIMD ループと同じウィンドウ評価器を再利用でき設定 `WindowSec` も共通化できる。
- **後方互換**: `bytes` は既定値 0、`SlidingWindowSnapshot` の追加プロパティはオプショナルではなく必須引数だが、唯一の生成箇所は `SlidingWindowMetrics.GetSnapshot()` のため呼び出し側修正なし。テスト側は新引数を追加。
- **メトリクス名は据え置き**: `throughput_files_per_min` / `throughput_bytes_per_sec` の系列を分けず上書き。HybridRateController が無効な経路（旧 `RateControlledTransferController` / `AdaptiveConcurrencyControllerAdapter`）は従来どおり累積平均を記録。
- **UI ラベル**: 新メトリクス `throughput_window_sec` を併記し、ダッシュボード側がそれを根拠に「（直近 N 秒）」を付記する。

## Test plan

- [x] `dotnet build` 成功（Release / 0 警告 0 エラー）
- [x] `dotnet test tests/unit` 890 件 PASS
- [ ] 手動: HybridRateController 有効時にダッシュボードのスループットカードに「（直近 30 秒）」が表示されることを確認
- [ ] 手動: 旧 `RateControlledTransferController` 経路（`UseHybridController=false`）では従来表示のままであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)