### PR TITLE
fix(ci): codecov-action を v6.0.2(SHA固定)に更新し fail_ci_if_error を true に復元

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,12 @@ jobs:
           "path=$coverage" >> $env:GITHUB_OUTPUT
 
       - name: Codecov へカバレッジ送信
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ steps.coverage.outputs.path }}
           flags: unit
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           verbose: true
 
       - name: テスト結果のアップロード


### PR DESCRIPTION
## 概要

codecov の GPG 鍵不具合は **v6.0.2（2026-06-07 リリース）で修正済み**。
暫定回避として設定していた `fail_ci_if_error: false` を解除し、修正版を SHA 固定で参照する恒久対応に切り替える。

## 変更内容

| 項目 | 変更前 | 変更後 |
|---|---|---|
| action 参照 | `codecov/codecov-action@v6` | `codecov/codecov-action@fb8b3582...` (`# v6.0.2`) |
| fail_ci_if_error | `false`（暫定回避） | `true`（本来の設定に復元） |

## SHA 固定の理由

浮動タグ（`@v6`）は再び書き換えられるリスクがある。commit SHA 固定により、検証済みのバイナリのみを実行することを保証する。

## 参考

- [codecov/codecov-action v6.0.2 リリースノート](https://github.com/codecov/codecov-action/releases/tag/v6.0.2)
- 暫定回避 PR: #236

Generated with [Claude Code](https://claude.com/claude-code)