### PR TITLE
fix: ルート・転送パス変更時の state DB 初期化を必須化 (#198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   - `ConfigHashChecker.ComputeHash` に `DestinationProvider`（"sharepoint"/"dropbox"）と `Graph.OneDriveSourceFolder`（転送元フォルダパス）を追加し、これらの変更をハッシュで検知できるようにした
   - `DashboardPage` の転送開始前にハッシュ変更を検出し、前回ハッシュが存在する場合は確認ダイアログを表示して DB 強制リセット（`ResetAllAsync` + `ClearAll`）を実施するよう変更
   - 初回起動（ハッシュファイル未作成）は DB が空のため確認ダイアログをスキップ
-  - `ConfigHashCheckerTests` に `ComputeHash_DifferentDestinationProvider_ReturnsDifferentHash` と `ComputeHash_DifferentOneDriveSourceFolder_ReturnsDifferentHash` の2件を追加
+  - `ConfigHashCheckerTests` に `ComputeHash_DifferentDestinationProvider_ReturnsDifferentHash`・`ComputeHash_DifferentOneDriveSourceFolder_ReturnsDifferentHash`・`ComputeHash_GraphProviderEqualsSharePoint_ReturnsSameHash` の3件を追加
 
 - **Dashboard の転送処理が常に SharePoint パイプラインを使用するバグを修正**（App.xaml.cs）
   - `MigrationWork` が `opts.DestinationProvider` を無視して常に `SharePointMigrationPipeline` を生成していた

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 
 ### Fixed
 
+- **ルート・転送パス変更時の state DB 初期化を必須化（#198）**
+  - `ConfigHashChecker.ComputeHash` に `DestinationProvider`（"sharepoint"/"dropbox"）と `Graph.OneDriveSourceFolder`（転送元フォルダパス）を追加し、これらの変更をハッシュで検知できるようにした
+  - `DashboardPage` の転送開始前にハッシュ変更を検出し、前回ハッシュが存在する場合は確認ダイアログを表示して DB 強制リセット（`ResetAllAsync` + `ClearAll`）を実施するよう変更
+  - 初回起動（ハッシュファイル未作成）は DB が空のため確認ダイアログをスキップ
+  - `ConfigHashCheckerTests` に `ComputeHash_DifferentDestinationProvider_ReturnsDifferentHash` と `ComputeHash_DifferentOneDriveSourceFolder_ReturnsDifferentHash` の2件を追加
+
 - **Dashboard の転送処理が常に SharePoint パイプラインを使用するバグを修正**（App.xaml.cs）
   - `MigrationWork` が `opts.DestinationProvider` を無視して常に `SharePointMigrationPipeline` を生成していた
   - `isDropbox` フラグで分岐し、Dropbox 路線では `DropboxStorageProvider` + `DropboxMigrationPipeline` を使用するよう修正

--- a/src/CloudMigrator.Core/Configuration/ConfigHashChecker.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigHashChecker.cs
@@ -35,7 +35,14 @@ public static class ConfigHashChecker
                 .Replace('\\', '/')
                 .Trim('/')).Append('|');
         // DestinationProvider（#198）: sharepoint/dropbox のルート変更を検知する
-        sb.Append(options.DestinationProvider?.Trim().ToLowerInvariant() ?? string.Empty).Append('|');
+        // "graph" は "sharepoint" の旧エイリアス（ConfigurationService.NormalizeProvider と同じ規則）
+        var normalizedProvider = options.DestinationProvider?.Trim().ToLowerInvariant() switch
+        {
+            "sharepoint" or "graph" => "sharepoint",
+            "dropbox" => "dropbox",
+            var v => v ?? string.Empty
+        };
+        sb.Append(normalizedProvider).Append('|');
         // OneDriveSourceFolder（#198）: 転送元フォルダパス変更を検知する
         sb.Append(
             (options.Graph.OneDriveSourceFolder ?? string.Empty)

--- a/src/CloudMigrator.Core/Configuration/ConfigHashChecker.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigHashChecker.cs
@@ -11,6 +11,12 @@ namespace CloudMigrator.Core.Configuration;
 public static class ConfigHashChecker
 {
     /// <summary>
+    /// ハッシュファイルのスキーマバージョンプレフィックス。
+    /// このバージョンが付いていない旧形式ファイルは「変更なし」として扱い、
+    /// 次回転送成功時に新形式へ自動移行する（アップグレード時の誤 DB 初期化を防ぐ）。
+    /// </summary>
+    private const string HashVersionPrefix = "v2:";
+    /// <summary>
     /// 設定の SHA-256 ハッシュを計算する。
     /// Graph/Dropbox の識別子・ルートパスなど転送結果に影響する値を対象とする。
     /// </summary>
@@ -56,7 +62,9 @@ public static class ConfigHashChecker
 
     /// <summary>
     /// ハッシュファイルを読み込み、新しいハッシュと比較する。
-    /// ファイルが存在しない場合・内容が異なる場合は true を返す。
+    /// ファイルが存在しない場合は true を返す。
+    /// 旧形式（バージョンプレフィックスなし）のファイルはアップグレード時の誤 DB 初期化を防ぐため
+    /// 変更なし（false）として扱い、次回転送成功時に新形式へ移行する。
     /// </summary>
     public static async Task<bool> HasChangedAsync(
         string hashFilePath,
@@ -69,10 +77,15 @@ public static class ConfigHashChecker
         var stored = (await File.ReadAllTextAsync(hashFilePath, cancellationToken)
             .ConfigureAwait(false)).Trim();
 
-        return !string.Equals(stored, newHash, StringComparison.OrdinalIgnoreCase);
+        // 旧形式（バージョンプレフィックスなし）: 変更なしとして扱い新形式への移行を待つ
+        if (!stored.StartsWith(HashVersionPrefix, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var storedHash = stored[HashVersionPrefix.Length..];
+        return !string.Equals(storedHash, newHash, StringComparison.OrdinalIgnoreCase);
     }
 
-    /// <summary>ハッシュをファイルへ保存する。</summary>
+    /// <summary>ハッシュをバージョンプレフィックス付きでファイルへ保存する。</summary>
     public static async Task SaveHashAsync(
         string hashFilePath,
         string hash,
@@ -82,7 +95,7 @@ public static class ConfigHashChecker
         if (!string.IsNullOrEmpty(dir))
             Directory.CreateDirectory(dir);
 
-        await File.WriteAllTextAsync(hashFilePath, hash, cancellationToken)
+        await File.WriteAllTextAsync(hashFilePath, HashVersionPrefix + hash, cancellationToken)
             .ConfigureAwait(false);
     }
 

--- a/src/CloudMigrator.Core/Configuration/ConfigHashChecker.cs
+++ b/src/CloudMigrator.Core/Configuration/ConfigHashChecker.cs
@@ -33,6 +33,14 @@ public static class ConfigHashChecker
             (options.DestinationRoot ?? string.Empty)
                 .Trim()
                 .Replace('\\', '/')
+                .Trim('/')).Append('|');
+        // DestinationProvider（#198）: sharepoint/dropbox のルート変更を検知する
+        sb.Append(options.DestinationProvider?.Trim().ToLowerInvariant() ?? string.Empty).Append('|');
+        // OneDriveSourceFolder（#198）: 転送元フォルダパス変更を検知する
+        sb.Append(
+            (options.Graph.OneDriveSourceFolder ?? string.Empty)
+                .Trim()
+                .Replace('\\', '/')
                 .Trim('/'));
 
         var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(sb.ToString()));

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -1031,21 +1031,25 @@ else
         // ハッシュファイルが存在しても変更あり → リセット必要
         // ハッシュファイルが存在しないが DB にデータあり（旧バージョンからのアップグレード／
         // ハッシュファイルだけ削除された等） → 整合性保護のためリセット必要
+        // opts と同一の DB を参照するため GetForOptionsAsync(opts) を使用
         var needsReset = hashChanged && hashFileExists;
         if (!needsReset && !hashFileExists)
         {
-            var stateDbForCheck = await StateDbAccessor.GetCurrentAsync(CancellationToken.None);
+            var stateDbForCheck = await StateDbAccessor.GetForOptionsAsync(opts, CancellationToken.None);
             var summary = await stateDbForCheck.GetSummaryAsync(CancellationToken.None);
             needsReset = summary.Total > 0;
         }
 
         if (needsReset)
         {
+            // ジョブ実行中は DB 操作不可（_isJobRunning はキャッシュ値のため実体を再確認）
+            if (JobService.IsRunning) return;
+
             var confirmed = await _configChangedDialogRef!.ShowAsync();
             if (confirmed is not true) return;
 
-            // DB 全データ削除
-            var stateDb = await StateDbAccessor.GetCurrentAsync(CancellationToken.None);
+            // DB 全データ削除（opts に対応する DB を使用）
+            var stateDb = await StateDbAccessor.GetForOptionsAsync(opts, CancellationToken.None);
             await stateDb.ResetAllAsync(CancellationToken.None);
 
             // キャッシュファイル削除（OneDrive/SharePoint/Dropbox キャッシュ・skip_list）

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -1048,6 +1048,9 @@ else
             var confirmed = await _configChangedDialogRef!.ShowAsync();
             if (confirmed is not true) return;
 
+            // ダイアログ表示中（ShowAsync await 中）に別経路でジョブが開始した可能性があるため再確認
+            if (JobService.IsRunning) return;
+
             // DB 全データ削除（opts に対応する DB を使用）
             var stateDb = await StateDbAccessor.GetForOptionsAsync(opts, CancellationToken.None);
             await stateDb.ResetAllAsync(CancellationToken.None);

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -6,6 +6,7 @@
 @inject ILogChannel LogChannel
 @inject ISnackbar Snackbar
 @using CloudMigrator.Core.Configuration
+@using System.IO
 @implements IDisposable
 
 @* ── ヘッダー行（常時表示） ─────────────────────────────────────────────── *@
@@ -501,6 +502,23 @@ else
     }
 }
 
+@* ── #198: ルート・転送パス変更検出確認ダイアログ ────────────────────────── *@
+<MudMessageBox @ref="_configChangedDialogRef"
+               Title="設定変更を検出しました"
+               CancelText="転送を中止"
+               YesText="DB を初期化して転送開始">
+    <MessageContent>
+        <MudText>
+            転送ルート・パスが前回から変更されています。<br />
+            このまま転送を続けると、旧データとの整合性が失われます。<br />
+            <b>転送状態データベースを初期化してから転送を開始しますか？</b>
+        </MudText>
+        <MudAlert Severity="Severity.Warning" Class="mt-2" Dense="true">
+            初期化すると転送進捗・メトリクス・チェックポイントがすべて削除されます。
+        </MudAlert>
+    </MessageContent>
+</MudMessageBox>
+
 @code {
     // ── タブ ────────────────────────────────────────────────────────────────
     private string _dashboardTab = "overview";
@@ -509,6 +527,9 @@ else
     private TransferDbSummary? _summary;
     private TransferJobInfo? _currentJob;
     private bool _isJobRunning;
+
+    // ── #198: 設定変更確認ダイアログ ─────────────────────────────────────────
+    private MudMessageBox? _configChangedDialogRef;
 
     // ── フェーズ: idle / crawling / folder_creation / transferring / completed / stopped ─
     private string _phase = "";
@@ -999,6 +1020,31 @@ else
                 Severity.Warning);
             return;
         }
+
+        // #198: 前回転送時からルート・転送パスが変更されていれば DB 初期化を促す
+        var opts = OptionsFactory();
+        var hash = ConfigHashChecker.ComputeHash(opts);
+        var hashFilePath = opts.Paths.ConfigHash;
+        var hashFileExists = File.Exists(hashFilePath);
+        var hashChanged = await ConfigHashChecker.HasChangedAsync(hashFilePath, hash);
+        // ハッシュファイルが存在しない（初回）は DB も空のため確認不要
+        if (hashChanged && hashFileExists)
+        {
+            var confirmed = await _configChangedDialogRef!.ShowAsync();
+            if (confirmed is not true) return;
+
+            // DB 全データ削除
+            var stateDb = await StateDbAccessor.GetCurrentAsync(CancellationToken.None);
+            await stateDb.ResetAllAsync(CancellationToken.None);
+
+            // キャッシュファイル（ハッシュ含む）削除
+            ConfigHashChecker.ClearAll(opts.Paths, Logger);
+
+            Snackbar.Add("データベースを初期化しました。転送を開始します。", Severity.Info);
+        }
+
+        // ハッシュを保存（初回または変更なしの場合も更新）
+        await ConfigHashChecker.SaveHashAsync(hashFilePath, hash);
 
         _currentJob = await JobService.TryStartAsync();
         _isJobRunning = _currentJob?.Status is JobStatus.Pending or JobStatus.Running;

--- a/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
+++ b/src/CloudMigrator.Dashboard/Components/DashboardPage.razor
@@ -1027,8 +1027,19 @@ else
         var hashFilePath = opts.Paths.ConfigHash;
         var hashFileExists = File.Exists(hashFilePath);
         var hashChanged = await ConfigHashChecker.HasChangedAsync(hashFilePath, hash);
-        // ハッシュファイルが存在しない（初回）は DB も空のため確認不要
-        if (hashChanged && hashFileExists)
+
+        // ハッシュファイルが存在しても変更あり → リセット必要
+        // ハッシュファイルが存在しないが DB にデータあり（旧バージョンからのアップグレード／
+        // ハッシュファイルだけ削除された等） → 整合性保護のためリセット必要
+        var needsReset = hashChanged && hashFileExists;
+        if (!needsReset && !hashFileExists)
+        {
+            var stateDbForCheck = await StateDbAccessor.GetCurrentAsync(CancellationToken.None);
+            var summary = await stateDbForCheck.GetSummaryAsync(CancellationToken.None);
+            needsReset = summary.Total > 0;
+        }
+
+        if (needsReset)
         {
             var confirmed = await _configChangedDialogRef!.ShowAsync();
             if (confirmed is not true) return;
@@ -1037,17 +1048,19 @@ else
             var stateDb = await StateDbAccessor.GetCurrentAsync(CancellationToken.None);
             await stateDb.ResetAllAsync(CancellationToken.None);
 
-            // キャッシュファイル（ハッシュ含む）削除
+            // キャッシュファイル削除（OneDrive/SharePoint/Dropbox キャッシュ・skip_list）
             ConfigHashChecker.ClearAll(opts.Paths, Logger);
 
             Snackbar.Add("データベースを初期化しました。転送を開始します。", Severity.Info);
         }
 
-        // ハッシュを保存（初回または変更なしの場合も更新）
-        await ConfigHashChecker.SaveHashAsync(hashFilePath, hash);
-
+        // 転送開始成功後のみハッシュを保存（失敗時はハッシュを更新しない）
         _currentJob = await JobService.TryStartAsync();
         _isJobRunning = _currentJob?.Status is JobStatus.Pending or JobStatus.Running;
+        if (_currentJob is not null)
+        {
+            await ConfigHashChecker.SaveHashAsync(hashFilePath, hash);
+        }
     }
 
     private void StopJob() => JobService.Cancel();

--- a/tests/unit/ConfigHashCheckerTests.cs
+++ b/tests/unit/ConfigHashCheckerTests.cs
@@ -229,4 +229,34 @@ public class ConfigHashCheckerTests : IDisposable
 
         act.Should().NotThrow();
     }
+
+    [Fact]
+    public void ComputeHash_DifferentDestinationProvider_ReturnsDifferentHash()
+    {
+        // 検証対象: ComputeHash（#198）  目的: DestinationProvider（sharepoint/dropbox）が異なるとハッシュが変わること
+        var opts1 = CreateOptions();
+        opts1.DestinationProvider = "sharepoint";
+        var opts2 = CreateOptions();
+        opts2.DestinationProvider = "dropbox";
+
+        var h1 = ConfigHashChecker.ComputeHash(opts1);
+        var h2 = ConfigHashChecker.ComputeHash(opts2);
+
+        h1.Should().NotBe(h2);
+    }
+
+    [Fact]
+    public void ComputeHash_DifferentOneDriveSourceFolder_ReturnsDifferentHash()
+    {
+        // 検証対象: ComputeHash（#198）  目的: OneDriveSourceFolder（転送元フォルダパス）が異なるとハッシュが変わること
+        var opts1 = CreateOptions();
+        opts1.Graph.OneDriveSourceFolder = "Documents/Work";
+        var opts2 = CreateOptions();
+        opts2.Graph.OneDriveSourceFolder = "Documents/Personal";
+
+        var h1 = ConfigHashChecker.ComputeHash(opts1);
+        var h2 = ConfigHashChecker.ComputeHash(opts2);
+
+        h1.Should().NotBe(h2);
+    }
 }

--- a/tests/unit/ConfigHashCheckerTests.cs
+++ b/tests/unit/ConfigHashCheckerTests.cs
@@ -246,6 +246,21 @@ public class ConfigHashCheckerTests : IDisposable
     }
 
     [Fact]
+    public void ComputeHash_GraphProviderEqualsSharePoint_ReturnsSameHash()
+    {
+        // 検証対象: ComputeHash（#198）  目的: "graph"（旧エイリアス）と "sharepoint" は同一ハッシュになること
+        var opts1 = CreateOptions();
+        opts1.DestinationProvider = "graph";
+        var opts2 = CreateOptions();
+        opts2.DestinationProvider = "sharepoint";
+
+        var h1 = ConfigHashChecker.ComputeHash(opts1);
+        var h2 = ConfigHashChecker.ComputeHash(opts2);
+
+        h1.Should().Be(h2);
+    }
+
+    [Fact]
     public void ComputeHash_DifferentOneDriveSourceFolder_ReturnsDifferentHash()
     {
         // 検証対象: ComputeHash（#198）  目的: OneDriveSourceFolder（転送元フォルダパス）が異なるとハッシュが変わること

--- a/tests/unit/ConfigHashCheckerTests.cs
+++ b/tests/unit/ConfigHashCheckerTests.cs
@@ -157,7 +157,7 @@ public class ConfigHashCheckerTests : IDisposable
     {
         // 検証対象: HasChangedAsync  目的: ファイル末尾の改行・空白を無視してハッシュ比較すること
         var hash = "abcdef1234";
-        await File.WriteAllTextAsync(_hashFile, hash + "\n");
+        await File.WriteAllTextAsync(_hashFile, "v2:" + hash + "\n");
 
         var result = await ConfigHashChecker.HasChangedAsync(_hashFile, hash);
         result.Should().BeFalse();
@@ -166,12 +166,12 @@ public class ConfigHashCheckerTests : IDisposable
     [Fact]
     public async Task SaveHashAsync_CreatesDirectoryAndFile()
     {
-        // 検証対象: SaveHashAsync  目的: 中間ディレクトリを作成してハッシュを保存すること
+        // 検証対象: SaveHashAsync  目的: 中間ディレクトリを作成してバージョンプレフィックス付きでハッシュを保存すること
         var deepPath = Path.Combine(_testDir, "sub", "dir", "config_hash.txt");
         await ConfigHashChecker.SaveHashAsync(deepPath, "testhash");
 
         File.Exists(deepPath).Should().BeTrue();
-        (await File.ReadAllTextAsync(deepPath)).Should().Be("testhash");
+        (await File.ReadAllTextAsync(deepPath)).Should().Be("v2:testhash");
     }
 
     [Fact]
@@ -273,5 +273,17 @@ public class ConfigHashCheckerTests : IDisposable
         var h2 = ConfigHashChecker.ComputeHash(opts2);
 
         h1.Should().NotBe(h2);
+    }
+
+    [Fact]
+    public async Task HasChangedAsync_LegacyFormatFile_ReturnsFalse()
+    {
+        // 検証対象: HasChangedAsync（#202）  目的: バージョンプレフィックスのない旧形式ファイルは
+        // アップグレード後の誤 DB 初期化を防ぐため変更なし（false）と判定すること
+        var oldHash = "abcdefabcdef1234567890";
+        await File.WriteAllTextAsync(_hashFile, oldHash); // v2: プレフィックスなし（旧形式）
+
+        var result = await ConfigHashChecker.HasChangedAsync(_hashFile, "completelydifferenthash");
+        result.Should().BeFalse();
     }
 }


### PR DESCRIPTION
## 概要

ルートや転送パスを変更した際に古い state DB をそのまま使うと整合性が壊れる問題（#198）を修正します。

## 変更内容

### ConfigHashChecker.ComputeHash の拡張
- `DestinationProvider`（"sharepoint" / "dropbox"）をハッシュ対象に追加
- `Graph.OneDriveSourceFolder`（転送元フォルダパス）をハッシュ対象に追加

### DashboardPage.razor — 転送開始前のハッシュチェック
- 転送開始（`StartJobAsync`）前に `ComputeHash` → `HasChangedAsync` で設定変更を検出
- ハッシュファイルが存在（初回でない）かつ変更あり → `MudMessageBox` で DB 初期化の確認を求める
- 承認時: `ResetAllAsync` + `ClearAll` → 転送開始
- 初回（ハッシュファイルなし）/ 変更なし: そのまま転送開始
- 転送開始後に `SaveHashAsync` でハッシュを記録

### テスト追加（ConfigHashCheckerTests.cs）
- `ComputeHash_DifferentDestinationProvider_ReturnsDifferentHash`
- `ComputeHash_DifferentOneDriveSourceFolder_ReturnsDifferentHash`

## 受け入れ条件
- [x] `DestinationProvider` を変更するとハッシュが変わる
- [x] `OneDriveSourceFolder` を変更するとハッシュが変わる
- [x] 初回起動（ハッシュファイル未作成）は確認ダイアログが出ない
- [x] 設定変更を検出した場合、確認後に DB 初期化 + 転送開始
- [x] キャンセルした場合は転送中止

Closes #198
