### PR TITLE
feat: UI-01 システムテーマ追随・ダーク/ライトテーマ切替 (#177)

### DIFF
--- a/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
@@ -251,7 +251,7 @@ public sealed class ConfigurationService : IConfigurationService
                     rcLatencyMode = lmProp.GetString() ?? "None";
             }
 
-            // ui.themeMode を読み取る（大文字小文字を吸収・未知値は system にフォールバック）
+            // migrator.ui.themeMode を読み取る（大文字小文字を吸収・未知値は system にフォールバック）
             var themeMode = "system";
             if (m.TryGetProperty("ui", out var uiProp) && uiProp.ValueKind == JsonValueKind.Object)
             {

--- a/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
@@ -251,12 +251,15 @@ public sealed class ConfigurationService : IConfigurationService
                     rcLatencyMode = lmProp.GetString() ?? "None";
             }
 
-            // ui.themeMode を読み取る
+            // ui.themeMode を読み取る（大文字小文字を吸収・未知値は system にフォールバック）
             var themeMode = "system";
             if (m.TryGetProperty("ui", out var uiProp) && uiProp.ValueKind == JsonValueKind.Object)
             {
                 if (uiProp.TryGetProperty("themeMode", out var tmProp) && tmProp.ValueKind == JsonValueKind.String)
-                    themeMode = tmProp.GetString() ?? "system";
+                {
+                    var raw = tmProp.GetString()?.Trim().ToLowerInvariant() ?? "system";
+                    themeMode = raw is "light" or "dark" or "system" ? raw : "system";
+                }
             }
 
             return new ConfigDto(
@@ -457,12 +460,15 @@ public sealed class ConfigurationService : IConfigurationService
             if (update.GraphColumns.HasValue) m["graphColumns"] = Math.Clamp(update.GraphColumns.Value, 1, 4);
             if (update.ThemeMode is not null)
             {
+                var normalizedThemeMode = update.ThemeMode.Trim().ToLowerInvariant();
+                if (normalizedThemeMode is not ("light" or "dark" or "system"))
+                    throw new ArgumentException("ThemeMode は light / dark / system のいずれかを指定してください。", nameof(update));
                 if (m["ui"] is not JsonObject uiObj)
                 {
                     uiObj = new JsonObject();
                     m["ui"] = uiObj;
                 }
-                uiObj["themeMode"] = update.ThemeMode;
+                uiObj["themeMode"] = normalizedThemeMode;
             }
 
             // アトミック書き込み: 一時ファイルに書き込んでからリネーム

--- a/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
@@ -40,7 +40,9 @@ public sealed record ConfigDto(
     string RcLatencyMode = "None",
     // ── UI 表示設定（#156/#157: ダッシュボードグラフ表示制御）──
     bool ShowGraphs = true,
-    int GraphColumns = 2);
+    int GraphColumns = 2,
+    // ── UI テーマ設定（#177）──
+    string ThemeMode = "system");
 
 /// <summary>
 /// PUT /api/config で受け取るマージ更新 DTO。null フィールドは上書きしない。
@@ -78,7 +80,9 @@ public sealed record ConfigUpdateDto(
     string? RcLatencyMode = null,
     // ── UI 表示設定（#156/#157: ダッシュボードグラフ表示制御）──
     bool? ShowGraphs = null,
-    int? GraphColumns = null);
+    int? GraphColumns = null,
+    // ── UI テーマ設定（#177）──
+    string? ThemeMode = null);
 
 /// <summary>
 /// Graph プロバイダー設定 DTO（シークレット除外済み）。
@@ -247,6 +251,14 @@ public sealed class ConfigurationService : IConfigurationService
                     rcLatencyMode = lmProp.GetString() ?? "None";
             }
 
+            // ui.themeMode を読み取る
+            var themeMode = "system";
+            if (m.TryGetProperty("ui", out var uiProp) && uiProp.ValueKind == JsonValueKind.Object)
+            {
+                if (uiProp.TryGetProperty("themeMode", out var tmProp) && tmProp.ValueKind == JsonValueKind.String)
+                    themeMode = tmProp.GetString() ?? "system";
+            }
+
             return new ConfigDto(
                 MaxParallelTransfers: GetInt(m, "maxParallelTransfers", 4),
                 MaxParallelFolderCreations: GetInt(m, "maxParallelFolderCreations", 4),
@@ -277,7 +289,8 @@ public sealed class ConfigurationService : IConfigurationService
                 RcAddStep: rcAddStep,
                 RcLatencyMode: rcLatencyMode,
                 ShowGraphs: !(m.TryGetProperty("showGraphs", out var sgProp) && sgProp.ValueKind == JsonValueKind.False),
-                GraphColumns: Math.Clamp(GetInt(m, "graphColumns", 2), 1, 4));
+                GraphColumns: Math.Clamp(GetInt(m, "graphColumns", 2), 1, 4),
+                ThemeMode: themeMode);
         }
         catch (Exception ex) when (ex is IOException or JsonException)
         {
@@ -442,6 +455,15 @@ public sealed class ConfigurationService : IConfigurationService
             // UI 表示設定
             if (update.ShowGraphs.HasValue) m["showGraphs"] = update.ShowGraphs.Value;
             if (update.GraphColumns.HasValue) m["graphColumns"] = Math.Clamp(update.GraphColumns.Value, 1, 4);
+            if (update.ThemeMode is not null)
+            {
+                if (m["ui"] is not JsonObject uiObj)
+                {
+                    uiObj = new JsonObject();
+                    m["ui"] = uiObj;
+                }
+                uiObj["themeMode"] = update.ThemeMode;
+            }
 
             // アトミック書き込み: 一時ファイルに書き込んでからリネーム
             var tmpPath = _configFilePath + ".tmp";

--- a/src/CloudMigrator.Dashboard/Components/DashboardApp.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardApp.razor
@@ -5,7 +5,7 @@
 @inject ICredentialStore CredentialStore
 @inject IConfigurationService ConfigurationService
 
-<MudThemeProvider Theme="_theme" />
+<MudThemeProvider @ref="_themeProvider" Theme="_theme" @bind-IsDarkMode="_isDarkMode" DefaultScrollbar="true" />
 <MudPopoverProvider />
 <MudDialogProvider />
 <MudSnackbarProvider />
@@ -75,7 +75,7 @@ else
                     <DashboardPage />
                     break;
                 case Page.Settings:
-                    <SettingsPage />
+                    <SettingsPage OnThemeModeChanged="OnThemeModeChangedAsync" />
                     break;
                 case Page.Doctor:
                     <DoctorPage />
@@ -94,6 +94,10 @@ else
     private bool _loading = true;
     private bool _showWizard;
     private string? _secretExpiryWarning;
+    private MudThemeProvider? _themeProvider;
+    private bool _isDarkMode;
+    private bool _systemIsDark;
+    private string _themeMode = "system";
 
     private static readonly MudTheme _theme = new()
     {
@@ -102,6 +106,26 @@ else
             Primary = "#1976D2",
             Secondary = "#424242",
             AppbarBackground = "#1976D2",
+        },
+        PaletteDark = new PaletteDark
+        {
+            Background = "#141720",
+            BackgroundGray = "#0c0e14",
+            Surface = "#1a1e2e",
+            AppbarBackground = "#0f1117",
+            DrawerBackground = "#0a0c12",
+            Primary = "#818cf8",
+            PrimaryDarken = "#6366f1",
+            PrimaryLighten = "#a5b4fc",
+            Secondary = "#94a3b8",
+            Success = "#4ade80",
+            Warning = "#fbbf24",
+            Error = "#f87171",
+            Info = "#818cf8",
+            TextPrimary = "#e2e8f0",
+            TextSecondary = "#94a3b8",
+            Divider = "#252c42",
+            TableLines = "#1e2336",
         },
     };
 
@@ -112,6 +136,9 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        var cfg = await ConfigurationService.GetConfigAsync();
+        _themeMode = cfg.ThemeMode;
+
         var state = await WizardStateService.LoadAsync();
         if (!state.IsCompleted)
         {
@@ -158,6 +185,46 @@ else
     {
         await WizardStateService.ResetAsync();
         _showWizard = true;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && _themeProvider is not null)
+        {
+            _systemIsDark = await _themeProvider.GetSystemDarkModeAsync();
+            _isDarkMode = _themeMode switch
+            {
+                "dark" => true,
+                "light" => false,
+                _ => _systemIsDark,
+            };
+            StateHasChanged();
+            await _themeProvider.WatchSystemDarkModeAsync(OnSystemPreferenceChanged);
+        }
+    }
+
+    private async Task OnSystemPreferenceChanged(bool isDark)
+    {
+        _systemIsDark = isDark;
+        if (_themeMode == "system")
+        {
+            _isDarkMode = isDark;
+            StateHasChanged();
+        }
+        await Task.CompletedTask;
+    }
+
+    internal async Task OnThemeModeChangedAsync(string themeMode)
+    {
+        _themeMode = themeMode;
+        _isDarkMode = themeMode switch
+        {
+            "dark" => true,
+            "light" => false,
+            _ => _systemIsDark,
+        };
+        StateHasChanged();
+        await Task.CompletedTask;
     }
 
     private async Task CheckSecretExpiryAsync()

--- a/src/CloudMigrator.Dashboard/Components/DashboardApp.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardApp.razor
@@ -5,7 +5,7 @@
 @inject ICredentialStore CredentialStore
 @inject IConfigurationService ConfigurationService
 
-<MudThemeProvider @ref="_themeProvider" Theme="_theme" @bind-IsDarkMode="_isDarkMode" DefaultScrollbar="true" />
+<MudThemeProvider @ref="_themeProvider" Theme="_theme" @bind-IsDarkMode="_isDarkMode" DefaultScrollbar="true" ObserveSystemDarkModeChange="false" />
 <MudPopoverProvider />
 <MudDialogProvider />
 <MudSnackbarProvider />

--- a/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
@@ -49,6 +49,37 @@ else
         </MudCardContent>
     </MudCard>
 
+    @* ── 表示設定（折りたたみなし） *@
+    <MudCard Elevation="2" Style="max-width: 600px;" Class="mb-4">
+        <MudCardHeader>
+            <CardHeaderContent>
+                <MudText Typo="Typo.subtitle1">表示設定</MudText>
+            </CardHeaderContent>
+        </MudCardHeader>
+        <MudCardContent>
+            <MudSelect T="string" @bind-Value="_editThemeMode"
+                       Label="テーマ"
+                       Variant="Variant.Outlined"
+                       HelperText="アプリの配色テーマを選択します。デフォルト: システムに従う">
+                <MudSelectItem Value="@("light")">ライト</MudSelectItem>
+                <MudSelectItem Value="@("dark")">ダーク</MudSelectItem>
+                <MudSelectItem Value="@("system")">システムに従う</MudSelectItem>
+            </MudSelect>
+        </MudCardContent>
+        <MudCardActions>
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.Save"
+                       OnClick="SaveThemeAsync">
+                保存
+            </MudButton>
+            <MudButton Variant="Variant.Text"
+                       OnClick="ResetThemeAsync">
+                リセット
+            </MudButton>
+        </MudCardActions>
+    </MudCard>
+
     <MudCard Elevation="2" Style="max-width: 600px;">
         <MudCardContent>
             @* ── 上級者向け設定（折りたたみ） ──────────────────────── *@
@@ -369,6 +400,8 @@ else
     </MessageContent>
 </MudMessageBox>
 @code {
+    [Parameter] public EventCallback<string> OnThemeModeChanged { get; set; }
+
     private ConfigDto? _config;
     private DiscoveryConfigDto? _discovery;
     private bool _isRebuilding;
@@ -406,6 +439,8 @@ else
     // グラフ表示設定（#156/#157）
     private bool _editShowGraphs;
     private int _editGraphColumns;
+    // UI テーマ設定（#177）
+    private string _editThemeMode = "system";
 
     protected override async Task OnInitializedAsync()
     {
@@ -479,6 +514,7 @@ else
         _editRcLatencyMode = cfg.RcLatencyMode;
         _editShowGraphs = cfg.ShowGraphs;
         _editGraphColumns = cfg.GraphColumns;
+        _editThemeMode = cfg.ThemeMode;
     }
 
     private async Task SaveAsync()
@@ -552,6 +588,29 @@ else
         if (_config is not null)
             CopyToEditFields(_config);
         await Task.CompletedTask;
+    }
+
+    private async Task SaveThemeAsync()
+    {
+        try
+        {
+            await ConfigService.UpdateConfigAsync(new ConfigUpdateDto(ThemeMode: _editThemeMode));
+            _config = await ConfigService.GetConfigAsync();
+            CopyToEditFields(_config);
+            await OnThemeModeChanged.InvokeAsync(_editThemeMode);
+            Snackbar.Add("表示設定を保存しました。", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"表示設定の保存に失敗しました: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private Task ResetThemeAsync()
+    {
+        if (_config is not null)
+            _editThemeMode = _config.ThemeMode;
+        return Task.CompletedTask;
     }
 
     private async Task FullRebuildAsync()

--- a/tests/unit/ConfigurationServiceTests.cs
+++ b/tests/unit/ConfigurationServiceTests.cs
@@ -725,6 +725,95 @@ public sealed class ConfigurationServiceTests : IDisposable
         result.GraphColumns.Should().Be(3);
     }
 
+    // ── ThemeMode（UI テーマ設定 #177）────────────────────────────────
+
+    [Fact]
+    public async Task GetConfigAsync_WhenThemeModeAbsent_ReturnsSystemByDefault()
+    {
+        // 検証対象: GetConfigAsync（themeMode 未設定）  目的: デフォルト値 "system" を返すこと
+        var svc = new ConfigurationService(_configPath);
+
+        var result = await svc.GetConfigAsync();
+
+        result.ThemeMode.Should().Be("system");
+    }
+
+    [Theory]
+    [InlineData("light", "light")]
+    [InlineData("dark", "dark")]
+    [InlineData("system", "system")]
+    [InlineData("DARK", "dark")]       // 大文字を正規化
+    [InlineData("Light", "light")]     // 混在ケースを正規化
+    [InlineData("invalid", "system")]  // 未知値は system にフォールバック
+    [InlineData("", "system")]         // 空文字は system にフォールバック
+    public async Task GetConfigAsync_ThemeModeNormalization(string jsonValue, string expected)
+    {
+        // 検証対象: GetConfigAsync（themeMode 正規化）  目的: 大文字小文字吸収・未知値フォールバックが機能すること
+        WriteConfig(new
+        {
+            migrator = new
+            {
+                maxParallelTransfers = 4,
+                chunkSizeMb = 5,
+                largeFileThresholdMb = 4,
+                retryCount = 3,
+                timeoutSec = 300,
+                destinationRoot = string.Empty,
+                destinationProvider = "sharepoint",
+                ui = new { themeMode = jsonValue }
+            }
+        });
+        var svc = new ConfigurationService(_configPath);
+
+        var result = await svc.GetConfigAsync();
+
+        result.ThemeMode.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("light")]
+    [InlineData("dark")]
+    [InlineData("system")]
+    public async Task UpdateConfigAsync_ThemeMode_PersistsValue(string mode)
+    {
+        // 検証対象: UpdateConfigAsync（ThemeMode 保存）  目的: 保存した値が読み直しで正しく返ること
+        var svc = new ConfigurationService(_configPath);
+
+        await svc.UpdateConfigAsync(new ConfigUpdateDto(ThemeMode: mode));
+        var result = await svc.GetConfigAsync();
+
+        result.ThemeMode.Should().Be(mode);
+    }
+
+    [Theory]
+    [InlineData("LIGHT", "light")]   // 大文字保存 → 小文字で正規化保存
+    [InlineData("  dark  ", "dark")] // 前後空白を除去して保存
+    public async Task UpdateConfigAsync_ThemeMode_NormalizesBeforePersisting(string input, string expected)
+    {
+        // 検証対象: UpdateConfigAsync（ThemeMode 正規化保存）  目的: 大文字・前後空白を除去して保存すること
+        var svc = new ConfigurationService(_configPath);
+
+        await svc.UpdateConfigAsync(new ConfigUpdateDto(ThemeMode: input));
+        var result = await svc.GetConfigAsync();
+
+        result.ThemeMode.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("invalid")]
+    [InlineData("auto")]
+    [InlineData("")]
+    public async Task UpdateConfigAsync_ThemeMode_ThrowsForInvalidValue(string invalidMode)
+    {
+        // 検証対象: UpdateConfigAsync（ThemeMode 不正値）  目的: light/dark/system 以外は ArgumentException になること
+        var svc = new ConfigurationService(_configPath);
+
+        var act = async () => await svc.UpdateConfigAsync(new ConfigUpdateDto(ThemeMode: invalidMode));
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*ThemeMode*");
+    }
+
     [Fact]
     public async Task GetConfigAsync_WhenFileNotFound_ReturnsDefaultDto()
     {


### PR DESCRIPTION
## Summary

- `ConfigurationService` に `ThemeMode`（`"light"` / `"dark"` / `"system"`）の永続化を追加（`config.json` の `ui.themeMode`）
- `DashboardApp` に `PaletteDark`（ARBORデザイン配色）を追加し、`MudThemeProvider` でダークモードを制御
- OS のテーマ変更を `GetSystemDarkModeAsync` / `WatchSystemDarkModeAsync` でリアルタイム追随
- `SettingsPage` に「表示設定」カード（折りたたみなし）を追加し、テーマ選択 `MudSelect` を配置

## Test plan

- [ ] アプリ起動時にデフォルト「システムに従う」が適用されることを確認
- [ ] 設定ページ > 表示設定 > ダークを選択して保存 → ダークテーマに切り替わることを確認
- [ ] 設定ページ > 表示設定 > ライトを選択して保存 → ライトテーマに切り替わることを確認
- [ ] 「システムに従う」でOSのダーク/ライト切替が自動反映されることを確認
- [ ] アプリ再起動後に保存済みテーマが復元されることを確認
- [ ] `config.json` に `ui.themeMode` が書き込まれることを確認

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)