### PR TITLE
#197: 転送先フォルダ確認フラグを実装

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@
 
 ### Added
 
+- **転送先フォルダ確認フラグの実装（#197）**（SharePointDiscoveryPage, ConfigurationService, WizardApp）
+  - `DriveFolderPicker` コンポーネントを `SharePointDiscoveryPage` に組み込み、Library 内フォルダを選択後に「次へ」ボタンが有効化される
+  - `_destFolderConfirmed` フラグで転送先フォルダの明示選択を必須化。サイト/ドライブ変更時に自動リセット
+  - `DiscoveryConfigDto` / `DiscoveryConfigUpdateDto` に `DestinationConfirmed` フィールドを追加し `config.json` に永続化
+  - `DashboardPage` で `DestinationConfirmed` 未設定時に転送開始をブロック（警告 Snackbar 表示）
+  - `WizardState` に `Step3bDropboxFolderPicker` を追加し、Dropbox 路線の転送先フォルダ選択ステップをウィザードに追加
+  - `DropboxFolderPicker` / `DropboxFolderPage` コンポーネントと `IDropboxFolderService` / `DropboxFolderService` を新規追加
+
 - **ダッシュボードリデザイン（UI-03）**（DashboardPage）
   - レイアウトを「ヘッダー行（フェーズ・ルートチップ・転送開始/停止ボタン） ＋ 常時進捗バー ＋ MudTabs 3タブ（概要 / 詳細情報 / ログ）」に再構成
   - 概要タブ: ステータスカード 6 枚・経過時間行・一行ログ（フェードアニメーション）・移行完了サマリー

--- a/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
@@ -406,15 +406,21 @@ public sealed class ConfigurationService : IConfigurationService
             if (update.DestinationRoot is not null)
             {
                 m["destinationRoot"] = update.DestinationRoot;
-                // SharePoint 路線: sharePointDestFolderPath（Discovery 表示用）と同期する
+                var effectiveProvider = NormalizeProvider(
+                    update.DestinationProvider
+                    ?? m["destinationProvider"]?.GetValue<string>()
+                    ?? "sharepoint");
+                var isDropbox = string.Equals(effectiveProvider, "dropbox", StringComparison.OrdinalIgnoreCase);
+
                 if (m["graph"] is JsonObject gObj)
                 {
-                    gObj["sharePointDestFolderPath"] = update.DestinationRoot;
-                    // #197: Dropbox 路線: dropboxDestFolderPath（Discovery 表示用）も同期する
-                    gObj["dropboxDestFolderPath"] = update.DestinationRoot;
+                    if (isDropbox)
+                        gObj["dropboxDestFolderPath"] = update.DestinationRoot;
+                    else
+                        gObj["sharePointDestFolderPath"] = update.DestinationRoot;
                 }
-                // #197: Dropbox 路線: dropbox.rootPath（DropboxStorageProvider 用）も同期する
-                if (m["dropbox"] is JsonObject dropboxObjForSync)
+                // Dropbox 路線のみ dropbox.rootPath を同期する
+                if (isDropbox && m["dropbox"] is JsonObject dropboxObjForSync)
                     dropboxObjForSync["rootPath"] = update.DestinationRoot;
             }
             if (update.DestinationProvider is not null) m["destinationProvider"] = update.DestinationProvider;

--- a/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigurationService.cs
@@ -116,7 +116,11 @@ public sealed record DiscoveryConfigDto(
     string OneDriveDisplayName = "",
     string SharePointSiteDisplayName = "",
     string SharePointSiteWebUrl = "",
-    string SharePointDriveDisplayName = "");
+    string SharePointDriveDisplayName = "",
+    // ── Dropbox 転送先（#197）──
+    string DropboxDestFolderPath = "",
+    // ── 転送先フォルダ明示確認フラグ（#197）: root(="") と未選択を区別する ──
+    bool DestinationConfirmed = false);
 
 /// <summary>
 /// Discovery 結果マージ更新 DTO。null フィールドは上書きしない。
@@ -136,7 +140,11 @@ public sealed record DiscoveryConfigUpdateDto(
     string? OneDriveDisplayName = null,
     string? SharePointSiteDisplayName = null,
     string? SharePointSiteWebUrl = null,
-    string? SharePointDriveDisplayName = null);
+    string? SharePointDriveDisplayName = null,
+    // ── Dropbox 転送先（#197）──
+    string? DropboxDestFolderPath = null,
+    // ── 転送先フォルダ明示確認フラグ（#197）──
+    bool? DestinationConfirmed = null);
 
 /// <summary>
 /// config.json の読み書きを担当するサービス契約。
@@ -398,9 +406,16 @@ public sealed class ConfigurationService : IConfigurationService
             if (update.DestinationRoot is not null)
             {
                 m["destinationRoot"] = update.DestinationRoot;
-                // sharePointDestFolderPath（Discovery 表示用）と同期する
+                // SharePoint 路線: sharePointDestFolderPath（Discovery 表示用）と同期する
                 if (m["graph"] is JsonObject gObj)
+                {
                     gObj["sharePointDestFolderPath"] = update.DestinationRoot;
+                    // #197: Dropbox 路線: dropboxDestFolderPath（Discovery 表示用）も同期する
+                    gObj["dropboxDestFolderPath"] = update.DestinationRoot;
+                }
+                // #197: Dropbox 路線: dropbox.rootPath（DropboxStorageProvider 用）も同期する
+                if (m["dropbox"] is JsonObject dropboxObjForSync)
+                    dropboxObjForSync["rootPath"] = update.DestinationRoot;
             }
             if (update.DestinationProvider is not null) m["destinationProvider"] = update.DestinationProvider;
 
@@ -616,12 +631,17 @@ public sealed class ConfigurationService : IConfigurationService
             var sharePointSiteDisplayName = hasGraphObject ? GetString(gProp, "sharePointSiteDisplayName", string.Empty) : string.Empty;
             var sharePointSiteWebUrl = hasGraphObject ? GetString(gProp, "sharePointSiteWebUrl", string.Empty) : string.Empty;
             var sharePointDriveDisplayName = hasGraphObject ? GetString(gProp, "sharePointDriveDisplayName", string.Empty) : string.Empty;
+            // #197: Dropbox 転送先 / 明示確認フラグ
+            var dropboxDestFolderPath = hasGraphObject ? GetString(gProp, "dropboxDestFolderPath", string.Empty) : string.Empty;
+            var destinationConfirmed = m.TryGetProperty("destinationConfirmed", out var dcProp)
+                && dcProp.ValueKind == JsonValueKind.True;
 
             return new DiscoveryConfigDto(
                 oneDriveUserId, oneDriveDriveId, oneDriveSourceFolderId, oneDriveSourceFolderPath,
                 sharePointSiteId, sharePointDriveId, sharePointDestFolderId, sharePointDestFolderPath,
                 migrationRoute, destinationProvider,
-                oneDriveDisplayName, sharePointSiteDisplayName, sharePointSiteWebUrl, sharePointDriveDisplayName);
+                oneDriveDisplayName, sharePointSiteDisplayName, sharePointSiteWebUrl, sharePointDriveDisplayName,
+                dropboxDestFolderPath, destinationConfirmed);
         }
         catch (JsonException)
         {
@@ -689,6 +709,26 @@ public sealed class ConfigurationService : IConfigurationService
                 g["sharePointDestFolderPath"] = effectiveDestFolderPath;
                 m["destinationRoot"] = effectiveDestFolderPath;
             }
+
+            // #197: Dropbox 転送先 — graph.dropboxDestFolderPath / destinationRoot / dropbox.rootPath を三点同期する。
+            // Dropbox の「転送先フォルダ」は以下 3 フィールドで参照されるため全て同値に保つ。
+            //   - migrator.graph.dropboxDestFolderPath : Discovery 表示・ウィザード復元用
+            //   - migrator.destinationRoot             : skip-list 再構築・共通ランタイム用
+            //   - migrator.dropbox.rootPath            : DropboxStorageProvider（転送実行）用
+            if (update.DropboxDestFolderPath is not null)
+            {
+                g["dropboxDestFolderPath"] = update.DropboxDestFolderPath;
+                m["destinationRoot"] = update.DropboxDestFolderPath;
+
+                if (m["dropbox"] is not JsonObject dropboxObj)
+                {
+                    dropboxObj = new JsonObject();
+                    m["dropbox"] = dropboxObj;
+                }
+                dropboxObj["rootPath"] = update.DropboxDestFolderPath;
+            }
+
+            if (update.DestinationConfirmed.HasValue) m["destinationConfirmed"] = update.DestinationConfirmed.Value;
 
             if (update.MigrationRoute is not null) m["migrationRoute"] = update.MigrationRoute;
             if (update.DestinationProvider is not null) m["destinationProvider"] = update.DestinationProvider;

--- a/src/CloudMigrator.Core/Wizard/WizardState.cs
+++ b/src/CloudMigrator.Core/Wizard/WizardState.cs
@@ -34,6 +34,10 @@ public sealed class WizardState
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public WizardStepState Step3DropboxOAuth { get; set; } = WizardStepState.NotStarted;
 
+    /// <summary>Step 3b: Dropbox 転送先フォルダ選択（OneDrive→Dropbox 路線）。</summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public WizardStepState Step3bDropboxFolderPicker { get; set; } = WizardStepState.NotStarted;
+
     /// <summary>Step 4: 接続テスト &amp; 完了。</summary>
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public WizardStepState Step4ConnectionTest { get; set; } = WizardStepState.NotStarted;
@@ -60,6 +64,7 @@ public sealed class WizardState
             Step2aOneDriveDiscovery = Safe(Step2aOneDriveDiscovery),
             Step2bSharePointDiscovery = Safe(Step2bSharePointDiscovery),
             Step3DropboxOAuth = Safe(Step3DropboxOAuth),
+            Step3bDropboxFolderPicker = Safe(Step3bDropboxFolderPicker),
             Step4ConnectionTest = Safe(Step4ConnectionTest),
             IsCompleted = IsCompleted,
         };

--- a/src/CloudMigrator.Dashboard/App.xaml.cs
+++ b/src/CloudMigrator.Dashboard/App.xaml.cs
@@ -344,6 +344,7 @@ public partial class App : Application
         services.AddSingleton<ICredentialStore>(_ => CredentialStoreFactory.Create());
         services.AddSingleton<IDropboxOAuthService, DropboxOAuthService>();
         services.AddSingleton<IDropboxVerifyService, DropboxVerifyService>();
+        services.AddSingleton<IDropboxFolderService, DropboxFolderService>();
         services.AddSingleton<IAzureAuthVerifyService, AzureAuthVerifyService>();
         services.AddSingleton<IGraphDiscoveryService, GraphDiscoveryService>();
         services.AddSingleton<ISharePointVerifyService, SharePointVerifyService>();

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -4,6 +4,7 @@
 @inject IConfigurationService ConfigService
 @inject ILogger<DashboardPage> Logger
 @inject ILogChannel LogChannel
+@inject ISnackbar Snackbar
 @using CloudMigrator.Core.Configuration
 @implements IDisposable
 
@@ -24,7 +25,15 @@
                     {
                         <MudText Typo="Typo.caption">転送元: @_discovery.OneDriveSourceFolderPath</MudText>
                     }
-                    @if (!string.IsNullOrEmpty(_discovery?.SharePointDestFolderPath))
+                    @if (_discovery?.MigrationRoute == "OneDriveToDropbox")
+                    {
+                        <MudText Typo="Typo.caption">
+                            転送先: @(string.IsNullOrEmpty(_discovery.DropboxDestFolderPath)
+                                ? "（Dropbox ルート）"
+                                : _discovery.DropboxDestFolderPath)
+                        </MudText>
+                    }
+                    else if (!string.IsNullOrEmpty(_discovery?.SharePointDestFolderPath))
                     {
                         <MudText Typo="Typo.caption">転送先: @_discovery.SharePointDestFolderPath</MudText>
                     }
@@ -526,6 +535,7 @@ else
     private string RouteDisplayLabel => _discovery?.MigrationRoute switch
     {
         "OneDriveToSharePoint" => "OneDrive → SharePoint",
+        "OneDriveToDropbox"    => "OneDrive → Dropbox",
         { Length: > 0 } r => r,
         _ => ""
     };
@@ -980,6 +990,16 @@ else
     private async Task StartJobAsync()
     {
         if (_isJobRunning) return;
+
+        // #197: 転送先フォルダが未確認の場合は転送を開始しない
+        if (_discovery?.DestinationConfirmed != true)
+        {
+            Snackbar.Add(
+                "転送先フォルダが確認されていません。ウィザードで転送先フォルダを選択・確認してから転送を開始してください。",
+                Severity.Warning);
+            return;
+        }
+
         _currentJob = await JobService.TryStartAsync();
         _isJobRunning = _currentJob?.Status is JobStatus.Pending or JobStatus.Running;
     }

--- a/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/SettingsPage.razor
@@ -84,6 +84,9 @@ else
                                 break;
                             case "OneDriveToDropbox":
                                 <MudText Typo="Typo.body2">Dropbox</MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary" Style="word-break: break-all;">
+                                    @(_discovery.DropboxDestFolderPath is { Length: > 0 } dp ? dp : "（Dropbox ルート）")
+                                </MudText>
                                 break;
                             default:
                                 <MudText Typo="Typo.body2">未設定</MudText>

--- a/src/CloudMigrator.Dashboard/Components/Wizard/DropboxFolderPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/DropboxFolderPage.razor
@@ -1,0 +1,175 @@
+@using CloudMigrator.Core.Configuration
+@using CloudMigrator.Core.Credentials
+@using CloudMigrator.Providers.Dropbox.Auth
+@inject IConfigurationService ConfigurationService
+@inject ICredentialStore CredentialStore
+@inject ISnackbar Snackbar
+
+@* Step 3b: Dropbox 転送先フォルダ選択 *@
+<MudContainer MaxWidth="MaxWidth.Small" Class="py-8">
+    <MudStack Spacing="6">
+        <div>
+            <MudText Typo="Typo.h5">転送先フォルダを選択</MudText>
+            <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mt-1">
+                OneDrive のファイルを移行する Dropbox 内のフォルダを選択してください。
+                ルートを選択するとすべてのファイルが Dropbox 直下に転送されます。
+            </MudText>
+        </div>
+
+        @* 前回確認済みの転送先がある場合の提案 *@
+        @if (_previouslyConfirmed && !string.IsNullOrEmpty(_savedFolderPath) && !_destFolderConfirmed)
+        {
+            <MudAlert Severity="Severity.Info" Dense="true">
+                前回の転送先:
+                <strong>@(_savedFolderPath == "" ? "（ルート）" : _savedFolderPath)</strong>
+                <MudButton Variant="Variant.Text"
+                           Color="Color.Primary"
+                           Size="Size.Small"
+                           OnClick="UsePreviousFolder">
+                    この転送先を使用
+                </MudButton>
+            </MudAlert>
+        }
+        @if (_previouslyConfirmed && string.IsNullOrEmpty(_savedFolderPath) && !_destFolderConfirmed)
+        {
+            <MudAlert Severity="Severity.Info" Dense="true">
+                前回の転送先: <strong>（Dropbox ルート）</strong>
+                <MudButton Variant="Variant.Text"
+                           Color="Color.Primary"
+                           Size="Size.Small"
+                           OnClick="UsePreviousFolder">
+                    この転送先を使用
+                </MudButton>
+            </MudAlert>
+        }
+
+        @* フォルダピッカー *@
+        @if (_accessToken is not null)
+        {
+            <MudPaper Elevation="1" Class="pa-3">
+                <MudText Typo="Typo.subtitle2" Class="mb-2">転送先フォルダ</MudText>
+                <DropboxFolderPicker AccessToken="@_accessToken"
+                                     InitialFolderPath="@_selectedFolderPath"
+                                     OnFolderSelected="OnFolderSelected"
+                                     Disabled="@_isSaving" />
+            </MudPaper>
+        }
+        else if (_isLoadingToken)
+        {
+            <MudProgressLinear Color="Color.Primary" Indeterminate="true" />
+        }
+        else
+        {
+            <MudAlert Severity="Severity.Error">
+                Dropbox のアクセストークンを取得できません。前のステップで認証を完了してください。
+            </MudAlert>
+        }
+
+        @* 確認状態の表示 *@
+        @if (_destFolderConfirmed)
+        {
+            <MudAlert Severity="Severity.Success" Dense="true">
+                転送先フォルダを確認済み:
+                <strong>@(_selectedFolderPath == "" ? "（Dropbox ルート）" : _selectedFolderPath)</strong>
+            </MudAlert>
+        }
+
+        @if (_saveError is not null)
+        {
+            <MudAlert Severity="Severity.Error" Dense="true">@_saveError</MudAlert>
+        }
+
+        @* ナビゲーションボタン *@
+        <MudStack Row="true" Spacing="2" Justify="Justify.SpaceBetween">
+            <MudButton Variant="Variant.Outlined"
+                       StartIcon="@Icons.Material.Filled.ArrowBack"
+                       Disabled="@_isSaving"
+                       OnClick="@(() => OnBackClick.InvokeAsync())">
+                戻る
+            </MudButton>
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       EndIcon="@Icons.Material.Filled.ArrowForward"
+                       Disabled="@(!_destFolderConfirmed || _isSaving)"
+                       OnClick="SaveAndContinueAsync">
+                次へ
+            </MudButton>
+        </MudStack>
+
+    </MudStack>
+</MudContainer>
+
+@code {
+    [Parameter] public EventCallback OnBackClick { get; set; }
+    [Parameter] public EventCallback OnFolderConfirmed { get; set; }
+
+    private string? _accessToken;
+    private bool _isLoadingToken = true;
+    private bool _isSaving;
+    private bool _destFolderConfirmed;
+    private string _selectedFolderPath = string.Empty;
+    private string? _saveError;
+
+    // 前回確認済み情報（復元提案用）
+    private bool _previouslyConfirmed;
+    private string _savedFolderPath = string.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        // Dropbox アクセストークン取得
+        _accessToken = await CredentialStore.GetAsync(CredentialKeys.DropboxAccessToken);
+        _isLoadingToken = false;
+
+        // 保存済み設定の読み込み
+        var config = await ConfigurationService.GetDiscoveryConfigAsync();
+        _savedFolderPath = config.DropboxDestFolderPath;
+        _previouslyConfirmed = config.DestinationConfirmed;
+
+        // 確認済み設定があれば初期選択に反映
+        if (_previouslyConfirmed)
+        {
+            _selectedFolderPath = _savedFolderPath;
+        }
+    }
+
+    private void OnFolderSelected(string folderPath)
+    {
+        _selectedFolderPath = folderPath;
+        _destFolderConfirmed = true;
+        StateHasChanged();
+    }
+
+    private void UsePreviousFolder()
+    {
+        _selectedFolderPath = _savedFolderPath;
+        _destFolderConfirmed = true;
+        StateHasChanged();
+    }
+
+    private async Task SaveAndContinueAsync()
+    {
+        if (!_destFolderConfirmed) return;
+
+        _isSaving = true;
+        _saveError = null;
+
+        try
+        {
+            // 三点同期: dropboxDestFolderPath / destinationRoot / dropbox.rootPath
+            await ConfigurationService.UpdateDiscoveryConfigAsync(
+                new DiscoveryConfigUpdateDto(
+                    DropboxDestFolderPath: _selectedFolderPath,
+                    DestinationConfirmed: true));
+
+            await OnFolderConfirmed.InvokeAsync();
+        }
+        catch (Exception ex)
+        {
+            _saveError = $"設定の保存に失敗しました: {ex.Message}";
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+}

--- a/src/CloudMigrator.Dashboard/Components/Wizard/DropboxFolderPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/DropboxFolderPage.razor
@@ -17,23 +17,11 @@
         </div>
 
         @* 前回確認済みの転送先がある場合の提案 *@
-        @if (_previouslyConfirmed && !string.IsNullOrEmpty(_savedFolderPath) && !_destFolderConfirmed)
+        @if (_previouslyConfirmed && !_destFolderConfirmed)
         {
             <MudAlert Severity="Severity.Info" Dense="true">
                 前回の転送先:
-                <strong>@(_savedFolderPath == "" ? "（ルート）" : _savedFolderPath)</strong>
-                <MudButton Variant="Variant.Text"
-                           Color="Color.Primary"
-                           Size="Size.Small"
-                           OnClick="UsePreviousFolder">
-                    この転送先を使用
-                </MudButton>
-            </MudAlert>
-        }
-        @if (_previouslyConfirmed && string.IsNullOrEmpty(_savedFolderPath) && !_destFolderConfirmed)
-        {
-            <MudAlert Severity="Severity.Info" Dense="true">
-                前回の転送先: <strong>（Dropbox ルート）</strong>
+                <strong>@(string.IsNullOrEmpty(_savedFolderPath) ? "（Dropbox ルート）" : _savedFolderPath)</strong>
                 <MudButton Variant="Variant.Text"
                            Color="Color.Primary"
                            Size="Size.Small"

--- a/src/CloudMigrator.Dashboard/Components/Wizard/DropboxFolderPicker.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/DropboxFolderPicker.razor
@@ -66,7 +66,7 @@
                 }
                 else
                 {
-                    <MudList T="string" Dense="true">
+                    <MudList T="DropboxFolderEntry" Dense="true">
                         @foreach (var folder in _folders)
                         {
                             var entry = folder;

--- a/src/CloudMigrator.Dashboard/Components/Wizard/DropboxFolderPicker.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/DropboxFolderPicker.razor
@@ -1,0 +1,210 @@
+@using CloudMigrator.Providers.Dropbox.Auth
+
+@* Dropbox フォルダを階層ナビゲーションで選択するインラインコンポーネント *@
+
+<MudStack Spacing="2">
+
+    @* ── 現在の選択表示 ── *@
+    @if (!_isOpen)
+    {
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudIcon Icon="@Icons.Material.Filled.CloudQueue" Size="Size.Small" Color="Color.Primary" />
+            <MudText Typo="Typo.body2">
+                @(string.IsNullOrEmpty(SelectedFolderPath)
+                    ? "（ルート — Dropbox 全体）"
+                    : SelectedFolderPath)
+            </MudText>
+            <MudButton Variant="Variant.Text"
+                       Color="Color.Primary"
+                       Size="Size.Small"
+                       StartIcon="@Icons.Material.Filled.Edit"
+                       Disabled="@Disabled"
+                       OnClick="OpenPicker">
+                変更
+            </MudButton>
+        </MudStack>
+    }
+
+    @* ── フォルダブラウザ（展開時） ── *@
+    @if (_isOpen)
+    {
+        <MudPaper Elevation="2" Class="pa-3">
+            <MudStack Spacing="2">
+
+                @* パンくずナビ *@
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Wrap="Wrap.Wrap">
+                    @for (var i = 0; i < _breadcrumbs.Count; i++)
+                    {
+                        var depth = i;
+                        var label = _breadcrumbs[i];
+                        @if (i > 0)
+                        {
+                            <MudText Color="Color.Secondary"> › </MudText>
+                        }
+                        @if (i < _breadcrumbs.Count - 1)
+                        {
+                            <MudLink OnClick="@(() => NavigateToBreadcrumbDepth(depth))"
+                                     Style="cursor: pointer;">
+                                @label
+                            </MudLink>
+                        }
+                        else
+                        {
+                            <MudText>@label</MudText>
+                        }
+                    }
+                </MudStack>
+
+                @* フォルダ一覧 *@
+                @if (_isLoading)
+                {
+                    <MudProgressLinear Color="Color.Primary" Indeterminate="true" />
+                }
+                else if (_error is not null)
+                {
+                    <MudAlert Severity="Severity.Error" Dense="true">@_error</MudAlert>
+                }
+                else
+                {
+                    <MudList T="string" Dense="true">
+                        @foreach (var folder in _folders)
+                        {
+                            var entry = folder;
+                            <MudListItem Icon="@Icons.Material.Filled.Folder"
+                                         OnClick="@(() => NavigateIntoFolderAsync(entry))"
+                                         Style="cursor: pointer;">
+                                @entry.Name
+                            </MudListItem>
+                        }
+                        @if (_folders.Count == 0)
+                        {
+                            <MudText Typo="Typo.body2" Color="Color.Secondary" Class="px-2">
+                                （サブフォルダなし）
+                            </MudText>
+                        }
+                    </MudList>
+                }
+
+                @* アクションボタン *@
+                <MudStack Row="true" Spacing="2" Justify="Justify.FlexEnd">
+                    <MudButton Variant="Variant.Outlined"
+                               Size="Size.Small"
+                               OnClick="ClosePicker">
+                        キャンセル
+                    </MudButton>
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Primary"
+                               Size="Size.Small"
+                               OnClick="ConfirmSelection">
+                        このフォルダを選択
+                    </MudButton>
+                </MudStack>
+
+            </MudStack>
+        </MudPaper>
+    }
+
+</MudStack>
+
+@code {
+    /// <summary>Dropbox アクセストークン。</summary>
+    [Parameter, EditorRequired] public string AccessToken { get; set; } = string.Empty;
+
+    /// <summary>初期フォルダパス（空 = ルート）。</summary>
+    [Parameter] public string InitialFolderPath { get; set; } = string.Empty;
+
+    /// <summary>フォルダが確定されたときに呼び出される。引数は Dropbox API パス（ルートは <c>""</c>）。</summary>
+    [Parameter] public EventCallback<string> OnFolderSelected { get; set; }
+
+    /// <summary>無効状態。</summary>
+    [Parameter] public bool Disabled { get; set; }
+
+    [Inject] private IDropboxFolderService FolderService { get; set; } = default!;
+
+    private bool _isOpen;
+    private bool _isLoading;
+    private string? _error;
+
+    // 現在のナビゲーション状態
+    private string _currentPath = string.Empty;
+    private List<string> _breadcrumbs = ["（ルート）"];
+    private List<DropboxFolderEntry> _folders = [];
+
+    // 確定済みの選択値
+    public string SelectedFolderPath { get; private set; } = string.Empty;
+
+    protected override void OnParametersSet()
+    {
+        // 初期選択値の反映
+        SelectedFolderPath = InitialFolderPath;
+    }
+
+    private async Task OpenPicker()
+    {
+        _currentPath = SelectedFolderPath;
+        _breadcrumbs = BuildBreadcrumbs(_currentPath);
+        _isOpen = true;
+        await LoadFoldersAsync();
+    }
+
+    private void ClosePicker()
+    {
+        _isOpen = false;
+    }
+
+    private async Task NavigateIntoFolderAsync(DropboxFolderEntry folder)
+    {
+        _currentPath = folder.PathDisplay;
+        _breadcrumbs = BuildBreadcrumbs(_currentPath);
+        await LoadFoldersAsync();
+    }
+
+    private async Task NavigateToBreadcrumbDepth(int depth)
+    {
+        if (depth == 0)
+        {
+            _currentPath = string.Empty;
+        }
+        else
+        {
+            // パスを depth 段目まで再構築
+            var parts = _currentPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            _currentPath = "/" + string.Join("/", parts.Take(depth));
+        }
+        _breadcrumbs = BuildBreadcrumbs(_currentPath);
+        await LoadFoldersAsync();
+    }
+
+    private async Task LoadFoldersAsync()
+    {
+        _isLoading = true;
+        _error = null;
+        _folders = [];
+        StateHasChanged();
+
+        var result = await FolderService.ListFoldersAsync(AccessToken, _currentPath);
+        if (result.Success)
+            _folders = result.Folders?.ToList() ?? [];
+        else
+            _error = $"フォルダ一覧の取得に失敗しました: {result.ErrorMessage}";
+
+        _isLoading = false;
+        StateHasChanged();
+    }
+
+    private async Task ConfirmSelection()
+    {
+        SelectedFolderPath = _currentPath;
+        _isOpen = false;
+        await OnFolderSelected.InvokeAsync(SelectedFolderPath);
+    }
+
+    private static List<string> BuildBreadcrumbs(string path)
+    {
+        var crumbs = new List<string> { "（ルート）" };
+        if (string.IsNullOrEmpty(path))
+            return crumbs;
+        crumbs.AddRange(path.Split('/', StringSplitOptions.RemoveEmptyEntries));
+        return crumbs;
+    }
+}

--- a/src/CloudMigrator.Dashboard/Components/Wizard/SharePointDiscoveryPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/SharePointDiscoveryPage.razor
@@ -152,7 +152,7 @@
                 <MudList T="SharePointDriveEntry" Dense="true">
                     @foreach (var drive in _driveListResult.Drives!)
                     {
-                        <MudListItem OnClick="@(() => _selectedDrive = drive)"
+                        <MudListItem OnClick="@(() => SelectDrive(drive))"
                                      Class="@(_selectedDrive?.DriveId == drive.DriveId ? "mud-selected-item" : "")">
                             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                                 <MudIcon Icon="@Icons.Material.Filled.Folder" Size="Size.Small" />
@@ -213,15 +213,19 @@
             <div>
                 <MudText Typo="Typo.subtitle2" Class="mb-1">移行先フォルダ</MudText>
                 <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-2">
-                    Library 内のどのフォルダに保存するか選択します。選択しない場合は Library ルートに保存します。
+                    Library 内のどのフォルダに保存するか選択してください。ルートを選択するとライブラリ直下に転送されます。
                 </MudText>
+
+                @* TODO #197: 前回提案表示は後で復活させる（_showPreviousDestSuggestion で判定） *@
+
                 <DriveFolderPicker @ref="_destFolderPicker"
-                                   DriveId="@_selectedDrive.DriveId"
+                                   DriveId="@(_selectedDrive!.DriveId)"
                                    ClientId="@_cachedClientId"
                                    TenantId="@_cachedTenantId"
                                    ClientSecret="@_cachedClientSecret"
                                    InitialFolderId="@_initialDestFolderId"
                                    InitialFolderPath="@_initialDestFolderPath"
+                                   OnFolderSelected="OnDestFolderSelected"
                                    Disabled="@_isBusy" />
             </div>
         }
@@ -238,7 +242,7 @@
             <MudButton Variant="Variant.Filled"
                        Color="Color.Primary"
                        EndIcon="@Icons.Material.Filled.ArrowForward"
-                       Disabled="@(_isBusy || _selectedSite is null || _selectedDrive is null)"
+                       Disabled="@(_isBusy || _selectedSite is null || _selectedDrive is null || !_destFolderConfirmed)"
                        OnClick="SaveAndContinueAsync">
                 次へ
             </MudButton>
@@ -271,11 +275,28 @@
     private string _initialDestFolderId = string.Empty;
     private string _initialDestFolderPath = string.Empty;
 
+    // #197: 転送先フォルダ選択必須化
+    private bool _destFolderConfirmed;
+    private string _savedSiteId = string.Empty;
+    private string _savedDriveId = string.Empty;
+    private bool _savedDestinationConfirmed;
+
+    private bool _showPreviousDestSuggestion =>
+        _savedDestinationConfirmed &&
+        _selectedSite?.SiteId == _savedSiteId &&
+        _selectedDrive?.DriveId == _savedDriveId &&
+        !_destFolderConfirmed;
+
     protected override async Task OnInitializedAsync()
     {
         var config = await ConfigurationService.GetDiscoveryConfigAsync();
         _initialDestFolderId = config.SharePointDestFolderId;
         _initialDestFolderPath = config.SharePointDestFolderPath;
+
+        // 保存済みの site/drive ID と DestinationConfirmed フラグを読み込む
+        _savedSiteId = config.SharePointSiteId;
+        _savedDriveId = config.SharePointDriveId;
+        _savedDestinationConfirmed = config.DestinationConfirmed;
 
         await LoadAllSitesAsync();
     }
@@ -402,6 +423,8 @@
         _selectedSite = site;
         _driveListResult = null;
         _selectedDrive = null;
+        // #197: site 変更時に転送先確認フラグをリセット
+        _destFolderConfirmed = false;
         await LoadDrivesAsync();
     }
 
@@ -416,6 +439,8 @@
         _phase = BusyPhase.DriveList;
         _driveListResult = null;
         _selectedDrive = null;
+        // #197: drive 変更時に転送先確認フラグをリセット
+        _destFolderConfirmed = false;
         StateHasChanged();
 
         try
@@ -437,6 +462,7 @@
     private async Task SaveAndContinueAsync()
     {
         if (_selectedSite is null || _selectedDrive is null) return;
+        if (!_destFolderConfirmed) return;
 
         _isBusy = true;
         try
@@ -453,7 +479,9 @@
                 DestinationProvider: "sharepoint",
                 SharePointSiteDisplayName: _selectedSite.DisplayName,
                 SharePointSiteWebUrl: string.IsNullOrWhiteSpace(_selectedSite.WebUrl) ? null : _selectedSite.WebUrl,
-                SharePointDriveDisplayName: _selectedDrive.DisplayName));
+                SharePointDriveDisplayName: _selectedDrive.DisplayName,
+                // #197: 転送先フォルダを明示選択済みとしてフラグを保存
+                DestinationConfirmed: true));
 
             Snackbar.Add("SharePoint の接続先を保存しました。", Severity.Success);
             await OnDiscoveryCompleted.InvokeAsync();
@@ -467,5 +495,23 @@
             _isBusy = false;
         }
     }
-}
 
+    // #197: DriveFolderPicker でフォルダが選択/確定されたときに呼ばれる
+    private void OnDestFolderSelected((string FolderId, string FolderPath) _)
+    {
+        _destFolderConfirmed = true;
+    }
+
+    // #197: 保存済み site/drive が一致する場合に前回の転送先を再利用する
+    private void UsePreviousDestFolder()
+    {
+        _destFolderConfirmed = true;
+    }
+
+    // ドライブ選択：転送先フォルダ確認フラグをリセット
+    private void SelectDrive(SharePointDriveEntry drive)
+    {
+        _selectedDrive = drive;
+        _destFolderConfirmed = false;
+    }
+}

--- a/src/CloudMigrator.Dashboard/Components/Wizard/SharePointDiscoveryPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/SharePointDiscoveryPage.razor
@@ -486,12 +486,6 @@
         _destFolderConfirmed = true;
     }
 
-    // #197: 保存済み site/drive が一致する場合に前回の転送先を再利用する
-    private void UsePreviousDestFolder()
-    {
-        _destFolderConfirmed = true;
-    }
-
     // ドライブ選択：転送先フォルダ確認フラグをリセット
     private void SelectDrive(SharePointDriveEntry drive)
     {

--- a/src/CloudMigrator.Dashboard/Components/Wizard/SharePointDiscoveryPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/SharePointDiscoveryPage.razor
@@ -216,8 +216,6 @@
                     Library 内のどのフォルダに保存するか選択してください。ルートを選択するとライブラリ直下に転送されます。
                 </MudText>
 
-                @* TODO #197: 前回提案表示は後で復活させる（_showPreviousDestSuggestion で判定） *@
-
                 <DriveFolderPicker @ref="_destFolderPicker"
                                    DriveId="@(_selectedDrive!.DriveId)"
                                    ClientId="@_cachedClientId"
@@ -277,26 +275,12 @@
 
     // #197: 転送先フォルダ選択必須化
     private bool _destFolderConfirmed;
-    private string _savedSiteId = string.Empty;
-    private string _savedDriveId = string.Empty;
-    private bool _savedDestinationConfirmed;
-
-    private bool _showPreviousDestSuggestion =>
-        _savedDestinationConfirmed &&
-        _selectedSite?.SiteId == _savedSiteId &&
-        _selectedDrive?.DriveId == _savedDriveId &&
-        !_destFolderConfirmed;
 
     protected override async Task OnInitializedAsync()
     {
         var config = await ConfigurationService.GetDiscoveryConfigAsync();
         _initialDestFolderId = config.SharePointDestFolderId;
         _initialDestFolderPath = config.SharePointDestFolderPath;
-
-        // 保存済みの site/drive ID と DestinationConfirmed フラグを読み込む
-        _savedSiteId = config.SharePointSiteId;
-        _savedDriveId = config.SharePointDriveId;
-        _savedDestinationConfirmed = config.DestinationConfirmed;
 
         await LoadAllSitesAsync();
     }

--- a/src/CloudMigrator.Dashboard/Components/Wizard/WizardApp.razor
+++ b/src/CloudMigrator.Dashboard/Components/Wizard/WizardApp.razor
@@ -42,7 +42,12 @@
 
             case WizardStep.DropboxOAuth:
                 <DropboxOAuthPage OnBackClick="GoToAzureAuth"
-                                  OnAuthCompleted="GoToDropboxConnectionTest" />
+                                  OnAuthCompleted="GoToDropboxFolderPicker" />
+                break;
+
+            case WizardStep.DropboxFolderPicker:
+                <DropboxFolderPage OnBackClick="GoToDropboxOAuth"
+                                   OnFolderConfirmed="GoToDropboxConnectionTest" />
                 break;
 
             case WizardStep.ConnectionTest:
@@ -70,6 +75,7 @@
         DriveDiscovery,
         SharePointDiscovery,
         DropboxOAuth,
+        DropboxFolderPicker,
         ConnectionTest,
     }
 
@@ -156,9 +162,17 @@
         _currentStep = WizardStep.DropboxOAuth;
     }
 
-    private async Task GoToDropboxConnectionTest()
+    private async Task GoToDropboxFolderPicker()
     {
         _state.Step3DropboxOAuth = WizardStepState.Verified;
+        _state.Step3bDropboxFolderPicker = WizardStepState.InProgress;
+        await WizardStateService.SaveAsync(_state);
+        _currentStep = WizardStep.DropboxFolderPicker;
+    }
+
+    private async Task GoToDropboxConnectionTest()
+    {
+        _state.Step3bDropboxFolderPicker = WizardStepState.Verified;
         _state.Step4ConnectionTest = WizardStepState.InProgress;
         _currentStep = WizardStep.ConnectionTest;
         await WizardStateService.SaveAsync(_state);
@@ -169,7 +183,9 @@
         // 「戻る」ボタン: 路線に応じて direct back
         if (_state.SelectedRoute == WizardRoute.OneDriveToDropbox)
         {
-            GoToDropboxOAuth();
+            // #197: Dropbox 路線は DropboxFolderPicker へ戻る
+            _state.Step3bDropboxFolderPicker = WizardStepState.InProgress;
+            _currentStep = WizardStep.DropboxFolderPicker;
         }
         else
         {
@@ -239,6 +255,11 @@
             state.Step3DropboxOAuth != WizardStepState.Verified)
             return WizardStep.DropboxOAuth;
 
+        // Dropbox 路線: Step 3b（フォルダ選択）が未完了
+        if (state.SelectedRoute == WizardRoute.OneDriveToDropbox &&
+            state.Step3bDropboxFolderPicker != WizardStepState.Verified)
+            return WizardStep.DropboxFolderPicker;
+
         // Step 4 が未完了（両路線共通）
         if (state.Step4ConnectionTest != WizardStepState.Verified)
             return WizardStep.ConnectionTest;
@@ -254,6 +275,7 @@
         WizardStep.DriveDiscovery       => "Step 2a: OneDrive Drive ID 取得",
         WizardStep.SharePointDiscovery  => "Step 2b: SharePoint 接続先設定",
         WizardStep.DropboxOAuth         => "Step 3: Dropbox 連携",
+        WizardStep.DropboxFolderPicker  => "Step 3b: 転送先フォルダ選択",
         WizardStep.ConnectionTest       => "Step 4: 接続テスト",
         _                               => string.Empty,
     };

--- a/src/CloudMigrator.Providers.Dropbox/Auth/DropboxFolderService.cs
+++ b/src/CloudMigrator.Providers.Dropbox/Auth/DropboxFolderService.cs
@@ -1,0 +1,110 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace CloudMigrator.Providers.Dropbox.Auth;
+
+/// <summary>
+/// Dropbox <c>files/list_folder</c> API を呼び出してフォルダ一覧を返す <see cref="IDropboxFolderService"/> 実装。
+/// ページネーションを自動処理し、フォルダエントリのみ返す。
+/// </summary>
+public sealed class DropboxFolderService : IDropboxFolderService
+{
+    private const string ApiBaseUrl = "https://api.dropboxapi.com/2";
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<DropboxFolderService> _logger;
+
+    public DropboxFolderService(IHttpClientFactory httpClientFactory, ILogger<DropboxFolderService> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<DropboxFolderListResult> ListFoldersAsync(
+        string accessToken,
+        string folderPath,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var client = _httpClientFactory.CreateClient();
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+            var folders = new List<DropboxFolderEntry>();
+
+            var hasMore = true;
+            string? cursor = null;
+
+            while (hasMore)
+            {
+                HttpResponseMessage response;
+                if (cursor is null)
+                    response = await PostListFolderAsync(client, folderPath, ct).ConfigureAwait(false);
+                else
+                    response = await PostListFolderContinueAsync(client, cursor, ct).ConfigureAwait(false);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    var errorBody = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+                    _logger.LogWarning(
+                        "Dropbox files/list_folder 失敗 [{Path}]: HTTP {Status} — {Body}",
+                        folderPath, (int)response.StatusCode, errorBody);
+                    return new DropboxFolderListResult(false, ErrorMessage: $"HTTP {(int)response.StatusCode}");
+                }
+
+                var responseJson = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+                using var doc = JsonDocument.Parse(responseJson);
+                var root = doc.RootElement;
+
+                if (root.TryGetProperty("entries", out var entries))
+                {
+                    foreach (var entry in entries.EnumerateArray())
+                    {
+                        if (!entry.TryGetProperty(".tag", out var tag) || tag.GetString() != "folder")
+                            continue;
+
+                        var name = entry.TryGetProperty("name", out var n) ? n.GetString() ?? string.Empty : string.Empty;
+                        var pathDisplay = entry.TryGetProperty("path_display", out var pd)
+                            ? pd.GetString() ?? string.Empty
+                            : string.Empty;
+
+                        folders.Add(new DropboxFolderEntry(name, pathDisplay));
+                    }
+                }
+
+                hasMore = root.TryGetProperty("has_more", out var hm) && hm.GetBoolean();
+                cursor = hasMore && root.TryGetProperty("cursor", out var c) ? c.GetString() : null;
+            }
+
+            folders.Sort(static (a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+            return new DropboxFolderListResult(true, folders);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Dropbox フォルダ一覧取得中にエラーが発生しました（path={Path}）。", folderPath);
+            return new DropboxFolderListResult(false, ErrorMessage: ex.Message);
+        }
+    }
+
+    private async Task<HttpResponseMessage> PostListFolderAsync(HttpClient client, string path, CancellationToken ct)
+    {
+        var json = JsonSerializer.Serialize(new
+        {
+            path,
+            recursive = false,
+            include_deleted = false,
+        });
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        return await client.PostAsync($"{ApiBaseUrl}/files/list_folder", content, ct).ConfigureAwait(false);
+    }
+
+    private static async Task<HttpResponseMessage> PostListFolderContinueAsync(HttpClient client, string cursor, CancellationToken ct)
+    {
+        var json = JsonSerializer.Serialize(new { cursor });
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        return await client.PostAsync($"{ApiBaseUrl}/files/list_folder/continue", content, ct).ConfigureAwait(false);
+    }
+}

--- a/src/CloudMigrator.Providers.Dropbox/Auth/DropboxFolderService.cs
+++ b/src/CloudMigrator.Providers.Dropbox/Auth/DropboxFolderService.cs
@@ -40,11 +40,9 @@ public sealed class DropboxFolderService : IDropboxFolderService
 
             while (hasMore)
             {
-                HttpResponseMessage response;
-                if (cursor is null)
-                    response = await PostListFolderAsync(client, folderPath, ct).ConfigureAwait(false);
-                else
-                    response = await PostListFolderContinueAsync(client, cursor, ct).ConfigureAwait(false);
+                using var response = cursor is null
+                    ? await PostListFolderAsync(client, folderPath, ct).ConfigureAwait(false)
+                    : await PostListFolderContinueAsync(client, cursor, ct).ConfigureAwait(false);
 
                 if (!response.IsSuccessStatusCode)
                 {

--- a/src/CloudMigrator.Providers.Dropbox/Auth/IDropboxFolderService.cs
+++ b/src/CloudMigrator.Providers.Dropbox/Auth/IDropboxFolderService.cs
@@ -1,0 +1,25 @@
+namespace CloudMigrator.Providers.Dropbox.Auth;
+
+/// <summary>Dropbox フォルダ一覧取得サービス（ウィザード転送先選択用）。</summary>
+public interface IDropboxFolderService
+{
+    /// <summary>
+    /// 指定フォルダ直下のフォルダ一覧を返す。
+    /// </summary>
+    /// <param name="accessToken">Dropbox アクセストークン。</param>
+    /// <param name="folderPath">Dropbox API パス（ルートは <c>""</c>、サブフォルダは <c>/folder</c>）。</param>
+    /// <param name="ct">キャンセルトークン。</param>
+    Task<DropboxFolderListResult> ListFoldersAsync(
+        string accessToken,
+        string folderPath,
+        CancellationToken ct = default);
+}
+
+/// <summary>Dropbox フォルダエントリ。</summary>
+public sealed record DropboxFolderEntry(string Name, string PathDisplay);
+
+/// <summary>フォルダ一覧取得結果。</summary>
+public sealed record DropboxFolderListResult(
+    bool Success,
+    IReadOnlyList<DropboxFolderEntry>? Folders = null,
+    string? ErrorMessage = null);

--- a/tasks.md
+++ b/tasks.md
@@ -15,10 +15,11 @@
 
 | 順番 | Issue | 種別 | タイトル | 判断 |
 |------|-------|------|----------|------|
-| 1 | [#190](https://github.com/scottlz0310/cloud-migrator/issues/190) | bug | DashboardPage の ITransferStateDb が Dropbox 実行中も SharePoint DB を参照し続ける問題 | 実装済み（PR 対応中）。route-aware な state DB アクセサへ切り替え、Dashboard / Settings / MigrationWork が同じ DB 解決を使うようにした。 |
-| 2 | [#189](https://github.com/scottlz0310/cloud-migrator/issues/189) | enhancement / dashboard | 路線に応じて設定項目を排他表示する | 次の推奨着手。#190 で整えた route/provider と DB 参照の境界を前提に、SharePoint 専用設定と Dropbox 専用設定を分離する。 |
-| 3 | [#191](https://github.com/scottlz0310/cloud-migrator/issues/191) | refactor | DashboardPage タブバーを MudTabs（静的 MudTabPanel）に戻す | アクセシビリティと保守性改善。#190 と同じ DashboardPage に触れるため、bug 修正後に実施して差分衝突を避ける。 |
-| 4 | [#15](https://github.com/scottlz0310/cloud-migrator/issues/15) | maintenance | Dependency Dashboard | 機能修正後に CI が安定した状態で依存関係更新を確認する。Renovate 管理のため通常実装とは別レーン。 |
+| 1 | [#197](https://github.com/scottlz0310/cloud-migrator/issues/197) | enhancement | 転送先フォルダ確認フラグ | 実装済み（PR 作成予定）。`DriveFolderPicker` 組み込み・`DestinationConfirmed` フラグ永続化・Dropbox フォルダ選択ウィザードステップ追加。 |
+| 2 | [#190](https://github.com/scottlz0310/cloud-migrator/issues/190) | bug | DashboardPage の ITransferStateDb が Dropbox 実行中も SharePoint DB を参照し続ける問題 | 実装済み（PR 対応中）。route-aware な state DB アクセサへ切り替え、Dashboard / Settings / MigrationWork が同じ DB 解決を使うようにした。 |
+| 3 | [#189](https://github.com/scottlz0310/cloud-migrator/issues/189) | enhancement / dashboard | 路線に応じて設定項目を排他表示する | 次の推奨着手。#190 で整えた route/provider と DB 参照の境界を前提に、SharePoint 専用設定と Dropbox 専用設定を分離する。 |
+| 4 | [#191](https://github.com/scottlz0310/cloud-migrator/issues/191) | refactor | DashboardPage タブバーを MudTabs（静的 MudTabPanel）に戻す | アクセシビリティと保守性改善。#190 と同じ DashboardPage に触れるため、bug 修正後に実施して差分衝突を避ける。 |
+| 5 | [#15](https://github.com/scottlz0310/cloud-migrator/issues/15) | maintenance | Dependency Dashboard | 機能修正後に CI が安定した状態で依存関係更新を確認する。Renovate 管理のため通常実装とは別レーン。 |
 | 保留 | [#101](https://github.com/scottlz0310/cloud-migrator/issues/101) | epic / installer | MSIX パッケージング・Microsoft Store 公開 | MSI 配布 #97 の運用実績、Partner Center、Store 提出素材が前提。現フェーズでは計画保持のみ。 |
 
 ---

--- a/tests/unit/ConfigurationServiceDiscoveryTests.cs
+++ b/tests/unit/ConfigurationServiceDiscoveryTests.cs
@@ -229,4 +229,102 @@ public sealed class ConfigurationServiceDiscoveryTests : IDisposable
         g["oneDriveSourceFolderPath"]!.GetValue<string>().Should().Be("Documents/Projects");
         g["oneDriveSourceFolder"]!.GetValue<string>().Should().Be("Documents/Projects");
     }
+
+    // ── DestinationConfirmed / DropboxDestFolderPath (#197) ───────────────
+
+    [Fact]
+    public async Task UpdateDiscoveryConfigAsync_WhenDestinationConfirmedIsTrue_PersistsFlag()
+    {
+        // 検証対象: UpdateDiscoveryConfigAsync  目的: DestinationConfirmed=true が config.json に保存されること
+        await _sut.UpdateDiscoveryConfigAsync(new DiscoveryConfigUpdateDto(DestinationConfirmed: true));
+
+        var result = await _sut.GetDiscoveryConfigAsync();
+        result.DestinationConfirmed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateDiscoveryConfigAsync_WhenDestinationConfirmedIsFalse_PersistsFlag()
+    {
+        // 検証対象: UpdateDiscoveryConfigAsync  目的: DestinationConfirmed=false が保存・読み取れること
+        await _sut.UpdateDiscoveryConfigAsync(new DiscoveryConfigUpdateDto(DestinationConfirmed: true));
+        await _sut.UpdateDiscoveryConfigAsync(new DiscoveryConfigUpdateDto(DestinationConfirmed: false));
+
+        var result = await _sut.GetDiscoveryConfigAsync();
+        result.DestinationConfirmed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetDiscoveryConfigAsync_WhenDestinationConfirmedIsMissing_ReturnsFalse()
+    {
+        // 検証対象: GetDiscoveryConfigAsync  目的: destinationConfirmed 未設定時に false が返されること
+        var result = await _sut.GetDiscoveryConfigAsync();
+
+        result.DestinationConfirmed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UpdateDiscoveryConfigAsync_WhenDropboxDestFolderPathSet_RoundTrips()
+    {
+        // 検証対象: UpdateDiscoveryConfigAsync  目的: DropboxDestFolderPath が保存・読み取れること
+        await _sut.UpdateDiscoveryConfigAsync(new DiscoveryConfigUpdateDto(
+            DropboxDestFolderPath: "/Photos",
+            DestinationConfirmed: true));
+
+        var result = await _sut.GetDiscoveryConfigAsync();
+        result.DropboxDestFolderPath.Should().Be("/Photos");
+        result.DestinationConfirmed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateDiscoveryConfigAsync_WhenDropboxRootSelected_DestinationConfirmedCanBeTrue()
+    {
+        // 検証対象: UpdateDiscoveryConfigAsync
+        // 目的: Dropbox ルート（""）を選択しても DestinationConfirmed=true が保存できること
+        await _sut.UpdateDiscoveryConfigAsync(new DiscoveryConfigUpdateDto(
+            DropboxDestFolderPath: "",
+            DestinationConfirmed: true));
+
+        var result = await _sut.GetDiscoveryConfigAsync();
+        result.DropboxDestFolderPath.Should().BeEmpty();
+        result.DestinationConfirmed.Should().BeTrue();
+    }
+
+    // ── Dropbox 三点同期 (#197) ────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateDiscoveryConfigAsync_WhenDropboxDestFolderPathSet_SyncsAllThreeFields()
+    {
+        // 検証対象: UpdateDiscoveryConfigAsync
+        // 目的: DropboxDestFolderPath 設定時に dropboxDestFolderPath / destinationRoot / dropbox.rootPath
+        //       の 3 フィールドが同値に同期されること
+        await _sut.UpdateDiscoveryConfigAsync(new DiscoveryConfigUpdateDto(
+            DropboxDestFolderPath: "/Backup",
+            DestinationProvider: "dropbox"));
+
+        var json = JsonNode.Parse(await File.ReadAllTextAsync(_configFile))!;
+        var m = json["migrator"]!.AsObject();
+        var g = m["graph"]!;
+
+        g["dropboxDestFolderPath"]!.GetValue<string>().Should().Be("/Backup");
+        m["destinationRoot"]!.GetValue<string>().Should().Be("/Backup");
+        m["dropbox"]!["rootPath"]!.GetValue<string>().Should().Be("/Backup");
+    }
+
+    [Fact]
+    public async Task UpdateDiscoveryConfigAsync_WhenDropboxRootPath_SyncsAllThreeFieldsAsEmpty()
+    {
+        // 検証対象: UpdateDiscoveryConfigAsync
+        // 目的: Dropbox ルート（""）でも 3 フィールドすべてが "" に同期されること
+        await _sut.UpdateDiscoveryConfigAsync(new DiscoveryConfigUpdateDto(
+            DropboxDestFolderPath: "",
+            DestinationProvider: "dropbox"));
+
+        var json = JsonNode.Parse(await File.ReadAllTextAsync(_configFile))!;
+        var m = json["migrator"]!.AsObject();
+        var g = m["graph"]!;
+
+        g["dropboxDestFolderPath"]!.GetValue<string>().Should().BeEmpty();
+        m["destinationRoot"]!.GetValue<string>().Should().BeEmpty();
+        m["dropbox"]!["rootPath"]!.GetValue<string>().Should().BeEmpty();
+    }
 }

--- a/tests/unit/ConfigurationServiceTests.cs
+++ b/tests/unit/ConfigurationServiceTests.cs
@@ -152,7 +152,140 @@ public sealed class ConfigurationServiceTests : IDisposable
         result.DestinationRoot.Should().Be("Documents/テスト");
     }
 
-    // ── NormalizeProvider: GetConfigAsync 経由での正規化検証 ─────────────
+    // ── UpdateConfigAsync / DestinationRoot 同期（provider 限定）────────────
+
+    [Fact]
+    public async Task UpdateConfigAsync_WhenSharePointProvider_UpdatesOnlySharePointDestFolderPath()
+    {
+        // 検証対象: UpdateConfigAsync（DestinationRoot 同期）
+        // 目的: destinationProvider=sharepoint のとき DestinationRoot 更新が
+        //       sharePointDestFolderPath のみ同期し dropboxDestFolderPath / dropbox.rootPath は変えないこと
+        WriteConfig(new
+        {
+            migrator = new
+            {
+                maxParallelTransfers = 4,
+                chunkSizeMb = 5,
+                largeFileThresholdMb = 4,
+                retryCount = 3,
+                timeoutSec = 300,
+                destinationRoot = string.Empty,
+                destinationProvider = "sharepoint",
+                graph = new { sharePointDestFolderPath = "OldSP", dropboxDestFolderPath = "OldDropbox" },
+                dropbox = new { rootPath = "OldRoot" }
+            }
+        });
+        var svc = new ConfigurationService(_configPath);
+
+        await svc.UpdateConfigAsync(new ConfigUpdateDto(DestinationRoot: "NewSP"));
+
+        var json = System.Text.Json.Nodes.JsonNode.Parse(await File.ReadAllTextAsync(_configPath))!;
+        var m = json["migrator"]!.AsObject();
+        m["destinationRoot"]!.GetValue<string>().Should().Be("NewSP");
+        m["graph"]!["sharePointDestFolderPath"]!.GetValue<string>().Should().Be("NewSP");
+        m["graph"]!["dropboxDestFolderPath"]!.GetValue<string>().Should().Be("OldDropbox");  // 変わらない
+        m["dropbox"]!["rootPath"]!.GetValue<string>().Should().Be("OldRoot");                // 変わらない
+    }
+
+    [Fact]
+    public async Task UpdateConfigAsync_WhenDropboxProvider_UpdatesOnlyDropboxPaths()
+    {
+        // 検証対象: UpdateConfigAsync（DestinationRoot 同期）
+        // 目的: destinationProvider=dropbox のとき DestinationRoot 更新が
+        //       dropboxDestFolderPath / dropbox.rootPath のみ同期し sharePointDestFolderPath は変えないこと
+        WriteConfig(new
+        {
+            migrator = new
+            {
+                maxParallelTransfers = 4,
+                chunkSizeMb = 5,
+                largeFileThresholdMb = 4,
+                retryCount = 3,
+                timeoutSec = 300,
+                destinationRoot = string.Empty,
+                destinationProvider = "dropbox",
+                graph = new { sharePointDestFolderPath = "OldSP", dropboxDestFolderPath = "OldDropbox" },
+                dropbox = new { rootPath = "OldRoot" }
+            }
+        });
+        var svc = new ConfigurationService(_configPath);
+
+        await svc.UpdateConfigAsync(new ConfigUpdateDto(DestinationRoot: "/NewDropbox"));
+
+        var json = System.Text.Json.Nodes.JsonNode.Parse(await File.ReadAllTextAsync(_configPath))!;
+        var m = json["migrator"]!.AsObject();
+        m["destinationRoot"]!.GetValue<string>().Should().Be("/NewDropbox");
+        m["graph"]!["dropboxDestFolderPath"]!.GetValue<string>().Should().Be("/NewDropbox");
+        m["dropbox"]!["rootPath"]!.GetValue<string>().Should().Be("/NewDropbox");
+        m["graph"]!["sharePointDestFolderPath"]!.GetValue<string>().Should().Be("OldSP");   // 変わらない
+    }
+
+    [Fact]
+    public async Task UpdateConfigAsync_WhenProviderAndRootChangedSimultaneously_UsesNewProvider()
+    {
+        // 検証対象: UpdateConfigAsync（DestinationRoot + DestinationProvider 同時更新）
+        // 目的: DestinationProvider と DestinationRoot を同時に更新する場合、
+        //       新しい provider 側のパスのみ同期されること
+        WriteConfig(new
+        {
+            migrator = new
+            {
+                maxParallelTransfers = 4,
+                chunkSizeMb = 5,
+                largeFileThresholdMb = 4,
+                retryCount = 3,
+                timeoutSec = 300,
+                destinationRoot = string.Empty,
+                destinationProvider = "sharepoint",
+                graph = new { sharePointDestFolderPath = "OldSP", dropboxDestFolderPath = "OldDropbox" },
+                dropbox = new { rootPath = "OldRoot" }
+            }
+        });
+        var svc = new ConfigurationService(_configPath);
+
+        // SharePoint → Dropbox に切り替えながら DestinationRoot も同時変更
+        await svc.UpdateConfigAsync(new ConfigUpdateDto(
+            DestinationRoot: "/NewDropboxRoot",
+            DestinationProvider: "dropbox"));
+
+        var json = System.Text.Json.Nodes.JsonNode.Parse(await File.ReadAllTextAsync(_configPath))!;
+        var m = json["migrator"]!.AsObject();
+        m["destinationProvider"]!.GetValue<string>().Should().Be("dropbox");
+        m["graph"]!["dropboxDestFolderPath"]!.GetValue<string>().Should().Be("/NewDropboxRoot");
+        m["dropbox"]!["rootPath"]!.GetValue<string>().Should().Be("/NewDropboxRoot");
+        m["graph"]!["sharePointDestFolderPath"]!.GetValue<string>().Should().Be("OldSP");  // 変わらない
+    }
+
+    [Fact]
+    public async Task UpdateConfigAsync_WhenGraphAliasProvider_TreatsAsSharePoint()
+    {
+        // 検証対象: UpdateConfigAsync（DestinationRoot 同期 / NormalizeProvider）
+        // 目的: destinationProvider="graph" の旧エイリアスでも sharePointDestFolderPath が更新されること
+        WriteConfig(new
+        {
+            migrator = new
+            {
+                maxParallelTransfers = 4,
+                chunkSizeMb = 5,
+                largeFileThresholdMb = 4,
+                retryCount = 3,
+                timeoutSec = 300,
+                destinationRoot = string.Empty,
+                destinationProvider = "graph",
+                graph = new { sharePointDestFolderPath = "OldSP", dropboxDestFolderPath = "OldDropbox" }
+            }
+        });
+        var svc = new ConfigurationService(_configPath);
+
+        await svc.UpdateConfigAsync(new ConfigUpdateDto(DestinationRoot: "NewSP"));
+
+        var json = System.Text.Json.Nodes.JsonNode.Parse(await File.ReadAllTextAsync(_configPath))!;
+        var m = json["migrator"]!.AsObject();
+        m["graph"]!["sharePointDestFolderPath"]!.GetValue<string>().Should().Be("NewSP");
+        m["graph"]!["dropboxDestFolderPath"]!.GetValue<string>().Should().Be("OldDropbox");  // 変わらない
+    }
+
+
 
     [Theory]
     [InlineData("graph", "sharepoint")]

--- a/tests/unit/DropboxFolderServiceTests.cs
+++ b/tests/unit/DropboxFolderServiceTests.cs
@@ -1,0 +1,140 @@
+using System.Net;
+using System.Text;
+using CloudMigrator.Providers.Dropbox.Auth;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace CloudMigrator.Tests.Unit;
+
+/// <summary>
+/// 検証対象: DropboxFolderService.ListFoldersAsync
+/// 目的: ページネーション/JSON パース/失敗ステータス/例外の各ケースを網羅する
+/// </summary>
+public sealed class DropboxFolderServiceTests
+{
+    // Dropbox API の ".tag" フィールドは C# 匿名型で表現できないため生 JSON を使う
+
+    private static HttpResponseMessage JsonResponse(string json, HttpStatusCode status = HttpStatusCode.OK)
+        => new(status) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    private static IHttpClientFactory BuildFactory(params HttpResponseMessage[] responses)
+    {
+        var handler = new SequentialHttpHandler(responses);
+        var client = new HttpClient(handler);
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+        return factory.Object;
+    }
+
+    // ── 成功 1 ページ ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListFoldersAsync_SinglePage_ReturnsFoldersSortedByName()
+    {
+        // 検証対象: ListFoldersAsync  目的: 1 ページのレスポンスからフォルダのみを取得し名前順で返すこと
+        const string json = """
+            {
+              "entries": [
+                { ".tag": "folder", "name": "Zulu",    "path_display": "/Zulu" },
+                { ".tag": "file",   "name": "file.txt","path_display": "/file.txt" },
+                { ".tag": "folder", "name": "Alpha",   "path_display": "/Alpha" }
+              ],
+              "has_more": false
+            }
+            """;
+        var sut = new DropboxFolderService(BuildFactory(JsonResponse(json)), NullLogger<DropboxFolderService>.Instance);
+
+        var result = await sut.ListFoldersAsync("token", "");
+
+        result.Success.Should().BeTrue();
+        result.Folders.Should().HaveCount(2);
+        result.Folders![0].Name.Should().Be("Alpha");
+        result.Folders![1].Name.Should().Be("Zulu");
+    }
+
+    // ── 成功 複数ページ ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListFoldersAsync_MultiplePaged_ReturnsAllFoldersMerged()
+    {
+        // 検証対象: ListFoldersAsync  目的: has_more=true でページネーションを自動処理し全フォルダを返すこと
+        const string page1 = """
+            {
+              "entries": [{ ".tag": "folder", "name": "Beta", "path_display": "/Beta" }],
+              "has_more": true,
+              "cursor": "cursor-abc"
+            }
+            """;
+        const string page2 = """
+            {
+              "entries": [{ ".tag": "folder", "name": "Alpha", "path_display": "/Alpha" }],
+              "has_more": false
+            }
+            """;
+        var sut = new DropboxFolderService(
+            BuildFactory(JsonResponse(page1), JsonResponse(page2)),
+            NullLogger<DropboxFolderService>.Instance);
+
+        var result = await sut.ListFoldersAsync("token", "");
+
+        result.Success.Should().BeTrue();
+        result.Folders.Should().HaveCount(2);
+        result.Folders![0].Name.Should().Be("Alpha");
+        result.Folders![1].Name.Should().Be("Beta");
+    }
+
+    // ── 失敗ステータス ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListFoldersAsync_WhenHttpError_ReturnsFailureWithStatusCode()
+    {
+        // 検証対象: ListFoldersAsync  目的: Dropbox API が非成功ステータスを返した場合に Success=false を返すこと
+        var sut = new DropboxFolderService(
+            BuildFactory(JsonResponse("""{"error":"path/not_found"}""", HttpStatusCode.Conflict)),
+            NullLogger<DropboxFolderService>.Instance);
+
+        var result = await sut.ListFoldersAsync("token", "/NonExistent");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("409");
+    }
+
+    // ── 例外 ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListFoldersAsync_WhenHttpThrows_ReturnsFailureWithMessage()
+    {
+        // 検証対象: ListFoldersAsync  目的: HTTP 通信で例外が発生した場合に Success=false を返すこと
+        var handler = new ExceptionHttpHandler(new HttpRequestException("network error"));
+        var client = new HttpClient(handler);
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+        var sut = new DropboxFolderService(factory.Object, NullLogger<DropboxFolderService>.Instance);
+
+        var result = await sut.ListFoldersAsync("token", "");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("network error");
+    }
+
+    // ── ヘルパークラス ────────────────────────────────────────────────────
+
+    private sealed class SequentialHttpHandler(params HttpResponseMessage[] responses) : HttpMessageHandler
+    {
+        private int _index;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            if (_index >= responses.Length)
+                throw new InvalidOperationException($"予期しない HTTP 呼び出し（index={_index}）");
+            return Task.FromResult(responses[_index++]);
+        }
+    }
+
+    private sealed class ExceptionHttpHandler(Exception ex) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => Task.FromException<HttpResponseMessage>(ex);
+    }
+}


### PR DESCRIPTION
## 概要

Issue #197 の実装。SharePoint / Dropbox 双方で、転送先フォルダを明示的に選択しないと転送を開始できないようにする。

## 変更内容

### SharePoint 路線
- \SharePointDiscoveryPage\ に \DriveFolderPicker\ コンポーネントを組み込み
- ドライブ選択後、フォルダを選択・確定するまで「次へ」ボタンを無効化（\_destFolderConfirmed\ ガード）
- サイト / ドライブ変更時に確認フラグを自動リセット

### Dropbox 路線
- \DropboxFolderPicker\ / \DropboxFolderPage\ コンポーネントを新規追加
- \IDropboxFolderService\ / \DropboxFolderService\ を実装（フォルダ一覧取得・選択）
- \WizardState\ に \Step3bDropboxFolderPicker\ ステップを追加

### 共通
- \DiscoveryConfigDto\ / \DiscoveryConfigUpdateDto\ に \DestinationConfirmed\ フィールドを追加し \config.json\ に永続化
- \DashboardPage\ で \DestinationConfirmed\ 未設定時に転送開始をブロック（警告 Snackbar）

## テスト

- ユニットテスト 930 件全通過
- pre-commit フック（build / format / restore / test）全パス

Closes #197