### PR TITLE
fix: release.yml の .NET SDK バージョン指定を global.json に統一

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: .NET セットアップ
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.201'
+          global-json-file: global.json
 
       - name: バージョン文字列を抽出（v プレフィックス除去）
         id: version
@@ -149,7 +149,7 @@ jobs:
       - name: .NET セットアップ
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.201'
+          global-json-file: global.json
 
       - name: WiX Toolset v5 インストール
         run: dotnet tool install wix --version 5.0.2 --global


### PR DESCRIPTION
## 概要
\elease.yml\ で \dotnet-version: '10.0.201'\ を固定指定していたため、\global.json\ の SDK バージョンと乖離が生じ、v0.6.0 の CI（win-x64 / linux-x64）が失敗した。

## 変更内容
| 変更前 | 変更後 |
|--------|--------|
| \dotnet-version: '10.0.201'\ | \global-json-file: global.json\ |

\ctions/setup-dotnet@v5\ がネイティブで \global.json\ を参照する機能を利用。

## 効果
- \global.json\ が唯一の SDK バージョン管理源となり、Renovate によるバージョンアップが \elease.yml\ に自動反映される
- 手動同期ミスによる CI 失敗を防止

## 関連
- v0.6.0 CI 失敗: win-x64 / linux-x64 ジョブが SDK ミスマッチで失敗した件の根本対処