### PR TITLE
ci: リリース作成後に draft=false --latest を自動適用

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,23 +101,26 @@ jobs:
         run: |
           set -euo pipefail
 
+          RELEASE_EXISTS=false
           if gh release view "${{ github.ref_name }}" > /dev/null 2>&1; then
             echo "Release '${{ github.ref_name }}' は既に存在します。"
-            exit 0
+            RELEASE_EXISTS=true
           fi
 
-          if gh release create "${{ github.ref_name }}" \
-            --title "${{ github.ref_name }}" \
-            --generate-notes; then
-            echo "Release '${{ github.ref_name }}' を作成しました。"
-          elif gh release view "${{ github.ref_name }}" > /dev/null 2>&1; then
-            echo "別の並列ジョブが Release '${{ github.ref_name }}' を作成済みのため成功扱いにします。"
-          else
-            echo "Release '${{ github.ref_name }}' の作成に失敗しました。"
-            exit 1
+          if [ "$RELEASE_EXISTS" = "false" ]; then
+            if gh release create "${{ github.ref_name }}" \
+              --title "${{ github.ref_name }}" \
+              --generate-notes; then
+              echo "Release '${{ github.ref_name }}' を作成しました。"
+            elif gh release view "${{ github.ref_name }}" > /dev/null 2>&1; then
+              echo "別の並列ジョブが Release '${{ github.ref_name }}' を作成済みのため成功扱いにします。"
+            else
+              echo "Release '${{ github.ref_name }}' の作成に失敗しました。"
+              exit 1
+            fi
           fi
 
-          # Draft 状態のまま残らないよう、常に公開・Latest に設定する
+          # Draft 状態のまま残らないよう、常に公開・Latest に設定する（既存リリースも対象）
           gh release edit "${{ github.ref_name }}" --draft=false --latest
           echo "Release '${{ github.ref_name }}' を公開済み・Latest に設定しました。"
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,16 +110,16 @@ jobs:
             --title "${{ github.ref_name }}" \
             --generate-notes; then
             echo "Release '${{ github.ref_name }}' を作成しました。"
-            exit 0
-          fi
-
-          if gh release view "${{ github.ref_name }}" > /dev/null 2>&1; then
+          elif gh release view "${{ github.ref_name }}" > /dev/null 2>&1; then
             echo "別の並列ジョブが Release '${{ github.ref_name }}' を作成済みのため成功扱いにします。"
-            exit 0
+          else
+            echo "Release '${{ github.ref_name }}' の作成に失敗しました。"
+            exit 1
           fi
 
-          echo "Release '${{ github.ref_name }}' の作成に失敗しました。"
-          exit 1
+          # Draft 状態のまま残らないよう、常に公開・Latest に設定する
+          gh release edit "${{ github.ref_name }}" --draft=false --latest
+          echo "Release '${{ github.ref_name }}' を公開済み・Latest に設定しました。"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## 問題
タグ再発行など、リリースが既存の Draft 状態で存在する場合、gh release create が「既存」と判断してスキップし、Draft のまま公開されない。

## 修正
リリース作成ステップ末尾に以下を追加し、常に公開・Latest 状態に強制する。

## 効果
- タグ再発行・並列実行・手動 Draft 作成のいずれのケースでも、ワークフロー完了後に必ず公開済み Latest になる
- 今回の v0.6.0 で発生したトップページ版数ズレ（v0.4.0 表示）の再発防止