### PR TITLE
ci: upload/download-artifact を v7 に統一（upload@v8 は未リリース）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           verbose: true
 
       - name: テスト結果のアップロード
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results-${{ matrix.os }}-dotnet${{ matrix.dotnet }}
@@ -143,7 +143,7 @@ jobs:
             -p:Version=0.0.0-ci --output "publish/win-x64"
 
       - name: バイナリをアーティファクトに保存（MSI ビルド検証用）
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: ci-publish-win-x64
           path: publish/win-x64/
@@ -175,7 +175,7 @@ jobs:
           wix extension add -g WixToolset.Util.wixext/5.0.2
 
       - name: バイナリをダウンロード
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: ci-publish-win-x64
           path: published/win-x64
@@ -200,7 +200,7 @@ jobs:
             -o cloud-migrator-ci.msi
 
       - name: MSI をアーティファクトに保存
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: msi-ci
           path: cloud-migrator-ci.msi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           verbose: true
 
       - name: テスト結果のアップロード
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v8
         if: always()
         with:
           name: test-results-${{ matrix.os }}-dotnet${{ matrix.dotnet }}
@@ -143,7 +143,7 @@ jobs:
             -p:Version=0.0.0-ci --output "publish/win-x64"
 
       - name: バイナリをアーティファクトに保存（MSI ビルド検証用）
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v8
         with:
           name: ci-publish-win-x64
           path: publish/win-x64/
@@ -200,7 +200,7 @@ jobs:
             -o cloud-migrator-ci.msi
 
       - name: MSI をアーティファクトに保存
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v8
         with:
           name: msi-ci
           path: cloud-migrator-ci.msi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Published バイナリをアーティファクトに保存（MSI ビルド用 / win-x64 のみ）
         if: matrix.rid == 'win-x64'
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: publish-win-x64
           path: publish/win-x64/
@@ -168,7 +168,7 @@ jobs:
           wix extension add -g WixToolset.Util.wixext/5.0.2
 
       - name: win-x64 バイナリをダウンロード
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: publish-win-x64
           path: published/win-x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Published バイナリをアーティファクトに保存（MSI ビルド用 / win-x64 のみ）
         if: matrix.rid == 'win-x64'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v8
         with:
           name: publish-win-x64
           path: publish/win-x64/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@
 
 ### Fixed
 
-- **CI: `upload-artifact@v7` / `download-artifact@v8` のバージョン不整合を修正**
-  - ci.yml (3箇所) および release.yml (1箇所) の `upload-artifact` を `v8` に統一
-  - 外部 Renovate プリセット (`renovate-config`) には GitHub Actions を一括グループ管理するルールが既に存在するため、次回以降は同一 PR で揃って更新される
+- **CI: `upload-artifact` / `download-artifact` のバージョン不整合を修正**
+  - `download-artifact@v8` に対して `upload-artifact@v8` は未リリースのため、両方を `v7` に統一
+  - 対象: ci.yml (upload×3, download×1)、release.yml (upload×1, download×1)
+  - 外部 Renovate プリセット (`renovate-config`) の GitHub Actions 一括グループルールにより、将来 `upload-artifact@v8` がリリースされた際は同一 PR でペア更新される
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **CI: `upload-artifact@v7` / `download-artifact@v8` のバージョン不整合を修正**
+  - ci.yml (3箇所) および release.yml (1箇所) の `upload-artifact` を `v8` に統一
+  - 外部 Renovate プリセット (`renovate-config`) には GitHub Actions を一括グループ管理するルールが既に存在するため、次回以降は同一 PR で揃って更新される
+
 ---
 
 ## [0.7.1] - 2026-05-04


### PR DESCRIPTION
## 原因

`upload-artifact@v7` と `download-artifact@v8` のバージョン不整合により、MSI ビルド検証ジョブがアーティファクトダウンロード直後に失敗していた。

調査の結果、`actions/upload-artifact` の最新リリースは **v7.0.1** であり、**v8 は未リリース**。`download-artifact` のみ v8 が先行リリースされていたことが根本原因。

## 変更内容

`download-artifact@v8` → `download-artifact@v7` に戻し、全6箇所を v7 に統一。

| ファイル | 行 | 変更 |
|---|---|---|
| `.github/workflows/ci.yml` | 68, 146, 203 | `upload-artifact@v7`（変更なし・既に正しい） |
| `.github/workflows/ci.yml` | 178 | `download-artifact@v8` → `@v7` |
| `.github/workflows/release.yml` | 136 | `upload-artifact@v7`（変更なし・既に正しい） |
| `.github/workflows/release.yml` | 171 | `download-artifact@v8` → `@v7` |

## Renovate 一元管理について

外部プリセット `scottlz0310/renovate-config` の `presets/default.json` に `matchManagers: ["github-actions"]` + `groupName: "GitHub Actions"` が既に定義されており、将来 `upload-artifact@v8` がリリースされた際は upload/download-artifact が同一 PR でペア更新される。`renovate-config` 側の修正は不要。

## 関連

Renovate PR #219 (Kiota 更新) の CI 失敗を調査して発見。本 PR マージ後に #219 をリベース・再実行することで通過するはず。

🤖 Generated with [Claude Code](https://claude.com/claude-code)