### PR TITLE
[codex] fix dashboard state DB routing

### DIFF
--- a/docs/archive/tasks-archive-20260501.md
+++ b/docs/archive/tasks-archive-20260501.md
@@ -1,0 +1,80 @@
+# タスク管理
+
+詳細仕様: [docs/implementation-plan.md](docs/implementation-plan.md)
+前フェーズ履歴: [tasks-archive-20260414.md](docs/archive/tasks-archive-20260414.md)
+
+## 現在の状態: v0.6.0 HybridRateController バグ修正・UI 改善 📋
+
+---
+
+## ✅ 完了: Graph API レートベース転送制御エンジン実装（v0.5.0）
+
+**PR**: [#148](https://github.com/scottlz0310/cloud-migrator/pull/148)  
+**完了日**: 2026-04-16
+
+### 完了タスク
+
+- [x] `ITransferRateController` / `IMetricsAggregator` インターフェース定義
+- [x] `TransferMetricsAggregator` 実装（1 秒バケット固定リングバッファ）
+- [x] `MetricsBuffer` 実装（非同期 DB バッファ）
+- [x] `RateControlledTransferController` 実装（ヒステリシス 3 段階制御 + トークンバケット）
+- [x] `AdaptiveConcurrencyControllerAdapter` 実装（後方互換アダプター）
+- [x] `RateControlSettings` / `MigratorOptions.RateControl` 設定統合
+- [x] `TransferCommand` への `UseRateControl` フラグ統合
+- [x] `SharePointMigrationPipeline` Phase C インフライトカウンター回復修正
+- [x] `TransferMetricsAggregator.GetSnapshot()` Rate429 計算式修正
+- [x] `RateControlledTransferController.DisposeAsync()` べき等性保証
+- [x] `CliServices.cs` 不要フィールド整理
+- [x] ユニットテスト 627 件全合格
+
+---
+
+## 次フェーズ: v0.6.0 スループット主制御ハイブリッド方式
+
+> 設計書: [docs/transfer-control-design-v2.md](docs/transfer-control-design-v2.md)
+
+### 概要
+
+v0.5.0 のヒステリシス制御（requests/sec）から **トークンバケット × AIMD フィードバック × 並列数補助制御のハイブリッド方式**（tokens/sec）へ移行する。
+
+### 実装順序
+
+| 順番 | ISSUE | タイトル | 状態 | 備考 |
+|------|-------|---------|------|------|
+| 1（並行） | [#160](https://github.com/scottlz0310/cloud-migrator/issues/160) | トークンバケット + 重み付きコスト | ✅ 完了（PR #167） | `FileCostCalculator` / `WeightedTokenBucket` 追加・設定統合・テスト 53 件 |
+| 1（並行） | [#161](https://github.com/scottlz0310/cloud-migrator/issues/161) | スライディングウィンドウ指標収集 | ✅ 完了 | `SlidingWindowMetrics` 追加・P95/件数&時間切替・設定統合・テスト 24 件 |
+| 2 | [#162](https://github.com/scottlz0310/cloud-migrator/issues/162) | AIMD フィードバック制御 + クールダウン | ✅ 完了 | `AimdFeedbackController` 追加・4 信号判定・ベースライン EMA・クールダウン・テスト 24 件 |
+| 3 | [#163](https://github.com/scottlz0310/cloud-migrator/issues/163) | 並列数補助制御ハイブリッド移行 | 🟢 統合 PR 実装完了 | `HybridRateController` 追加・§7 制御ループ + §4.3 並列数補助制御・`RateStateStore` v2/v0.5.x 互換・CLI + Dashboard 統合・テスト 25 件。旧 `AdaptiveConcurrencyController` / `TokenBucketRateLimiter` は `[Obsolete]` 付与のみ（実削除は後続 PR） |
+| 4 | [#159](https://github.com/scottlz0310/cloud-migrator/issues/159) | スループット表示を制御窓ベースに変更（UI） | ✅ 完了 | HybridRateController 経路で `throughput_window_sec` 記録・Dashboard タイトルに「（直近 N 秒）」付記 |
+| 5 | [#155](https://github.com/scottlz0310/cloud-migrator/issues/155) | 統計エリア統合（UI） | ✅ 完了 | 統計7指標 + RCモニター4指標を1カードに統合 |
+| 自由 | [#154](https://github.com/scottlz0310/cloud-migrator/issues/154) | ルート情報をダッシュボードに移動（UI） | ✅ 完了 | ヘッダーにルートチップ＋ツールチップ追加 |
+| 自由 | [#156](https://github.com/scottlz0310/cloud-migrator/issues/156) | グラフ表示オン/オフ切り替え（UI） | ✅ 完了 | ShowGraphs 設定 + ヘッダーアイコンボタン |
+| 自由 | [#157](https://github.com/scottlz0310/cloud-migrator/issues/157) | グラフ列数可変設定（UI） | ✅ 完了 | GraphColumns 設定 + MudItem 幅動的制御 |
+| 自由 | [#158](https://github.com/scottlz0310/cloud-migrator/issues/158) | フォルダ/ファイル進捗 Phase 連動表示（UI） | ✅ 完了 | folder_creation/transferring フェーズ連動進捗バー統合 |
+
+### スコープ外（凍結・v0.6.0 効果確認後に判断）
+
+| ISSUE | 内容 | 判断タイミング |
+|-------|------|---------------|
+| [#136](https://github.com/scottlz0310/cloud-migrator/issues/136) §1 | パルス制御 | #162 完了後 |
+| [#136](https://github.com/scottlz0310/cloud-migrator/issues/136) §2 | ファイルサイズ別レーン分離 | #160 完了後 |
+
+---
+
+## 🔧 進行中: HybridRateController バグ修正・UI 改善
+
+### 完了タスク
+
+- [x] `AimdFeedbackController`: クールダウン中の429で `Hold` を返す修正（二重クールダウン防止）
+- [x] `LatencyEvaluationMode.None` 追加・デフォルト化（429専制御、SlowDecrease 無効化）
+- [x] `HybridRateController`: 制御ログ `LogDebug` → `LogInformation` 昇格（信号・レート・429率・P95 出力）
+- [x] `EmergencyDecay` / `EmergencyInflightDecay` デフォルト緩和: 0.7/0.75 → **0.9/0.9**（Retry-After主制御設計）
+- [x] 設定メニュー: `UseHybridController` / `CooldownSec` / `EmergencyDecay` / `EmergencyInflightDecay` / `AddStep` / `LatencyMode` の6項目追加（UI・API・バリデーション）
+- [x] Dashboard リアルタイムモニタ: HybridRateController のメトリクスキー不一致修正（`rate_tokens_per_sec` / `max_inflight` / `rate_429` / `signal` 対応）
+- [x] ユニットテスト 902 件全合格
+- [x] ダッシュボードリデザイン（UI-03、#179）: タブ構造 3 タブ（概要 / 詳細情報 / ログ）・`GetLatestProcessingNameAsync` 追加・一行ログフェードアニメーション
+- [x] ユニットテスト 922 件全合格
+- [x] Dropbox 路線選択時に SharePoint 路線に固定されるバグ修正: `DropboxOAuthPage` で `config.json` への `destinationProvider`/`migrationRoute` 書き込みを追加
+- [x] Dashboard の転送処理が常に SharePoint パイプラインを使用するバグ修正: `App.xaml.cs` の `MigrationWork` に `isDropbox` 分岐を追加し、Dropbox 路線では `DropboxMigrationPipeline` を使用するよう修正
+
+---

--- a/docs/archive/tasks-archive-20260501.md
+++ b/docs/archive/tasks-archive-20260501.md
@@ -1,7 +1,7 @@
 # タスク管理
 
-詳細仕様: [docs/implementation-plan.md](docs/implementation-plan.md)
-前フェーズ履歴: [tasks-archive-20260414.md](docs/archive/tasks-archive-20260414.md)
+詳細仕様: [docs/implementation-plan.md](../implementation-plan.md)
+前フェーズ履歴: [tasks-archive-20260414.md](tasks-archive-20260414.md)
 
 ## 現在の状態: v0.6.0 HybridRateController バグ修正・UI 改善 📋
 
@@ -31,7 +31,7 @@
 
 ## 次フェーズ: v0.6.0 スループット主制御ハイブリッド方式
 
-> 設計書: [docs/transfer-control-design-v2.md](docs/transfer-control-design-v2.md)
+> 設計書: [docs/transfer-control-design-v2.md](../transfer-control-design-v2.md)
 
 ### 概要
 

--- a/src/CloudMigrator.Dashboard/App.xaml.cs
+++ b/src/CloudMigrator.Dashboard/App.xaml.cs
@@ -85,10 +85,15 @@ public partial class App : Application
                 .Get<MigratorOptions>() ?? new MigratorOptions());
 
         services.AddSingleton<IConfigurationService, ConfigurationService>();
+        services.AddSingleton<ITransferStateDbAccessor>(sp =>
+            new TransferStateDbAccessor(
+                sp.GetRequiredService<Func<MigratorOptions>>(),
+                dbPath,
+                sp.GetRequiredService<ILogger<TransferStateDbAccessor>>()));
         services.AddSingleton<ITransferJobService>(sp =>
         {
             var loggerFactory2 = sp.GetRequiredService<ILoggerFactory>();
-            var stateDb = sp.GetRequiredService<ITransferStateDb>();
+            var stateDbAccessor = sp.GetRequiredService<ITransferStateDbAccessor>();
 
             async Task MigrationWork(CancellationToken ct)
             {
@@ -106,23 +111,9 @@ public partial class App : Application
                 // プロファイルを参照し、対応する Enabled=true かつ UseRateControl=false 時のみ ACC を使用する
                 var isDropbox = opts.DestinationProvider.Equals("dropbox", StringComparison.OrdinalIgnoreCase);
 
-                // Dropbox 路線では専用 stateDb を早期生成してメトリクスバッファ・ハッシュリセットを正しい DB に向ける
-                // （DI 解決の stateDb は ResolveDefaultDbPath() により SharePoint DB を指す場合がある）
-                SqliteTransferStateDb? dropboxStateDb = null;
-                if (isDropbox)
-                {
-                    dropboxStateDb = new SqliteTransferStateDb(opts.Paths.DropboxStateDb);
-                    try
-                    {
-                        await dropboxStateDb.InitializeAsync(ct).ConfigureAwait(false);
-                    }
-                    catch
-                    {
-                        await dropboxStateDb.DisposeAsync().ConfigureAwait(false);
-                        throw;
-                    }
-                }
-                ITransferStateDb effectiveStateDb = dropboxStateDb is not null ? dropboxStateDb : stateDb;
+                // UI とジョブが同じ route-aware な DB 解決を使うことで、Dropbox 実行時も
+                // Dashboard が書き込み先と同じ state DB を参照できるようにする。
+                var effectiveStateDb = await stateDbAccessor.GetForOptionsAsync(opts, ct).ConfigureAwait(false);
 
                 var adaptiveOpts = opts.GetAdaptiveConcurrency(isDropbox ? "dropbox" : "sharepoint");
                 AdaptiveConcurrencyController? accMain = null;        // Dispose + onRateLimit 用に保持
@@ -279,12 +270,10 @@ public partial class App : Application
                                 disposeHttpClient: true,
                                 maxRetry: opts.RetryCount,
                                 onRateLimit: onRateLimit);
-                            // dropboxStateDb は MigrationWork 冒頭で早期生成・初期化済み
-                            // hashChanged 時のリセットも effectiveStateDb.ResetAllAsync() により処理済み
                             var dropboxPipeline = new DropboxMigrationPipeline(
                                 storageProvider,
                                 dropboxProvider,
-                                dropboxStateDb!,
+                                effectiveStateDb,
                                 opts,
                                 loggerFactory2.CreateLogger<DropboxMigrationPipeline>(),
                                 concurrencyController);
@@ -303,7 +292,7 @@ public partial class App : Application
                         var pipeline = new SharePointMigrationPipeline(
                             storageProvider,
                             storageProvider,
-                            stateDb,
+                            effectiveStateDb,
                             opts,
                             loggerFactory2.CreateLogger<SharePointMigrationPipeline>(),
                             concurrencyController,
@@ -325,9 +314,6 @@ public partial class App : Application
                         await rateController.DisposeAsync().ConfigureAwait(false);
                     if (rateMetricsBuffer is not null)
                         await rateMetricsBuffer.DisposeAsync().ConfigureAwait(false);
-                    // Dropbox 路線で早期生成した専用 stateDb を最後に Dispose する
-                    if (dropboxStateDb is not null)
-                        await dropboxStateDb.DisposeAsync().ConfigureAwait(false);
                 }
             }
 
@@ -348,29 +334,6 @@ public partial class App : Application
                 DriveId: configuration["Migrator:Graph:SharePointDriveId"] ?? string.Empty,
                 DestinationRoot: configuration["Migrator:DestinationRoot"] ?? string.Empty);
             return new SetupDoctorService(opts, sp.GetRequiredService<System.Net.Http.IHttpClientFactory>());
-        });
-
-        // ITransferStateDb: --db-path 引数 > 選択済み DB > SharePoint デフォルト（初回実行時は DB を新規作成）
-        services.AddSingleton<ITransferStateDb>(sp =>
-        {
-            var resolvedPath = dbPath ?? ResolveDefaultDbPath();
-            var db = new SqliteTransferStateDb(resolvedPath);
-            try
-            {
-                db.InitializeAsync(CancellationToken.None).GetAwaiter().GetResult();
-            }
-            catch (Exception ex)
-            {
-                // 初期化失敗: db を確実に破棄してからフォールバック（ファイルハンドルのリーク防止）
-                db.DisposeAsync().AsTask().GetAwaiter().GetResult();
-                MessageBox.Show(
-                    $"DB の初期化に失敗しました。DB なしモードで起動します。\n\n{ex.Message}",
-                    "警告",
-                    MessageBoxButton.OK,
-                    MessageBoxImage.Warning);
-                return NullTransferStateDb.Instance;
-            }
-            return db;
         });
 
         // ── WPF Host サービス ──────────────────────────────────────────────
@@ -455,32 +418,4 @@ public partial class App : Application
         return controller;
     }
 
-    /// <summary>
-    /// デフォルトの DB パスを解決する。
-    /// 両方の DB が存在する場合はユーザーに選択させる。
-    /// </summary>
-    private static string ResolveDefaultDbPath()
-    {
-        var dropboxDb = AppDataPaths.LogFile("dropbox_transfer_state.db");
-        var sharePointDb = AppDataPaths.LogFile("sharepoint_transfer_state.db");
-        var hasDropbox = File.Exists(dropboxDb);
-        var hasSharePoint = File.Exists(sharePointDb);
-
-        if (hasDropbox && hasSharePoint)
-        {
-            var result = MessageBox.Show(
-                "Dropbox 用 DB と SharePoint 用 DB の両方が見つかりました。\n" +
-                "表示する DB を選択してください。\n\n" +
-                "はい: Dropbox\nいいえ: SharePoint",
-                "DB の選択",
-                MessageBoxButton.YesNo,
-                MessageBoxImage.Question);
-
-            return result == MessageBoxResult.Yes ? dropboxDb : sharePointDb;
-        }
-
-        if (hasDropbox) return dropboxDb;
-        // SharePoint DB（既存または新規作成）をデフォルトとして返す
-        return sharePointDb;
-    }
 }

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -517,6 +517,7 @@ else
     // ── 一行ログ ────────────────────────────────────────────────────────────────
     private string? _latestProcessingName;
     private bool _logVisible = true;
+    private ITransferStateDb? _activeStateDb;
 
     // ── ログタブ（直近エントリ） ────────────────────────────────────────────────
     [Parameter] public EventCallback NavigateToLogs { get; set; }
@@ -712,8 +713,9 @@ else
         {
             try
             {
-                var stateDb = await StateDbAccessor.GetCurrentAsync(ct);
-                newName = await stateDb.GetLatestProcessingNameAsync(ct);
+                var stateDb = _activeStateDb;
+                if (stateDb is not null)
+                    newName = await stateDb.GetLatestProcessingNameAsync(ct);
             }
             catch (OperationCanceledException) { throw; }
             catch (Exception ex) { Logger.LogDebug(ex, "一行ログ取得失敗（スキップ）"); }
@@ -753,7 +755,20 @@ else
         catch (OperationCanceledException) { throw; }
         catch (Exception ex) { Logger.LogWarning(ex, "Discovery 設定の読み込みに失敗しました。"); }
 
-        var stateDb = await StateDbAccessor.GetForOptionsAsync(opts, ct);
+        ITransferStateDb stateDb;
+        try
+        {
+            stateDb = await StateDbAccessor.GetForOptionsAsync(opts, ct);
+            _activeStateDb = stateDb;
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "RefreshAllAsync: 状態 DB の解決に失敗しました。今回の UI 更新をスキップします。");
+            _summary ??= new TransferDbSummary();
+            _recentLogEntries = LogChannel.GetRecentEntries();
+            return;
+        }
 
         try { _summary = await stateDb.GetSummaryAsync(ct); }
         catch (Exception ex) { Logger.LogError(ex, "RefreshAllAsync: GetSummaryAsync 失敗"); _summary ??= new TransferDbSummary(); }

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -1,4 +1,4 @@
-@inject ITransferStateDb TransferStateDb
+@inject ITransferStateDbAccessor StateDbAccessor
 @inject ITransferJobService JobService
 @inject Func<MigratorOptions> OptionsFactory
 @inject IConfigurationService ConfigService
@@ -710,7 +710,11 @@ else
         string? newName = null;
         if (_phase == "transferring")
         {
-            try { newName = await TransferStateDb.GetLatestProcessingNameAsync(ct); }
+            try
+            {
+                var stateDb = await StateDbAccessor.GetCurrentAsync(ct);
+                newName = await stateDb.GetLatestProcessingNameAsync(ct);
+            }
             catch (OperationCanceledException) { throw; }
             catch (Exception ex) { Logger.LogDebug(ex, "一行ログ取得失敗（スキップ）"); }
         }
@@ -749,7 +753,9 @@ else
         catch (OperationCanceledException) { throw; }
         catch (Exception ex) { Logger.LogWarning(ex, "Discovery 設定の読み込みに失敗しました。"); }
 
-        try { _summary = await TransferStateDb.GetSummaryAsync(ct); }
+        var stateDb = await StateDbAccessor.GetForOptionsAsync(opts, ct);
+
+        try { _summary = await stateDb.GetSummaryAsync(ct); }
         catch (Exception ex) { Logger.LogError(ex, "RefreshAllAsync: GetSummaryAsync 失敗"); _summary ??= new TransferDbSummary(); }
         if (_summary is null) return;
 
@@ -760,15 +766,15 @@ else
         if (_currentJob is not null)
             _currentJob = JobService.GetJob(_currentJob.JobId) ?? _currentJob;
 
-        await RefreshPhaseAsync(opts.DestinationProvider, ct);
-        await RefreshMetricsAsync(ct);
-        await UpdateElapsedAndEtaAsync(ct);
-        await RefreshFolderProgressAsync(ct);
-        if (_useRateControl) await RefreshRateControlMetricsAsync(ct);
+        await RefreshPhaseAsync(opts.DestinationProvider, stateDb, ct);
+        await RefreshMetricsAsync(stateDb, ct);
+        await UpdateElapsedAndEtaAsync(stateDb, ct);
+        await RefreshFolderProgressAsync(stateDb, ct);
+        if (_useRateControl) await RefreshRateControlMetricsAsync(stateDb, ct);
         _recentLogEntries = LogChannel.GetRecentEntries();
     }
 
-    private async Task RefreshPhaseAsync(string destinationProvider, CancellationToken ct)
+    private async Task RefreshPhaseAsync(string destinationProvider, ITransferStateDb stateDb, CancellationToken ct)
     {
         if (_summary is null) return;
 
@@ -805,11 +811,11 @@ else
             return;
         }
 
-        var folderCreationDone = await TransferStateDb.GetCheckpointAsync("folder_creation_complete", ct);
+        var folderCreationDone = await stateDb.GetCheckpointAsync("folder_creation_complete", ct);
         _phase = folderCreationDone == "true" ? "transferring" : "folder_creation";
     }
 
-    private async Task RefreshRateControlMetricsAsync(CancellationToken ct)
+    private async Task RefreshRateControlMetricsAsync(ITransferStateDb stateDb, CancellationToken ct)
     {
         // 直近 2 分間のメトリクスから最新値を 1 クエリで一括取得する
         // 例外発生時はログに残してスキップ（PeriodicTimer ループが停止しないよう保護）
@@ -819,7 +825,7 @@ else
             if (_useHybridController)
             {
                 // HybridRateController のメトリクスキー（AimdSignal ベース）
-                var latest = await TransferStateDb.GetLatestMetricsAsync(
+                var latest = await stateDb.GetLatestMetricsAsync(
                     [HybridRateController.MetricRateTokensPerSec, HybridRateController.MetricMaxInflight,
                      HybridRateController.MetricRate429, HybridRateController.MetricSignal],
                     windowMinutes, ct);
@@ -832,7 +838,7 @@ else
             else
             {
                 // RateControlledTransferController のメトリクスキー（ヒステリシスコード）
-                var latest = await TransferStateDb.GetLatestMetricsAsync(
+                var latest = await stateDb.GetLatestMetricsAsync(
                     ["current_rate_limit", "current_in_flight", "rate_429_short", "rate_429_long", "hysteresis_state_code"],
                     windowMinutes, ct);
 
@@ -853,25 +859,25 @@ else
         }
     }
 
-    private async Task RefreshFolderProgressAsync(CancellationToken ct)
+    private async Task RefreshFolderProgressAsync(ITransferStateDb stateDb, CancellationToken ct)
     {
-        var totalStr = await TransferStateDb.GetCheckpointAsync("folder_total", ct);
+        var totalStr = await stateDb.GetCheckpointAsync("folder_total", ct);
         if (int.TryParse(totalStr, out var total)) _folderTotal = total;
         else { _folderTotal = 0; _folderDone = 0; }
 
         if (_folderTotal > 0)
         {
-            var metrics = await TransferStateDb.GetMetricsAsync("sp_folder_done", 120, ct);
+            var metrics = await stateDb.GetMetricsAsync("sp_folder_done", 120, ct);
             if (metrics.Count > 0) _folderDone = (int)metrics[^1].Value;
         }
     }
 
-    private async Task UpdateElapsedAndEtaAsync(CancellationToken ct)
+    private async Task UpdateElapsedAndEtaAsync(ITransferStateDb stateDb, CancellationToken ct)
     {
         if (_summary is null) return;
 
         // 実稼働時間: DBに累積保存された秒数（停止中の時間を含まない）
-        var workingSecondsStr = await TransferStateDb.GetCheckpointAsync("pipeline_working_seconds", ct);
+        var workingSecondsStr = await stateDb.GetCheckpointAsync("pipeline_working_seconds", ct);
         if (double.TryParse(workingSecondsStr, out var workingSeconds) && workingSeconds > 0)
         {
             // ジョブ実行中は現在のセッション分も加算する
@@ -895,7 +901,7 @@ else
             : (remaining == 0 ? "完了" : "—");
     }
 
-    private async Task RefreshMetricsAsync(CancellationToken ct)
+    private async Task RefreshMetricsAsync(ITransferStateDb stateDb, CancellationToken ct)
     {
         if (_summary is null) return;
         var startedAt = _summary.PipelineStartedAt ?? _summary.FirstUpdatedAt;
@@ -903,13 +909,13 @@ else
             ? Math.Clamp((int)(DateTimeOffset.UtcNow - startedAt.Value).TotalMinutes + 10, 60, 120)
             : 60;
 
-        var filesData = await TransferStateDb.GetMetricsAsync("throughput_files_per_min", minutes, ct);
-        var bytesData = await TransferStateDb.GetMetricsAsync("throughput_bytes_per_sec", minutes, ct);
-        var rlData    = await TransferStateDb.GetMetricsAsync("rate_limit_pct",            minutes, ct);
-        var parData   = await TransferStateDb.GetMetricsAsync("current_parallelism",       minutes, ct);
+        var filesData = await stateDb.GetMetricsAsync("throughput_files_per_min", minutes, ct);
+        var bytesData = await stateDb.GetMetricsAsync("throughput_bytes_per_sec", minutes, ct);
+        var rlData    = await stateDb.GetMetricsAsync("rate_limit_pct",            minutes, ct);
+        var parData   = await stateDb.GetMetricsAsync("current_parallelism",       minutes, ct);
         // #159: HybridRateController 経路でのみ書き込まれるウィンドウ幅。
         // 値が無いときは累積平均表示のままにする。
-        var winData   = await TransferStateDb.GetMetricsAsync("throughput_window_sec",     minutes, ct);
+        var winData   = await stateDb.GetMetricsAsync("throughput_window_sec",     minutes, ct);
         _throughputWindowSec = winData.Count > 0 ? winData[^1].Value : 0;
 
         if (filesData.Count > 0)

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -765,6 +765,7 @@ else
         catch (Exception ex)
         {
             Logger.LogWarning(ex, "RefreshAllAsync: 状態 DB の解決に失敗しました。今回の UI 更新をスキップします。");
+            _activeStateDb = null;
             _summary ??= new TransferDbSummary();
             _recentLogEntries = LogChannel.GetRecentEntries();
             return;

--- a/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
@@ -1,6 +1,7 @@
 @inject IConfigurationService ConfigService
-@inject ITransferStateDb TransferStateDb
+@inject ITransferStateDbAccessor StateDbAccessor
 @inject ITransferJobService JobService
+@inject Func<MigratorOptions> OptionsFactory
 @inject ISnackbar Snackbar
 @inject ILogger<SettingsPage> Logger
 
@@ -714,10 +715,11 @@ else
         try
         {
             // 3. DB 全データ削除
-            await TransferStateDb.ResetAllAsync(CancellationToken.None);
+            var stateDb = await StateDbAccessor.GetCurrentAsync(CancellationToken.None);
+            await stateDb.ResetAllAsync(CancellationToken.None);
 
-            // 4. キャッシュファイル削除（PathOptions はデフォルト値 = AppDataPaths.LogFile(...) と一致するため new() で十分）
-            var opts = new MigratorOptions();
+            // 4. キャッシュファイル削除
+            var opts = OptionsFactory();
             ConfigHashChecker.ClearAll(opts.Paths, Logger);
 
             Snackbar.Add("データベースの初期化が完了しました。転送を再開するにはダッシュボードの「転送開始」ボタンを押してください。", Severity.Success, cfg =>

--- a/src/CloudMigrator.Dashboard/ITransferStateDbAccessor.cs
+++ b/src/CloudMigrator.Dashboard/ITransferStateDbAccessor.cs
@@ -1,0 +1,11 @@
+using CloudMigrator.Core.Configuration;
+using CloudMigrator.Core.State;
+
+namespace CloudMigrator.Dashboard;
+
+public interface ITransferStateDbAccessor : IAsyncDisposable
+{
+    Task<ITransferStateDb> GetCurrentAsync(CancellationToken ct);
+
+    Task<ITransferStateDb> GetForOptionsAsync(MigratorOptions options, CancellationToken ct);
+}

--- a/src/CloudMigrator.Dashboard/TransferStateDbAccessor.cs
+++ b/src/CloudMigrator.Dashboard/TransferStateDbAccessor.cs
@@ -109,7 +109,8 @@ public sealed class TransferStateDbAccessor : ITransferStateDbAccessor
             }
             else
             {
-                _dbByPath[dbPath] = created;
+                if (!ReferenceEquals(created, NullTransferStateDb.Instance))
+                    _dbByPath[dbPath] = created;
                 result = created;
             }
         }

--- a/src/CloudMigrator.Dashboard/TransferStateDbAccessor.cs
+++ b/src/CloudMigrator.Dashboard/TransferStateDbAccessor.cs
@@ -27,8 +27,21 @@ public sealed class TransferStateDbAccessor : ITransferStateDbAccessor
     public Task<ITransferStateDb> GetCurrentAsync(CancellationToken ct)
         => GetForOptionsAsync(_optionsFactory(), ct);
 
-    public Task<ITransferStateDb> GetForOptionsAsync(MigratorOptions options, CancellationToken ct)
-        => GetByPathAsync(ResolveDbPath(options, _explicitDbPath), ct);
+    public async Task<ITransferStateDb> GetForOptionsAsync(MigratorOptions options, CancellationToken ct)
+    {
+        string dbPath;
+        try
+        {
+            dbPath = ResolveDbPath(options, _explicitDbPath);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "転送状態 DB パスの解決に失敗しました。DB なしモードで続行します。");
+            return NullTransferStateDb.Instance;
+        }
+
+        return await GetByPathAsync(dbPath, ct).ConfigureAwait(false);
+    }
 
     internal static string ResolveDbPath(MigratorOptions options, string? explicitDbPath)
     {
@@ -76,25 +89,38 @@ public sealed class TransferStateDbAccessor : ITransferStateDbAccessor
             created = NullTransferStateDb.Instance;
         }
 
+        ITransferStateDb? disposeTarget = null;
+        ITransferStateDb? result = null;
+        var throwDisposed = false;
+
         lock (_gate)
         {
             if (_disposed)
             {
                 if (!ReferenceEquals(created, NullTransferStateDb.Instance))
-                    created.DisposeAsync().AsTask().GetAwaiter().GetResult();
-                throw new ObjectDisposedException(nameof(TransferStateDbAccessor));
+                    disposeTarget = created;
+                throwDisposed = true;
             }
-
-            if (_dbByPath.TryGetValue(dbPath, out var existing))
+            else if (_dbByPath.TryGetValue(dbPath, out var existing))
             {
                 if (!ReferenceEquals(created, NullTransferStateDb.Instance))
-                    created.DisposeAsync().AsTask().GetAwaiter().GetResult();
-                return existing;
+                    disposeTarget = created;
+                result = existing;
             }
-
-            _dbByPath[dbPath] = created;
-            return created;
+            else
+            {
+                _dbByPath[dbPath] = created;
+                result = created;
+            }
         }
+
+        if (disposeTarget is not null)
+            await disposeTarget.DisposeAsync().ConfigureAwait(false);
+
+        if (throwDisposed)
+            throw new ObjectDisposedException(nameof(TransferStateDbAccessor));
+
+        return result!;
     }
 
     private static bool IsDropbox(string destinationProvider)

--- a/src/CloudMigrator.Dashboard/TransferStateDbAccessor.cs
+++ b/src/CloudMigrator.Dashboard/TransferStateDbAccessor.cs
@@ -1,0 +1,126 @@
+using System.IO;
+using CloudMigrator.Core.Configuration;
+using CloudMigrator.Core.State;
+using Microsoft.Extensions.Logging;
+
+namespace CloudMigrator.Dashboard;
+
+public sealed class TransferStateDbAccessor : ITransferStateDbAccessor
+{
+    private readonly Func<MigratorOptions> _optionsFactory;
+    private readonly string? _explicitDbPath;
+    private readonly ILogger<TransferStateDbAccessor> _logger;
+    private readonly Dictionary<string, ITransferStateDb> _dbByPath = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _gate = new();
+    private bool _disposed;
+
+    public TransferStateDbAccessor(
+        Func<MigratorOptions> optionsFactory,
+        string? explicitDbPath,
+        ILogger<TransferStateDbAccessor> logger)
+    {
+        _optionsFactory = optionsFactory;
+        _explicitDbPath = string.IsNullOrWhiteSpace(explicitDbPath) ? null : explicitDbPath;
+        _logger = logger;
+    }
+
+    public Task<ITransferStateDb> GetCurrentAsync(CancellationToken ct)
+        => GetForOptionsAsync(_optionsFactory(), ct);
+
+    public Task<ITransferStateDb> GetForOptionsAsync(MigratorOptions options, CancellationToken ct)
+        => GetByPathAsync(ResolveDbPath(options, _explicitDbPath), ct);
+
+    internal static string ResolveDbPath(MigratorOptions options, string? explicitDbPath)
+    {
+        var path = !string.IsNullOrWhiteSpace(explicitDbPath)
+            ? explicitDbPath
+            : IsDropbox(options.DestinationProvider)
+                ? options.Paths.DropboxStateDb
+                : options.Paths.SharePointStateDb;
+
+        if (string.IsNullOrWhiteSpace(path))
+            throw new InvalidOperationException("転送状態 DB のパスが設定されていません。");
+
+        return Path.GetFullPath(Environment.ExpandEnvironmentVariables(path));
+    }
+
+    private async Task<ITransferStateDb> GetByPathAsync(string dbPath, CancellationToken ct)
+    {
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            if (_dbByPath.TryGetValue(dbPath, out var existing))
+                return existing;
+        }
+
+        ITransferStateDb created;
+        SqliteTransferStateDb? sqliteDb = null;
+        try
+        {
+            sqliteDb = new SqliteTransferStateDb(dbPath);
+            await sqliteDb.InitializeAsync(ct).ConfigureAwait(false);
+            created = sqliteDb;
+            sqliteDb = null;
+        }
+        catch (OperationCanceledException)
+        {
+            if (sqliteDb is not null)
+                await sqliteDb.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            if (sqliteDb is not null)
+                await sqliteDb.DisposeAsync().ConfigureAwait(false);
+            _logger.LogError(ex, "転送状態 DB の初期化に失敗しました。DB なしモードで続行します。Path: {DbPath}", dbPath);
+            created = NullTransferStateDb.Instance;
+        }
+
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                if (!ReferenceEquals(created, NullTransferStateDb.Instance))
+                    created.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                throw new ObjectDisposedException(nameof(TransferStateDbAccessor));
+            }
+
+            if (_dbByPath.TryGetValue(dbPath, out var existing))
+            {
+                if (!ReferenceEquals(created, NullTransferStateDb.Instance))
+                    created.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                return existing;
+            }
+
+            _dbByPath[dbPath] = created;
+            return created;
+        }
+    }
+
+    private static bool IsDropbox(string destinationProvider)
+        => destinationProvider.Equals("dropbox", StringComparison.OrdinalIgnoreCase);
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(TransferStateDbAccessor));
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        ITransferStateDb[] dbs;
+        lock (_gate)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            dbs = _dbByPath.Values
+                .Where(db => !ReferenceEquals(db, NullTransferStateDb.Instance))
+                .Distinct()
+                .ToArray();
+            _dbByPath.Clear();
+        }
+
+        foreach (var db in dbs)
+            await db.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/tasks.md
+++ b/tasks.md
@@ -1,80 +1,153 @@
 # タスク管理
 
-詳細仕様: [docs/implementation-plan.md](docs/implementation-plan.md)
-前フェーズ履歴: [tasks-archive-20260414.md](docs/archive/tasks-archive-20260414.md)
+前フェーズ履歴: [docs/archive/tasks-archive-20260501.md](docs/archive/tasks-archive-20260501.md)
 
-## 現在の状態: v0.6.0 HybridRateController バグ修正・UI 改善 📋
+## 現在の状態: open issue 起点の v0.6.1 計画
 
----
-
-## ✅ 完了: Graph API レートベース転送制御エンジン実装（v0.5.0）
-
-**PR**: [#148](https://github.com/scottlz0310/cloud-migrator/pull/148)  
-**完了日**: 2026-04-16
-
-### 完了タスク
-
-- [x] `ITransferRateController` / `IMetricsAggregator` インターフェース定義
-- [x] `TransferMetricsAggregator` 実装（1 秒バケット固定リングバッファ）
-- [x] `MetricsBuffer` 実装（非同期 DB バッファ）
-- [x] `RateControlledTransferController` 実装（ヒステリシス 3 段階制御 + トークンバケット）
-- [x] `AdaptiveConcurrencyControllerAdapter` 実装（後方互換アダプター）
-- [x] `RateControlSettings` / `MigratorOptions.RateControl` 設定統合
-- [x] `TransferCommand` への `UseRateControl` フラグ統合
-- [x] `SharePointMigrationPipeline` Phase C インフライトカウンター回復修正
-- [x] `TransferMetricsAggregator.GetSnapshot()` Rate429 計算式修正
-- [x] `RateControlledTransferController.DisposeAsync()` べき等性保証
-- [x] `CliServices.cs` 不要フィールド整理
-- [x] ユニットテスト 627 件全合格
+- 確認日: 2026-05-01
+- 対象リポジトリ: `scottlz0310/cloud-migrator`
+- 確認方法: `gh issue list --state open --limit 200`
+- open issue 数: 5 件
 
 ---
 
-## 次フェーズ: v0.6.0 スループット主制御ハイブリッド方式
+## 推奨実装順
 
-> 設計書: [docs/transfer-control-design-v2.md](docs/transfer-control-design-v2.md)
-
-### 概要
-
-v0.5.0 のヒステリシス制御（requests/sec）から **トークンバケット × AIMD フィードバック × 並列数補助制御のハイブリッド方式**（tokens/sec）へ移行する。
-
-### 実装順序
-
-| 順番 | ISSUE | タイトル | 状態 | 備考 |
-|------|-------|---------|------|------|
-| 1（並行） | [#160](https://github.com/scottlz0310/cloud-migrator/issues/160) | トークンバケット + 重み付きコスト | ✅ 完了（PR #167） | `FileCostCalculator` / `WeightedTokenBucket` 追加・設定統合・テスト 53 件 |
-| 1（並行） | [#161](https://github.com/scottlz0310/cloud-migrator/issues/161) | スライディングウィンドウ指標収集 | ✅ 完了 | `SlidingWindowMetrics` 追加・P95/件数&時間切替・設定統合・テスト 24 件 |
-| 2 | [#162](https://github.com/scottlz0310/cloud-migrator/issues/162) | AIMD フィードバック制御 + クールダウン | ✅ 完了 | `AimdFeedbackController` 追加・4 信号判定・ベースライン EMA・クールダウン・テスト 24 件 |
-| 3 | [#163](https://github.com/scottlz0310/cloud-migrator/issues/163) | 並列数補助制御ハイブリッド移行 | 🟢 統合 PR 実装完了 | `HybridRateController` 追加・§7 制御ループ + §4.3 並列数補助制御・`RateStateStore` v2/v0.5.x 互換・CLI + Dashboard 統合・テスト 25 件。旧 `AdaptiveConcurrencyController` / `TokenBucketRateLimiter` は `[Obsolete]` 付与のみ（実削除は後続 PR） |
-| 4 | [#159](https://github.com/scottlz0310/cloud-migrator/issues/159) | スループット表示を制御窓ベースに変更（UI） | ✅ 完了 | HybridRateController 経路で `throughput_window_sec` 記録・Dashboard タイトルに「（直近 N 秒）」付記 |
-| 5 | [#155](https://github.com/scottlz0310/cloud-migrator/issues/155) | 統計エリア統合（UI） | ✅ 完了 | 統計7指標 + RCモニター4指標を1カードに統合 |
-| 自由 | [#154](https://github.com/scottlz0310/cloud-migrator/issues/154) | ルート情報をダッシュボードに移動（UI） | ✅ 完了 | ヘッダーにルートチップ＋ツールチップ追加 |
-| 自由 | [#156](https://github.com/scottlz0310/cloud-migrator/issues/156) | グラフ表示オン/オフ切り替え（UI） | ✅ 完了 | ShowGraphs 設定 + ヘッダーアイコンボタン |
-| 自由 | [#157](https://github.com/scottlz0310/cloud-migrator/issues/157) | グラフ列数可変設定（UI） | ✅ 完了 | GraphColumns 設定 + MudItem 幅動的制御 |
-| 自由 | [#158](https://github.com/scottlz0310/cloud-migrator/issues/158) | フォルダ/ファイル進捗 Phase 連動表示（UI） | ✅ 完了 | folder_creation/transferring フェーズ連動進捗バー統合 |
-
-### スコープ外（凍結・v0.6.0 効果確認後に判断）
-
-| ISSUE | 内容 | 判断タイミング |
-|-------|------|---------------|
-| [#136](https://github.com/scottlz0310/cloud-migrator/issues/136) §1 | パルス制御 | #162 完了後 |
-| [#136](https://github.com/scottlz0310/cloud-migrator/issues/136) §2 | ファイルサイズ別レーン分離 | #160 完了後 |
+| 順番 | Issue | 種別 | タイトル | 判断 |
+|------|-------|------|----------|------|
+| 1 | [#190](https://github.com/scottlz0310/cloud-migrator/issues/190) | bug | DashboardPage の ITransferStateDb が Dropbox 実行中も SharePoint DB を参照し続ける問題 | 実装済み（PR 対応中）。route-aware な state DB アクセサへ切り替え、Dashboard / Settings / MigrationWork が同じ DB 解決を使うようにした。 |
+| 2 | [#189](https://github.com/scottlz0310/cloud-migrator/issues/189) | enhancement / dashboard | 路線に応じて設定項目を排他表示する | 次の推奨着手。#190 で整えた route/provider と DB 参照の境界を前提に、SharePoint 専用設定と Dropbox 専用設定を分離する。 |
+| 3 | [#191](https://github.com/scottlz0310/cloud-migrator/issues/191) | refactor | DashboardPage タブバーを MudTabs（静的 MudTabPanel）に戻す | アクセシビリティと保守性改善。#190 と同じ DashboardPage に触れるため、bug 修正後に実施して差分衝突を避ける。 |
+| 4 | [#15](https://github.com/scottlz0310/cloud-migrator/issues/15) | maintenance | Dependency Dashboard | 機能修正後に CI が安定した状態で依存関係更新を確認する。Renovate 管理のため通常実装とは別レーン。 |
+| 保留 | [#101](https://github.com/scottlz0310/cloud-migrator/issues/101) | epic / installer | MSIX パッケージング・Microsoft Store 公開 | MSI 配布 #97 の運用実績、Partner Center、Store 提出素材が前提。現フェーズでは計画保持のみ。 |
 
 ---
 
-## 🔧 進行中: HybridRateController バグ修正・UI 改善
+## 1. #190: Dropbox 実行中の Dashboard state DB 参照修正
 
-### 完了タスク
+状態: 実装済み（PR 対応中）
 
-- [x] `AimdFeedbackController`: クールダウン中の429で `Hold` を返す修正（二重クールダウン防止）
-- [x] `LatencyEvaluationMode.None` 追加・デフォルト化（429専制御、SlowDecrease 無効化）
-- [x] `HybridRateController`: 制御ログ `LogDebug` → `LogInformation` 昇格（信号・レート・429率・P95 出力）
-- [x] `EmergencyDecay` / `EmergencyInflightDecay` デフォルト緩和: 0.7/0.75 → **0.9/0.9**（Retry-After主制御設計）
-- [x] 設定メニュー: `UseHybridController` / `CooldownSec` / `EmergencyDecay` / `EmergencyInflightDecay` / `AddStep` / `LatencyMode` の6項目追加（UI・API・バリデーション）
-- [x] Dashboard リアルタイムモニタ: HybridRateController のメトリクスキー不一致修正（`rate_tokens_per_sec` / `max_inflight` / `rate_429` / `signal` 対応）
-- [x] ユニットテスト 902 件全合格
-- [x] ダッシュボードリデザイン（UI-03、#179）: タブ構造 3 タブ（概要 / 詳細情報 / ログ）・`GetLatestProcessingNameAsync` 追加・一行ログフェードアニメーション
-- [x] ユニットテスト 922 件全合格
-- [x] Dropbox 路線選択時に SharePoint 路線に固定されるバグ修正: `DropboxOAuthPage` で `config.json` への `destinationProvider`/`migrationRoute` 書き込みを追加
-- [x] Dashboard の転送処理が常に SharePoint パイプラインを使用するバグ修正: `App.xaml.cs` の `MigrationWork` に `isDropbox` 分岐を追加し、Dropbox 路線では `DropboxMigrationPipeline` を使用するよう修正
+### 目的
+
+Dropbox 実行時に `MigrationWork` が Dropbox 専用 DB へ書き込む一方で、`DashboardPage` が DI singleton の SharePoint DB を読み続ける問題を解消する。
+
+### 実装メモ
+
+- `DashboardPage` の `GetLatestProcessingNameAsync` / `GetSummaryAsync` / `GetMetricsAsync` / `GetCheckpointAsync` が、実行中または選択中の provider に対応する DB を参照するようにする。
+- `SettingsPage` も `ITransferStateDb` を直接注入して `ResetAllAsync` しているため、同じ route-aware な DB 解決を共有できる形を優先する。
+- 候補:
+  - per-run `ITransferStateDb` factory
+  - route/provider に応じて DB を切り替える router 抽象
+  - 起動時 provider に基づく DI 登録
+- `MigrationWork` 側で使う DB と Dashboard 読み取り側の DB 選択規則を一致させる。
+- DB インスタンスの lifetime と `DisposeAsync` の責務を明確にする。
+
+### 受け入れ条件
+
+- [x] Dropbox 路線で実行中、Dashboard の進捗バー・サマリ・スループットグラフが Dropbox DB から更新される。
+- [x] SharePoint 路線の Dashboard 表示は従来どおり SharePoint DB を参照する。
+- [x] route 切り替え後に古い DB ハンドルへ読み書きし続けない。
+- [x] `NullTransferStateDb` フォールバック時の挙動が壊れない。
+- [x] 関連ユニットテストを追加または更新する。
 
 ---
+
+## 2. #189: 路線別 Settings 表示と Dropbox 専用設定追加
+
+### 目的
+
+SharePoint / Dropbox それぞれに関係する設定だけを表示し、Dropbox 専用設定を Dashboard 設定画面から編集できるようにする。
+
+### 実装メモ
+
+- `SettingsPage.razor` で `MigrationRoute` または `DestinationProvider` を基準に `IsSharePointRoute` / `IsDropboxRoute` を定義する。
+- SharePoint 専用設定:
+  - 転送制御エンジン
+  - レートベース制御パラメーター
+  - HybridRateController 実験的設定
+  - 動的並列制御
+  - 最大並行フォルダ作成数
+- Dropbox 専用設定:
+  - `SimpleUploadLimitMb`
+  - `UploadChunkSizeMb`
+  - `EnableEnsureFolder`
+- 共通設定:
+  - 最大並行転送数
+  - タイムアウト
+  - リトライ回数
+  - 大ファイル閾値
+- 非表示項目は保存時に値を消さず、既存設定を保持する。
+- `ConfigurationService` の read/write と validation が Dropbox 設定を扱えるか確認し、不足があれば拡張する。
+
+### 受け入れ条件
+
+- [ ] SharePoint 路線では Dropbox 専用設定が表示されない。
+- [ ] Dropbox 路線では SharePoint 専用設定が表示されない。
+- [ ] Dropbox 路線で `SimpleUploadLimitMb` / `UploadChunkSizeMb` / `EnableEnsureFolder` を設定・保存できる。
+- [ ] 共通設定は両路線で表示される。
+- [ ] 非表示項目の既存値が保存時に失われない。
+- [ ] 設定保存のユニットテストを追加または更新する。
+
+---
+
+## 3. #191: Dashboard タブバーを MudTabs に戻す
+
+### 目的
+
+PR #188 で導入したカスタム `<button>` タブバーを、MudBlazor 標準の `MudTabs` + 静的 `MudTabPanel` に戻し、保守性・キーボード操作・ARIA を回復する。
+
+### 実装メモ
+
+- `@foreach` による `MudTabPanel` 動的生成は避け、概要 / 詳細情報 / ログの 3 パネルを静的に配置する。
+- `_dashboardTab` string は `_dashboardTabIndex` int に置き換える。
+- 既存の概要・詳細情報・ログの中身は、対応する `MudTabPanel` 内へ移動する。
+- 見た目調整は inline style ではなく MudBlazor の `Class` / `TabPanelClass` / `ActiveTabClass` などで対応する。
+- MUD0002 が再発しないことを確認する。
+
+### 受け入れ条件
+
+- [ ] Dashboard タブが `MudTabs` + 静的 `MudTabPanel` 3 枚で構成される。
+- [ ] キーボード操作と ARIA 属性が MudBlazor 標準挙動に戻る。
+- [ ] 概要・詳細情報・ログの表示内容が既存実装から退化しない。
+- [ ] MUD0002 アナライザーエラーが発生しない。
+- [ ] Dashboard 関連テストまたはビルド確認を実施する。
+
+---
+
+## 4. #15: Dependency Dashboard 対応
+
+### 目的
+
+Renovate が検出した依存関係更新を、機能修正後の安定した状態で確認する。
+
+### 実装メモ
+
+- lock file maintenance は通常スケジュールに任せる。
+- `Microsoft.Graph` / `Microsoft.NET.Test.Sdk` などの minor update PR が作成されたら CI 結果を確認する。
+- `xunit` deprecation/replacement は影響範囲が大きいため、必要なら独立 issue 化して移行方針を決める。
+
+### 受け入れ条件
+
+- [ ] Renovate PR がある場合、CI 結果と差分を確認する。
+- [ ] 破壊的変更がある dependency update は機能修正 PR と混ぜない。
+- [ ] 必要に応じて追加 issue を起票する。
+
+---
+
+## 保留: #101 MSIX パッケージング・Microsoft Store 公開
+
+### 保留理由
+
+MSI 配布 #97 の安定運用、Microsoft Partner Center、Store 提出素材、プライバシーポリシー URL などが前提条件のため、現フェーズでは着手しない。
+
+### 再開条件
+
+- [ ] MSI 配布 #97 の運用実績が十分に積まれている。
+- [ ] Partner Center アカウントと Store 提出要件が準備済み。
+- [ ] MSIX / Store 配布の目的と対象ユーザーが明確になっている。
+
+---
+
+## 次の推奨着手
+
+[#189](https://github.com/scottlz0310/cloud-migrator/issues/189) から開始する。

--- a/tests/unit/TransferStateDbAccessorTests.cs
+++ b/tests/unit/TransferStateDbAccessorTests.cs
@@ -77,6 +77,25 @@ public sealed class TransferStateDbAccessorTests : IAsyncDisposable
         db.Should().BeSameAs(NullTransferStateDb.Instance);
     }
 
+    [Fact]
+    public async Task GetForOptionsAsync_InitializationFailure_DoesNotCacheNullTransferStateDb()
+    {
+        var blockedPath = Path.Combine(_tempDir, "blocked.db");
+        Directory.CreateDirectory(blockedPath);
+        var opts = CreateOptions("dropbox");
+        opts.Paths.DropboxStateDb = blockedPath;
+        await using var accessor = CreateAccessor(() => opts);
+
+        var first = await accessor.GetForOptionsAsync(opts, CancellationToken.None);
+        Directory.Delete(blockedPath);
+        var second = await accessor.GetForOptionsAsync(opts, CancellationToken.None);
+        await second.SaveCheckpointAsync("route", "dropbox", CancellationToken.None);
+
+        first.Should().BeSameAs(NullTransferStateDb.Instance);
+        second.Should().NotBeSameAs(NullTransferStateDb.Instance);
+        (await second.GetCheckpointAsync("route", CancellationToken.None)).Should().Be("dropbox");
+    }
+
     private TransferStateDbAccessor CreateAccessor(Func<MigratorOptions> optionsFactory, string? explicitDbPath = null)
     {
         var accessor = new TransferStateDbAccessor(

--- a/tests/unit/TransferStateDbAccessorTests.cs
+++ b/tests/unit/TransferStateDbAccessorTests.cs
@@ -1,0 +1,97 @@
+using CloudMigrator.Core.Configuration;
+using CloudMigrator.Dashboard;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CloudMigrator.Tests.Unit;
+
+public sealed class TransferStateDbAccessorTests : IAsyncDisposable
+{
+    private readonly string _tempDir = Path.Combine(Path.GetTempPath(), $"cloud_migrator_state_accessor_{Guid.NewGuid():N}");
+    private readonly List<TransferStateDbAccessor> _accessors = [];
+
+    public TransferStateDbAccessorTests()
+    {
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [Fact]
+    public async Task GetForOptionsAsync_DropboxRoute_UsesDropboxStateDb()
+    {
+        var opts = CreateOptions("dropbox");
+        await using var accessor = CreateAccessor(() => opts);
+
+        var db = await accessor.GetForOptionsAsync(opts, CancellationToken.None);
+        await db.SaveCheckpointAsync("route", "dropbox", CancellationToken.None);
+
+        File.Exists(opts.Paths.DropboxStateDb).Should().BeTrue();
+        File.Exists(opts.Paths.SharePointStateDb).Should().BeFalse();
+        (await db.GetCheckpointAsync("route", CancellationToken.None)).Should().Be("dropbox");
+    }
+
+    [Fact]
+    public async Task GetCurrentAsync_WhenProviderChanges_ReturnsDbForLatestProvider()
+    {
+        var opts = CreateOptions("sharepoint");
+        await using var accessor = CreateAccessor(() => opts);
+
+        var sharePointDb = await accessor.GetCurrentAsync(CancellationToken.None);
+        await sharePointDb.SaveCheckpointAsync("route", "sharepoint", CancellationToken.None);
+
+        opts.DestinationProvider = "dropbox";
+        var dropboxDb = await accessor.GetCurrentAsync(CancellationToken.None);
+        await dropboxDb.SaveCheckpointAsync("route", "dropbox", CancellationToken.None);
+
+        dropboxDb.Should().NotBeSameAs(sharePointDb);
+        (await sharePointDb.GetCheckpointAsync("route", CancellationToken.None)).Should().Be("sharepoint");
+        (await dropboxDb.GetCheckpointAsync("route", CancellationToken.None)).Should().Be("dropbox");
+    }
+
+    [Fact]
+    public async Task GetForOptionsAsync_ExplicitDbPath_OverridesProviderStateDbPaths()
+    {
+        var explicitPath = Path.Combine(_tempDir, "explicit.db");
+        var sharePointOpts = CreateOptions("sharepoint");
+        var dropboxOpts = CreateOptions("dropbox");
+        await using var accessor = CreateAccessor(() => sharePointOpts, explicitPath);
+
+        var sharePointDb = await accessor.GetForOptionsAsync(sharePointOpts, CancellationToken.None);
+        var dropboxDb = await accessor.GetForOptionsAsync(dropboxOpts, CancellationToken.None);
+        await dropboxDb.SaveCheckpointAsync("route", "explicit", CancellationToken.None);
+
+        dropboxDb.Should().BeSameAs(sharePointDb);
+        File.Exists(explicitPath).Should().BeTrue();
+        File.Exists(sharePointOpts.Paths.SharePointStateDb).Should().BeFalse();
+        File.Exists(dropboxOpts.Paths.DropboxStateDb).Should().BeFalse();
+    }
+
+    private TransferStateDbAccessor CreateAccessor(Func<MigratorOptions> optionsFactory, string? explicitDbPath = null)
+    {
+        var accessor = new TransferStateDbAccessor(
+            optionsFactory,
+            explicitDbPath,
+            NullLogger<TransferStateDbAccessor>.Instance);
+        _accessors.Add(accessor);
+        return accessor;
+    }
+
+    private MigratorOptions CreateOptions(string destinationProvider)
+        => new()
+        {
+            DestinationProvider = destinationProvider,
+            Paths = new PathOptions
+            {
+                DropboxStateDb = Path.Combine(_tempDir, $"{Guid.NewGuid():N}_dropbox.db"),
+                SharePointStateDb = Path.Combine(_tempDir, $"{Guid.NewGuid():N}_sharepoint.db"),
+            },
+        };
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var accessor in _accessors)
+            await accessor.DisposeAsync();
+
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+}

--- a/tests/unit/TransferStateDbAccessorTests.cs
+++ b/tests/unit/TransferStateDbAccessorTests.cs
@@ -1,4 +1,5 @@
 using CloudMigrator.Core.Configuration;
+using CloudMigrator.Core.State;
 using CloudMigrator.Dashboard;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -8,7 +9,6 @@ namespace CloudMigrator.Tests.Unit;
 public sealed class TransferStateDbAccessorTests : IAsyncDisposable
 {
     private readonly string _tempDir = Path.Combine(Path.GetTempPath(), $"cloud_migrator_state_accessor_{Guid.NewGuid():N}");
-    private readonly List<TransferStateDbAccessor> _accessors = [];
 
     public TransferStateDbAccessorTests()
     {
@@ -65,13 +65,24 @@ public sealed class TransferStateDbAccessorTests : IAsyncDisposable
         File.Exists(dropboxOpts.Paths.DropboxStateDb).Should().BeFalse();
     }
 
+    [Fact]
+    public async Task GetForOptionsAsync_InvalidStateDbPath_ReturnsNullTransferStateDb()
+    {
+        var opts = CreateOptions("dropbox");
+        opts.Paths.DropboxStateDb = "";
+        await using var accessor = CreateAccessor(() => opts);
+
+        var db = await accessor.GetForOptionsAsync(opts, CancellationToken.None);
+
+        db.Should().BeSameAs(NullTransferStateDb.Instance);
+    }
+
     private TransferStateDbAccessor CreateAccessor(Func<MigratorOptions> optionsFactory, string? explicitDbPath = null)
     {
         var accessor = new TransferStateDbAccessor(
             optionsFactory,
             explicitDbPath,
             NullLogger<TransferStateDbAccessor>.Instance);
-        _accessors.Add(accessor);
         return accessor;
     }
 
@@ -86,12 +97,11 @@ public sealed class TransferStateDbAccessorTests : IAsyncDisposable
             },
         };
 
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        foreach (var accessor in _accessors)
-            await accessor.DisposeAsync();
-
         if (Directory.Exists(_tempDir))
             Directory.Delete(_tempDir, recursive: true);
+
+        return ValueTask.CompletedTask;
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #190 by adding a route-aware `ITransferStateDbAccessor` for Dashboard state DB resolution.
- Updates `MigrationWork`, `DashboardPage`, and `SettingsPage` so Dropbox and SharePoint flows use the same provider/path selection rules.
- Archives the previous `tasks.md`, refreshes the open-issue task plan, and marks #190 as implemented in the new task list.

## Root Cause

Dropbox runs wrote transfer state into `opts.Paths.DropboxStateDb`, but Dashboard UI reads were still bound to a startup-time `ITransferStateDb` singleton that could point at the SharePoint DB. That made Dropbox progress, summary, and metrics appear empty or inconsistent.

## Validation

- `dotnet test tests/unit/CloudMigrator.Tests.Unit.csproj --filter TransferStateDbAccessorTests`
- `dotnet test tests/unit/CloudMigrator.Tests.Unit.csproj`
- pre-commit hook: `dotnet-build`, `dotnet-format`, `dotnet-restore`, `dotnet-test-unit`

Note: the pre-commit build completed with existing `Microsoft.Graph` version conflict warnings in integration/e2e projects, but no build errors.