### PR TITLE
chore: ルート選択画面からバージョンチップ（v0.4.0対応・v0.5.0予定）を削除

### DIFF
--- a/src/CloudMigrator.Dashboard/Components/Wizard/RouteSelectionPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/RouteSelectionPage.razor
@@ -27,11 +27,9 @@
                             Personal OneDrive から Dropbox へファイルを移行します
                         </MudText>
                     </div>
-                    <MudChip T="string" Color="Color.Success" Size="Size.Small">v0.4.0 対応</MudChip>
                 </MudStack>
             </MudPaper>
 
-            @* OneDrive → SharePoint 路線（v0.5.0 予定） *@
             <MudPaper Elevation="@(_selected == WizardRoute.OneDriveToSharePoint ? 3 : 1)"
                       Class="pa-4 cursor-pointer"
                       Style="@RouteCardStyle(WizardRoute.OneDriveToSharePoint)"
@@ -47,7 +45,6 @@
                             Personal OneDrive から SharePoint Document Library へ移行します
                         </MudText>
                     </div>
-                    <MudChip T="string" Color="Color.Default" Size="Size.Small">v0.5.0 予定</MudChip>
                 </MudStack>
             </MudPaper>
         </MudStack>


### PR DESCRIPTION
## 変更内容

`RouteSelectionPage.razor` のルート選択カードから不要になったバージョンチップを削除。

- `OneDrive → Dropbox` カードの `v0.4.0 対応` チップを削除
- `OneDrive → SharePoint` カードの `v0.5.0 予定` チップとコメントを削除
