### PR TITLE
fix(deps): SQLitePCLRaw 脆弱性 (CVE-2025-6965) 修正と CPM 導入

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 
 ### Fixed
 
+- **CI: SQLitePCLRaw の脆弱性 (CVE-2025-6965) を修正しビルド失敗を解消**
+  - `Microsoft.Data.Sqlite` 10.0.9 がトランジティブに引く `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 に高深刻度の脆弱性 (GHSA-2m69-gcr7-jv3q) があり、NuGet audit (NU1903) が `TreatWarningsAsErrors` によりビルドを失敗させていた
+  - `CloudMigrator.Core` に `SQLitePCLRaw.bundle_e_sqlite3` 3.0.3 を直接参照追加し、ネイティブ SQLite を修正済みの 3.50.x 系へ引き上げて脆弱な `lib.e_sqlite3` 2.1.11 を依存ツリーから排除
+  - `Microsoft.Data.Sqlite` 自体は 10.0.9 が最新のため据え置き（修正版バンドルを引く新リリースが出れば直接参照は撤去可能）
+
 - **CI: `upload-artifact` / `download-artifact` のバージョン不整合を修正**
   - `download-artifact@v8` に対して `upload-artifact@v8` は未リリースのため、両方を `v7` に統一
   - 対象: ci.yml (upload×3, download×1)、release.yml (upload×1, download×1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **NuGet 中央パッケージ管理 (CPM) を導入し依存バージョンを一元化**
+  - `Directory.Packages.props` を新設し、各 csproj に分散していた `PackageReference` の `Version` を `PackageVersion` として集約
+  - 各 csproj は `Version` 属性を持たず、バージョン定義は単一ファイルに集約。Renovate の更新対象が一元化され、同一パッケージのバージョン不整合リスクを解消
+
 ### Fixed
 
 - **CI: SQLitePCLRaw の脆弱性 (CVE-2025-6965) を修正しビルド失敗を解消**

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,40 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="FluentAssertions" Version="8.10.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Wpf" Version="10.0.71" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Graph" Version="6.2.0" />
+    <PackageVersion Include="Microsoft.Graph.Core" Version="4.0.1" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.84.2" />
+    <PackageVersion Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="MudBlazor" Version="9.5.0" />
+    <PackageVersion Include="Serilog" Version="4.3.1" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Formatting.Compact" Version="3.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
+    <!-- CVE-2025-6965 対策。ネイティブ SQLite を修正済み 3.50.x へ固定する。CloudMigrator.Core が直接参照（詳細は同 csproj のコメント参照） -->
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageVersion Include="System.CommandLine" Version="3.0.0-preview.5.26302.115" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
+</Project>

--- a/src/CloudMigrator.Cli/CloudMigrator.Cli.csproj
+++ b/src/CloudMigrator.Cli/CloudMigrator.Cli.csproj
@@ -9,8 +9,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
-    <PackageReference Include="System.CommandLine" Version="3.0.0-preview.5.26302.115" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/CloudMigrator.Core/CloudMigrator.Core.csproj
+++ b/src/CloudMigrator.Core/CloudMigrator.Core.csproj
@@ -13,6 +13,12 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <!--
+      Microsoft.Data.Sqlite 10.0.9 がトランジティブに引く SQLitePCLRaw.lib.e_sqlite3 2.1.11 には
+      CVE-2025-6965 (GHSA-2m69-gcr7-jv3q) があり、NuGet audit (NU1903) でビルドが失敗する。
+      bundle_e_sqlite3 3.0.3 を直接参照し、ネイティブ SQLite を修正済みの 3.50.x へ引き上げる。
+    -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/CloudMigrator.Core/CloudMigrator.Core.csproj
+++ b/src/CloudMigrator.Core/CloudMigrator.Core.csproj
@@ -5,20 +5,20 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Data.Sqlite" />
     <!--
-      Microsoft.Data.Sqlite 10.0.9 がトランジティブに引く SQLitePCLRaw.lib.e_sqlite3 2.1.11 には
+      Microsoft.Data.Sqlite がトランジティブに引く SQLitePCLRaw.lib.e_sqlite3 2.1.11 には
       CVE-2025-6965 (GHSA-2m69-gcr7-jv3q) があり、NuGet audit (NU1903) でビルドが失敗する。
-      bundle_e_sqlite3 3.0.3 を直接参照し、ネイティブ SQLite を修正済みの 3.50.x へ引き上げる。
+      bundle_e_sqlite3 を直接参照し、ネイティブ SQLite を修正済みの 3.50.x へ引き上げる。
     -->
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/CloudMigrator.Dashboard/CloudMigrator.Dashboard.csproj
+++ b/src/CloudMigrator.Dashboard/CloudMigrator.Dashboard.csproj
@@ -18,9 +18,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Wpf" Version="10.0.71" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
-    <PackageReference Include="MudBlazor" Version="9.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Wpf" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="MudBlazor" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CloudMigrator.Observability/CloudMigrator.Observability.csproj
+++ b/src/CloudMigrator.Observability/CloudMigrator.Observability.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="4.3.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="Serilog.Formatting.Compact" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Sinks.File" />
   </ItemGroup>
 
 </Project>

--- a/src/CloudMigrator.Providers.Dropbox/CloudMigrator.Providers.Dropbox.csproj
+++ b/src/CloudMigrator.Providers.Dropbox/CloudMigrator.Providers.Dropbox.csproj
@@ -6,7 +6,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/CloudMigrator.Providers.Graph/CloudMigrator.Providers.Graph.csproj
+++ b/src/CloudMigrator.Providers.Graph/CloudMigrator.Providers.Graph.csproj
@@ -7,11 +7,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Graph" Version="6.2.0" />
-    <PackageReference Include="Microsoft.Graph.Core" Version="4.0.1" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.84.2" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Graph" />
+    <PackageReference Include="Microsoft.Graph.Core" />
+    <PackageReference Include="Microsoft.Identity.Client" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/CloudMigrator.Setup.Cli/CloudMigrator.Setup.Cli.csproj
+++ b/src/CloudMigrator.Setup.Cli/CloudMigrator.Setup.Cli.csproj
@@ -6,8 +6,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
-    <PackageReference Include="System.CommandLine" Version="3.0.0-preview.5.26302.115" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/CloudMigrator.Testing/CloudMigrator.Testing.csproj
+++ b/src/CloudMigrator.Testing/CloudMigrator.Testing.csproj
@@ -6,8 +6,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.10.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Moq" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/tests/e2e/CloudMigrator.Tests.E2E.csproj
+++ b/tests/e2e/CloudMigrator.Tests.E2E.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.1" />
-    <PackageReference Include="FluentAssertions" Version="8.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/integration/CloudMigrator.Tests.Integration.csproj
+++ b/tests/integration/CloudMigrator.Tests.Integration.csproj
@@ -8,15 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/unit/CloudMigrator.Tests.Unit.csproj
+++ b/tests/unit/CloudMigrator.Tests.Unit.csproj
@@ -11,16 +11,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## 背景

Renovate PR #243 (`actions/checkout@v6 → v7`) の CI が `Build & Test (windows-latest / .NET 10.0)` で失敗していたため調査した。

## 原因

CI 失敗は **checkout@v7 とは無関係**。真因は NuGet audit (NU1903) による以下のビルドエラー:

> error NU1903: Package `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 has a known high severity vulnerability

- `Microsoft.Data.Sqlite` 10.0.9 がトランジティブに `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 を引く
- 同パッケージに **CVE-2025-6965 (GHSA-2m69-gcr7-jv3q, High / SQLite < 3.50.2 のメモリ破損)** があり、`TreatWarningsAsErrors=true` によりビルドが失敗
- アドバイザリ公開のタイミング起因で、main ブランチでも同様に失敗する状態だった

## 修正

### 1. 脆弱性の解消 (`fix`)

`CloudMigrator.Core` に `SQLitePCLRaw.bundle_e_sqlite3` 3.0.3 を直接参照追加。ネイティブ SQLite が修正済みの 3.50.x 系 (`SourceGear.sqlite3` 3.50.4) へ引き上げられ、脆弱な `lib.e_sqlite3` 2.1.11 が依存ツリーから排除される。

> `Microsoft.Data.Sqlite` 自体は 10.0.9 が最新のため据え置き。修正版バンドルを引く新リリースが出れば直接参照は撤去可能。

### 2. 依存バージョンの一元管理 (`refactor`)

NuGet 中央パッケージ管理 (CPM) を導入。`Directory.Packages.props` を新設し、各 csproj に分散・重複していた `PackageReference` の `Version` を `PackageVersion` として集約。Renovate の更新対象が単一ファイルに集約され、バージョン不整合リスクを解消する。

## 検証

- `dotnet build -c Release`: 0 警告 / 0 エラー
- `dotnet list package --vulnerable --include-transitive`: 全 13 プロジェクトで脆弱パッケージなし
- pre-commit (lefthook): build / format / unit テスト **1034 件** すべて成功

## PR #243 への影響

本 PR が main にマージされれば、PR #243 (checkout@v7) も rebase / 再実行で CI が通る見込み。checkout@v7 への更新自体は正当な変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)