### PR TITLE
ci: automate MSIX validation and WACK workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,3 +205,55 @@ jobs:
           name: msi-ci
           path: cloud-migrator-ci.msi
           retention-days: 7
+
+  msix-check:
+    name: MSIX パッケージ検証
+    runs-on: windows-latest
+    needs: build-test
+    if: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/main' }}
+    env:
+      LEFTHOOK: 0
+
+    steps:
+      - name: リポジトリを checkout
+        uses: actions/checkout@v7
+
+      - name: .NET SDK セットアップ
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: "10.0"
+
+      - name: manifest Version を取得
+        id: manifest
+        shell: pwsh
+        run: |
+          [xml]$manifest = Get-Content -LiteralPath "installer/msix/Package.appxmanifest" -Raw
+          $version = $manifest.Package.Identity.Version
+          if ([string]::IsNullOrWhiteSpace($version)) {
+            throw "Package.appxmanifest の Identity Version が空です。"
+          }
+          "version=$version" >> $env:GITHUB_OUTPUT
+
+      - name: MSIX を生成
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -File .\installer\msix\Build-MsixPackage.ps1 `
+            -Configuration Release `
+            -Version "${{ steps.manifest.outputs.version }}"
+
+      - name: MSIX manifest・アセットを静的検査
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -File .\scripts\ValidateMsixPackage.ps1 `
+            -PackagePath ".\installer\msix\AppPackages\CloudMigrator_${{ steps.manifest.outputs.version }}_x64.msix"
+
+      - name: MSIX 生成物をアーティファクトに保存
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: msix-ci-${{ github.run_id }}
+          path: |
+            installer/msix/AppPackages/CloudMigrator_*_x64.msix
+            installer/msix/AppPackages/CloudMigrator_*_x64_bundle.msixupload
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,75 @@ jobs:
           path: publish/win-x64/
           retention-days: 1
 
+  msix:
+    name: MSIX パッケージビルド
+    runs-on: windows-latest
+    needs: publish
+    env:
+      LEFTHOOK: 0
+
+    steps:
+      - name: リポジトリを checkout
+        uses: actions/checkout@v7
+
+      - name: .NET SDK セットアップ
+        uses: actions/setup-dotnet@v6
+        with:
+          global-json-file: global.json
+
+      - name: tag と manifest Version を照合
+        id: version
+        shell: pwsh
+        run: |
+          $tag = "${{ github.ref_name }}"
+          if ($tag -notmatch '^v(?<version>\d+\.\d+\.\d+(?:\.\d+)?)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$') {
+            throw "無効なリリースタグ形式です。SemVer 形式のタグを使用してください: $tag"
+          }
+
+          $tagVersion = $Matches['version']
+          if ($tagVersion -match '^\d+\.\d+\.\d+$') {
+            $tagVersion = "$tagVersion.0"
+          }
+          [xml]$manifest = Get-Content -LiteralPath "installer/msix/Package.appxmanifest" -Raw
+          $manifestVersion = $manifest.Package.Identity.Version
+          if ($tagVersion -ne $manifestVersion) {
+            throw "tag Version ($tagVersion) と manifest Version ($manifestVersion) が一致しません。"
+          }
+          "version=$manifestVersion" >> $env:GITHUB_OUTPUT
+
+      - name: MSIX を生成
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -File .\installer\msix\Build-MsixPackage.ps1 `
+            -Configuration Release `
+            -Version "${{ steps.version.outputs.version }}"
+
+      - name: MSIX manifest・アセットを静的検査
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -File .\scripts\ValidateMsixPackage.ps1 `
+            -PackagePath ".\installer\msix\AppPackages\CloudMigrator_${{ steps.version.outputs.version }}_x64.msix"
+
+      - name: MSIX をリリースにアップロード
+        shell: pwsh
+        run: |
+          gh release upload "${{ github.ref_name }}" `
+            ".\installer\msix\AppPackages\CloudMigrator_${{ steps.version.outputs.version }}_x64.msix" `
+            ".\installer\msix\AppPackages\CloudMigrator_${{ steps.version.outputs.version }}_x64_bundle.msixupload" `
+            --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: MSIX をアーティファクトに保存
+        uses: actions/upload-artifact@v7
+        with:
+          name: msix-release-${{ github.run_id }}
+          path: |
+            installer/msix/AppPackages/CloudMigrator_*_x64.msix
+            installer/msix/AppPackages/CloudMigrator_*_x64_bundle.msixupload
+          if-no-files-found: error
+          retention-days: 30
+
   msi:
     name: MSI インストーラービルド
     runs-on: windows-latest

--- a/.github/workflows/wack.yml
+++ b/.github/workflows/wack.yml
@@ -1,0 +1,155 @@
+name: WACK
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "検証する manifest Version（省略時は対象 commit の manifest から取得）"
+        required: false
+        type: string
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build-msix:
+    name: MSIX build for WACK
+    runs-on: windows-latest
+    env:
+      LEFTHOOK: 0
+    outputs:
+      version: ${{ steps.manifest.outputs.version }}
+
+    steps:
+      - name: リポジトリを checkout
+        uses: actions/checkout@v7
+
+      - name: .NET SDK セットアップ
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: "10.0"
+
+      - name: manifest Version と tag/input の整合性を確認
+        id: manifest
+        shell: pwsh
+        env:
+          REQUESTED_VERSION: ${{ github.event.inputs.version || '' }}
+        run: |
+          [xml]$manifest = Get-Content -LiteralPath "installer/msix/Package.appxmanifest" -Raw
+          $manifestVersion = $manifest.Package.Identity.Version
+          if ([string]::IsNullOrWhiteSpace($manifestVersion)) {
+            throw "Package.appxmanifest の Identity Version が空です。"
+          }
+
+          $tagVersion = ""
+          if ($env:GITHUB_REF_TYPE -eq "tag") {
+            $tag = $env:GITHUB_REF_NAME
+            if ($tag -notmatch '^v(?<version>\d+\.\d+\.\d+(?:\.\d+)?)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$') {
+              throw "無効な WACK 用 tag 形式です。SemVer 形式の tag を使用してください: $tag"
+            }
+            $tagVersion = $Matches['version']
+            if ($tagVersion -match "^\d+\.\d+\.\d+$") {
+              $tagVersion = "$tagVersion.0"
+            }
+            if ($tagVersion -ne $manifestVersion) {
+              throw "tag Version ($tagVersion) と manifest Version ($manifestVersion) が一致しません。"
+            }
+          }
+
+          if (-not [string]::IsNullOrWhiteSpace($env:REQUESTED_VERSION)) {
+            $requestedVersion = $env:REQUESTED_VERSION
+            if ($requestedVersion -match "^\d+\.\d+\.\d+$") {
+              $requestedVersion = "$requestedVersion.0"
+            }
+            if ($requestedVersion -ne $manifestVersion) {
+              throw "workflow_dispatch の version ($requestedVersion) と manifest Version ($manifestVersion) が一致しません。"
+            }
+          }
+
+          "version=$manifestVersion" >> $env:GITHUB_OUTPUT
+          "対象 Version: $manifestVersion"
+
+      - name: MSIX を生成
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -File .\installer\msix\Build-MsixPackage.ps1 `
+            -Configuration Release `
+            -Version "${{ steps.manifest.outputs.version }}"
+
+      - name: MSIX 静的検査
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -File .\scripts\ValidateMsixPackage.ps1 `
+            -PackagePath ".\installer\msix\AppPackages\CloudMigrator_${{ steps.manifest.outputs.version }}_x64.msix"
+
+      - name: WACK 入力 package を保存
+        uses: actions/upload-artifact@v7
+        with:
+          name: msix-wack-input-${{ github.run_id }}
+          path: installer/msix/AppPackages/CloudMigrator_*_x64.msix
+          if-no-files-found: error
+          retention-days: 7
+
+  wack:
+    name: WACK（self-hosted / Windows / wack）
+    needs: build-msix
+    runs-on: [self-hosted, windows, wack]
+    env:
+      LEFTHOOK: 0
+
+    steps:
+      - name: リポジトリを checkout
+        uses: actions/checkout@v7
+
+      - name: WACK 入力 package を取得
+        uses: actions/download-artifact@v8
+        with:
+          name: msix-wack-input-${{ github.run_id }}
+          path: wack-input
+
+      - name: runner の管理者権限・対話セッションを確認
+        shell: pwsh
+        run: |
+          if ($env:OS -ne "Windows_NT") {
+            throw "WACK runner は Windows である必要があります。"
+          }
+          if (-not [Environment]::UserInteractive) {
+            throw "WACK runner はアクティブなユーザーセッションで実行してください。サービス Session 0 は使用できません。"
+          }
+          $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+          $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+          if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+            throw "WACK runner は管理者権限で実行してください。GitHub-hosted runner の UAC 昇格には依存しません。"
+          }
+          $appCertPath = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\App Certification Kit\appcert.exe"
+          if (-not (Test-Path -LiteralPath $appCertPath -PathType Leaf)) {
+            throw "Windows App Certification Kit の appcert.exe が見つかりません: $appCertPath"
+          }
+
+      - name: WACK を実行
+        shell: pwsh
+        run: |
+          $packages = @(Get-ChildItem -LiteralPath "wack-input" -File -Filter "*.msix")
+          if ($packages.Count -ne 1) {
+            throw "WACK 入力 package は 1 個である必要があります。検出数: $($packages.Count)"
+          }
+          & pwsh -NoProfile -File .\scripts\run-wack-test.ps1 `
+            -PackagePath $packages[0].FullName `
+            -ReportDirectory "scripts/wack_reports"
+          if ($LASTEXITCODE -ne 0) {
+            throw "WACK または Required failure の検査に失敗しました（exit=$LASTEXITCODE）。"
+          }
+
+      - name: WACK レポートを保存
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: wack-reports-${{ github.run_id }}
+          path: |
+            scripts/wack_reports/
+            scripts/wack_work/logs/
+          if-no-files-found: warn
+          retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
   - `docs/msix-packaging-and-store-guide.md` に、生成物・manifest・SHA-256 の確認、UAC を含む WACK 実行と Required/Optional 判定、`runFullTrust` の審査ノートを集約
   - Partner Center の package/listing/submission options、公開保留、更新・差戻し時の再 WACK、提出証跡の記録方法を明記
   - MSIX の per-user / per-machine 相当の差異と、#268 で扱う self-hosted WACK CI との責務境界を記載
+- **MSIX 静的検査と self-hosted WACK workflow を追加（#268 / #101-E）**
+  - `ci.yml` の PR／main 向け MSIX 生成・manifest／Identity／Version／x64／アセット検査と artifact 保存を追加
+  - `wack.yml` の手動／`v*` tag 実行、管理者・対話 self-hosted runner 前提、Required failure の CI failure、Optional failure の XML/HTML artifact 保存を追加
+  - `scripts/ValidateMsixPackage.ps1` で `makeappx.exe` 展開後の package 内容を source manifest と比較
+  - `release.yml` の `v*` tag 実行で `.msix` / `.msixupload` を GitHub Release へ添付
 - **MSIX パッケージ化構成および `Package.appxmanifest` を追加（#264 / #101-A）**
   - `src/CloudMigrator.Dashboard/Package.appxmanifest` および `installer/msix/` を新設し、Identity (`scottlz0310.CloudMigrator`)、Capabilities (`internetClient`, `runFullTrust`)、およびビジュアルアセット参照を定義
   - `CloudMigrator.Dashboard.csproj` に MSIX パッケージングプロパティ (`EnableMsixTooling`, `WindowsPackageType`, `AppxBundle` 等) を追加

--- a/docs/msix-packaging-and-store-guide.md
+++ b/docs/msix-packaging-and-store-guide.md
@@ -375,7 +375,7 @@ Submission options で、次を確認します。
 
 ### 6.3 GitHub Release との境界
 
-現在の `.github/workflows/release.yml` は `v*` タグで GitHub Release と MSI 等のアセットを公開しますが、MSIX Store package や Partner Center の認定状態を確認するゲートではありません。したがって、Store の公開保留を GitHub Release の Draft と同一視しません。GitHub Release を Store 認定後に公開する運用へ変更する場合は、ワークフローとリリース方針を別途変更・検証します。
+現在の `.github/workflows/release.yml` は `v*` タグで GitHub Release と CLI/Dashboard、MSI、MSIX (`.msix` / `.msixupload`) のアセットを公開しますが、MSIX の WACK 完了や Partner Center の認定状態を確認するゲートではありません。したがって、Store の公開保留を GitHub Release の Draft と同一視しません。
 
 ---
 
@@ -404,16 +404,56 @@ Add-AppxPackage -Path .\installer\msix\AppPackages\CloudMigrator_0.7.1.0_x64.msi
 
 ## 8. CI/CD との責務分離（#268）
 
-現在の `.github/workflows/ci.yml` は .NET の format/build/test、品質チェック、Windows publish、MSI 検証を行います。現在の `.github/workflows/release.yml` も CLI/Dashboard のアーカイブと MSI を扱うだけで、MSIX の生成や WACK のフル実行を保証しません。
+[#268](https://github.com/scottlz0310/cloud-migrator/issues/268) では、GitHub-hosted runner での静的検査と、WACK 導入済み self-hosted runner でのフル WACK を分離しています。GitHub-hosted runner の UAC ダイアログには依存しません。
 
-[#268](https://github.com/scottlz0310/cloud-migrator/issues/268) では次を別途設計・実装します。
+### 8.1 PR／main の MSIX 静的検査
 
-- PR ごとの MSIX 生成、manifest・Identity・Version・x64・アセットの静的検査。
-- WACK 導入済みの self-hosted Windows runner で、管理者権限とアクティブセッションを前提にしたフル WACK。
-- Full WACK は明示された package を検査する。Required failure は CI failure、Optional failure はレポートと記録にする。
-- GitHub-hosted runner の UAC ダイアログに依存しない。
+`.github/workflows/ci.yml` の `MSIX パッケージ検証` job は、PR と `main` への push で `windows-latest` 上に MSIX を生成し、[scripts/ValidateMsixPackage.ps1](../scripts/ValidateMsixPackage.ps1) で次を検査します。
 
-#267 の手順書へ、未実装の GitHub Actions YAML を「現在の自動化」として追加しません。CI 組み込み後は、実際の workflow と本書のコマンドを再確認して更新します。
+- package 内 manifest の Identity Name、Publisher、Version、ProcessorArchitecture (`x64`)
+- DisplayName、PublisherDisplayName、Resources の言語、Capabilities、Executable
+- manifest が参照する 4 画像と `resources.pri`
+- package の SHA-256
+
+生成した `.msix` と `.msixupload` は `msix-ci-<run_id>` artifact に保存されます。MSIX は Windows SDK の `makeappx.exe` で展開して検査します。WACK はこの job では実行しません。
+
+### 8.2 self-hosted runner の準備
+
+WACK 用 runner は、リポジトリの **Settings > Actions > Runners** から追加し、次の条件を満たすラベルを付けます。
+
+| 条件 | 要件 |
+| --- | --- |
+| labels | `self-hosted`、`windows`、`wack` |
+| Windows | Windows 10/11 の対話ユーザーセッション |
+| 権限 | runner を起動するユーザーが Administrators グループに所属 |
+| セッション | `Environment.UserInteractive` が true になるアクティブセッション。Windows サービス／Session 0 では実行しない |
+| SDK | Windows SDK と Windows App Certification Kit (`appcert.exe`) |
+| PowerShell | PowerShell 7 (`pwsh`) |
+
+runner は、GitHub Actions の self-hosted runner をログオン済みユーザーの対話プロセスとして起動します。管理者権限・アクティブセッション・WACK の存在は、WACK job の開始時にも再検査します。runner に保存した資格情報や OAuth token を workflow のログへ出力しません。
+
+### 8.3 Full WACK の実行
+
+`.github/workflows/wack.yml` は次の入口を持ちます。
+
+- `workflow_dispatch`: Actions 画面から対象 branch と manifest Version を選択して実行する
+- `v*` tag push: リリース候補として実行する。tag の Version（`v0.8.0` は `0.8.0.0` に正規化）と manifest Version が一致しない場合は開始前に失敗する
+
+workflow は最初に `windows-latest` で同一 commit の MSIX を生成・静的検査し、その package を artifact 経由で `self-hosted / windows / wack` runner へ渡します。WACK runner は artifact 内の 1 個の `.msix` を `-PackagePath` で明示し、次の既存スクリプトを実行します。
+
+~~~powershell
+pwsh -NoProfile -File .\scripts\run-wack-test.ps1 `
+  -PackagePath .\wack-input\CloudMigrator_<version>_x64.msix `
+  -ReportDirectory scripts/wack_reports
+~~~
+
+`run-wack-test.ps1` は WACK の XML/HTML を回収し、`AnalyzeWackReport.ps1 -FailOnRequiredFailure` で判定します。Required failure またはレポート異常は job failure、Optional failure のみの場合は job を成功とし、XML/HTML と WACK ログを `wack-reports-<run_id>` artifact に保存します。Optional failure の審査影響は artifact と [WACK 検証結果](wack-validation-results.md) に記録してください。
+
+WACK の UAC は通常の開発者実機でのみ使用します。CI の WACK runner は開始時点で管理者権限を持つため、UAC ダイアログの表示・自動操作には依存しません。runner の管理者権限または対話セッションが不足する場合は、WACK を開始せず失敗させます。
+
+### 8.4 CI と Store 提出の境界
+
+CI artifact と GitHub Release の MSIX asset は検証・受け渡し用であり、Partner Center へ自動提出しません。Store への `.msixupload` の提出、認定用送信、公開保留、`Publish now` は手動手順の停止点として残します。GitHub Pages のプライバシーポリシー URL の有効化も、この workflow の成功とは別に確認します。
 
 ---
 

--- a/scripts/ValidateMsixPackage.ps1
+++ b/scripts/ValidateMsixPackage.ps1
@@ -1,0 +1,299 @@
+<#
+.SYNOPSIS
+    MSIX/AppX パッケージの manifest、リソース、アセットを静的検査する。
+
+.DESCRIPTION
+    makeappx.exe でパッケージを一時展開し、リポジトリの期待 manifest と
+    Identity、Version、アーキテクチャ、言語、capability、参照画像を比較する。
+    WACK は実行せず、PR の Windows runner でも再現できる検査だけを行う。
+
+.PARAMETER PackagePath
+    検査対象の .msix または .appx。
+
+.PARAMETER ManifestPath
+    期待値として比較する manifest。既定値は installer/msix/Package.appxmanifest。
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory, Position = 0)]
+    [string]$PackagePath,
+    [string]$ManifestPath = "installer/msix/Package.appxmanifest"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+
+function Resolve-RepositoryFile {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [Parameter(Mandatory)]
+        [string]$Description
+    )
+
+    $fullPath = if ([System.IO.Path]::IsPathRooted($Path)) {
+        [System.IO.Path]::GetFullPath($Path)
+    } else {
+        [System.IO.Path]::GetFullPath((Join-Path $repositoryRoot $Path))
+    }
+
+    if (-not (Test-Path -LiteralPath $fullPath -PathType Leaf)) {
+        throw "$Description が見つかりません: $fullPath"
+    }
+
+    return (Resolve-Path -LiteralPath $fullPath).Path
+}
+
+function Find-MakeAppx {
+    $programFilesX86 = ${env:ProgramFiles(x86)}
+    if ([string]::IsNullOrWhiteSpace($programFilesX86)) {
+        throw "Program Files (x86) が見つからないため、Windows SDK の makeappx.exe を検索できません。"
+    }
+
+    $windowsKitsBin = Join-Path $programFilesX86 "Windows Kits\10\bin"
+    if (-not (Test-Path -LiteralPath $windowsKitsBin -PathType Container)) {
+        throw "Windows SDK の bin ディレクトリが見つかりません: $windowsKitsBin"
+    }
+
+    $makeAppx = Get-ChildItem -LiteralPath $windowsKitsBin -Recurse -File -Filter "makeappx.exe" |
+        Where-Object { $_.FullName -match "\\x64\\makeappx\.exe$" } |
+        Sort-Object FullName -Descending |
+        Select-Object -First 1
+    if ($null -eq $makeAppx) {
+        throw "Windows SDK の x64 版 makeappx.exe が見つかりません。"
+    }
+
+    return $makeAppx.FullName
+}
+
+function Get-ManifestValue {
+    param(
+        [Parameter(Mandatory)]
+        [System.Xml.XmlNode]$Node,
+        [string]$AttributeName = ""
+    )
+
+    if ([string]::IsNullOrWhiteSpace($AttributeName)) {
+        return $Node.InnerText.Trim()
+    }
+
+    $attribute = $Node.Attributes[$AttributeName]
+    if ($null -eq $attribute) {
+        return ""
+    }
+
+    return $attribute.Value
+}
+
+function Get-ManifestImagePaths {
+    param(
+        [Parameter(Mandatory)]
+        [System.Xml.XmlDocument]$Manifest,
+        [Parameter(Mandatory)]
+        [System.Xml.XmlNamespaceManager]$Namespace
+    )
+
+    $properties = $Manifest.SelectSingleNode(
+        "/foundation:Package/foundation:Properties",
+        $Namespace)
+    $visualElements = $Manifest.SelectSingleNode(
+        "/foundation:Package/foundation:Applications/foundation:Application/uap:VisualElements",
+        $Namespace)
+    $defaultTile = $Manifest.SelectSingleNode(
+        "/foundation:Package/foundation:Applications/foundation:Application/uap:VisualElements/uap:DefaultTile",
+        $Namespace)
+    if ($null -eq $properties -or $null -eq $visualElements -or $null -eq $defaultTile) {
+        throw "manifest の Properties / VisualElements / DefaultTile が見つかりません。"
+    }
+
+    return @(
+        (Get-ManifestValue $properties.SelectSingleNode("foundation:Logo", $Namespace) ""),
+        (Get-ManifestValue $visualElements "Square150x150Logo"),
+        (Get-ManifestValue $visualElements "Square44x44Logo"),
+        (Get-ManifestValue $defaultTile "Wide310x150Logo")
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+}
+
+function Assert-Equal {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name,
+        [Parameter(Mandatory)]
+        [string]$Expected,
+        [Parameter(Mandatory)]
+        [string]$Actual
+    )
+
+    if ($Expected -ne $Actual) {
+        throw "$Name が一致しません。expected='$Expected', actual='$Actual'"
+    }
+}
+
+function Assert-SetEqual {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name,
+        [Parameter(Mandatory)]
+        [string[]]$Expected,
+        [Parameter(Mandatory)]
+        [string[]]$Actual
+    )
+
+    $expectedText = (@($Expected | Sort-Object -Unique) -join ",")
+    $actualText = (@($Actual | Sort-Object -Unique) -join ",")
+    Assert-Equal $Name $expectedText $actualText
+}
+
+$packageFullPath = Resolve-RepositoryFile $PackagePath "検査対象パッケージ"
+$expectedManifestPath = Resolve-RepositoryFile $ManifestPath "期待 manifest"
+$packageExtension = [System.IO.Path]::GetExtension($packageFullPath).ToLowerInvariant()
+if (@(".msix", ".appx") -notcontains $packageExtension) {
+    throw "検査対象には .msix または .appx を指定してください: $packageFullPath"
+}
+
+$makeAppx = Find-MakeAppx
+$namespaceUri = "http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+$uapNamespaceUri = "http://schemas.microsoft.com/appx/manifest/uap/windows10"
+
+[xml]$expectedManifest = Get-Content -LiteralPath $expectedManifestPath -Raw
+$expectedNamespace = New-Object System.Xml.XmlNamespaceManager($expectedManifest.NameTable)
+$expectedNamespace.AddNamespace("foundation", $namespaceUri)
+$expectedNamespace.AddNamespace("uap", $uapNamespaceUri)
+$expectedIdentity = $expectedManifest.SelectSingleNode(
+    "/foundation:Package/foundation:Identity",
+    $expectedNamespace)
+$expectedProperties = $expectedManifest.SelectSingleNode(
+    "/foundation:Package/foundation:Properties",
+    $expectedNamespace)
+$expectedApplication = $expectedManifest.SelectSingleNode(
+    "/foundation:Package/foundation:Applications/foundation:Application",
+    $expectedNamespace)
+if ($null -eq $expectedIdentity -or $null -eq $expectedProperties -or $null -eq $expectedApplication) {
+    throw "期待 manifest に Identity / Properties / Application が見つかりません。"
+}
+
+$expectedResources = @(
+    $expectedManifest.SelectNodes(
+        "/foundation:Package/foundation:Resources/foundation:Resource",
+        $expectedNamespace) |
+        ForEach-Object { Get-ManifestValue $_ "Language" }
+) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+$expectedCapabilities = @(
+    $expectedManifest.SelectNodes(
+        "/foundation:Package/foundation:Capabilities/*",
+        $expectedNamespace) |
+        ForEach-Object { Get-ManifestValue $_ "Name" }
+) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+$expectedImagePaths = Get-ManifestImagePaths $expectedManifest $expectedNamespace
+
+$extractDirectory = Join-Path ([System.IO.Path]::GetTempPath()) (
+    "cloud-migrator-msix-validate-" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $extractDirectory | Out-Null
+try {
+    Write-Host "MSIX を展開しています: $packageFullPath" -ForegroundColor Cyan
+    & $makeAppx unpack /p $packageFullPath /d $extractDirectory /l
+    if ($LASTEXITCODE -ne 0) {
+        throw "makeappx unpack に失敗しました（exit=$LASTEXITCODE）。"
+    }
+
+    $packageManifestPath = Join-Path $extractDirectory "AppxManifest.xml"
+    if (-not (Test-Path -LiteralPath $packageManifestPath -PathType Leaf)) {
+        throw "パッケージ内に AppxManifest.xml がありません。"
+    }
+    [xml]$packageManifest = Get-Content -LiteralPath $packageManifestPath -Raw
+    $packageNamespace = New-Object System.Xml.XmlNamespaceManager($packageManifest.NameTable)
+    $packageNamespace.AddNamespace("foundation", $namespaceUri)
+    $packageNamespace.AddNamespace("uap", $uapNamespaceUri)
+    $packageIdentity = $packageManifest.SelectSingleNode(
+        "/foundation:Package/foundation:Identity",
+        $packageNamespace)
+    $packageProperties = $packageManifest.SelectSingleNode(
+        "/foundation:Package/foundation:Properties",
+        $packageNamespace)
+    $packageApplication = $packageManifest.SelectSingleNode(
+        "/foundation:Package/foundation:Applications/foundation:Application",
+        $packageNamespace)
+    if ($null -eq $packageIdentity -or $null -eq $packageProperties -or $null -eq $packageApplication) {
+        throw "パッケージ内 manifest に Identity / Properties / Application が見つかりません。"
+    }
+
+    foreach ($attributeName in @("Name", "Publisher", "Version", "ProcessorArchitecture")) {
+        Assert-Equal `
+            "Identity.$attributeName" `
+            (Get-ManifestValue $expectedIdentity $attributeName) `
+            (Get-ManifestValue $packageIdentity $attributeName)
+    }
+    Assert-Equal `
+        "Properties.DisplayName" `
+        (Get-ManifestValue $expectedProperties.SelectSingleNode("foundation:DisplayName", $expectedNamespace) "") `
+        (Get-ManifestValue $packageProperties.SelectSingleNode("foundation:DisplayName", $packageNamespace) "")
+    Assert-Equal `
+        "Properties.PublisherDisplayName" `
+        (Get-ManifestValue $expectedProperties.SelectSingleNode("foundation:PublisherDisplayName", $expectedNamespace) "") `
+        (Get-ManifestValue $packageProperties.SelectSingleNode("foundation:PublisherDisplayName", $packageNamespace) "")
+
+    $packageResources = @(
+        $packageManifest.SelectNodes(
+            "/foundation:Package/foundation:Resources/foundation:Resource",
+            $packageNamespace) |
+            ForEach-Object { Get-ManifestValue $_ "Language" }
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    Assert-SetEqual "Resources.Language" $expectedResources $packageResources
+
+    $packageCapabilities = @(
+        $packageManifest.SelectNodes(
+            "/foundation:Package/foundation:Capabilities/*",
+            $packageNamespace) |
+            ForEach-Object { Get-ManifestValue $_ "Name" }
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    Assert-SetEqual "Capabilities" $expectedCapabilities $packageCapabilities
+
+    Assert-Equal `
+        "Application.Executable" `
+        (Get-ManifestValue $expectedApplication "Executable") `
+        (Get-ManifestValue $packageApplication "Executable")
+
+    $imagePaths = Get-ManifestImagePaths $packageManifest $packageNamespace
+    if ($imagePaths.Count -ne 4) {
+        throw "manifest が参照する画像数が 4 ではありません: $($imagePaths.Count)"
+    }
+    Assert-SetEqual "Manifest image paths" $expectedImagePaths $imagePaths
+    foreach ($imagePath in $imagePaths) {
+        $packageImagePath = Join-Path $extractDirectory ($imagePath -replace "[/]", "\")
+        if (-not (Test-Path -LiteralPath $packageImagePath -PathType Leaf)) {
+            throw "manifest が参照する画像がパッケージ内にありません: $imagePath"
+        }
+    }
+
+    $resourcesPriPath = Join-Path $extractDirectory "resources.pri"
+    if (-not (Test-Path -LiteralPath $resourcesPriPath -PathType Leaf)) {
+        throw "パッケージ内に resources.pri がありません。"
+    }
+
+    $packageHash = (Get-FileHash -LiteralPath $packageFullPath -Algorithm SHA256).Hash
+    Write-Host "MSIX 静的検査: PASS" -ForegroundColor Green
+    Write-Host "Identity: $($packageIdentity.Name)" -ForegroundColor Gray
+    Write-Host "Version: $($packageIdentity.Version) / Architecture: $($packageIdentity.ProcessorArchitecture)" -ForegroundColor Gray
+    Write-Host "Languages: $($packageResources -join ', ')" -ForegroundColor Gray
+    Write-Host "Assets: $($imagePaths -join ', ')" -ForegroundColor Gray
+    Write-Host "SHA-256: $packageHash" -ForegroundColor Gray
+
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
+        @(
+            "## MSIX 静的検査",
+            "",
+            "- 結果: PASS",
+            ("- Identity: " + $packageIdentity.Name),
+            ("- Version: " + $packageIdentity.Version),
+            ("- Architecture: " + $packageIdentity.ProcessorArchitecture),
+            ("- Languages: " + ($packageResources -join ", ")),
+            ("- SHA-256: " + $packageHash)
+        ) | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Encoding utf8
+    }
+} finally {
+    if (Test-Path -LiteralPath $extractDirectory) {
+        Remove-Item -LiteralPath $extractDirectory -Recurse -Force
+    }
+}

--- a/tasks.md
+++ b/tasks.md
@@ -138,7 +138,7 @@ MSI 配布 (#97) に続く次世代配布方式として MSIX パッケージン
 | [#265](https://github.com/scottlz0310/cloud-migrator/issues/265) | installer / test | #101-B: WACK 実行手順の策定・検証スクリプトおよびチェックリストの作成 | [45]/[63] 修正済み。高解像度ロゴ再生成後の現行パッケージも実機 WACK PASS（Required 0 / Optional 1 `[88]`）。[88] は許容方針 |
 | [#266](https://github.com/scottlz0310/cloud-migrator/issues/266) | installer / doc | #101-C: Partner Center Store Listing Data・提出アセット・プライバシーポリシーの整備 | ✅ 完了（`docs/assets/store/listingData.csv`、`store/...` 相対パスのフォルダーインポート手順、提出アセット仕様、`docs/privacy-policy.html`） |
 | [#267](https://github.com/scottlz0310/cloud-migrator/issues/267) | doc / installer | #101-D: MSIX パッケージング・WACK 検査・Partner Center 提出マニュアルの作成 | ✅ 完了（MSIX/WACK/Partner Center の手動手順、提出前停止条件、更新・差戻し、インストールスコープ、#268 との CI 境界を `docs/msix-packaging-and-store-guide.md` に集約） |
-| [#268](https://github.com/scottlz0310/cloud-migrator/issues/268) | ci / installer | #101-E: GitHub Actions CI による MSIX ビルドおよびリリースアタッチの自動化 | CI 経由のパッケージ生成を自動化 |
+| [#268](https://github.com/scottlz0310/cloud-migrator/issues/268) | ci / installer | #101-E: GitHub Actions CI による MSIX ビルドおよびリリースアタッチの自動化 | ✅ 完了（PR/main の MSIX 静的検査、self-hosted WACK workflow、Required/Optional 判定、artifact 保存を追加。runner の登録・管理は環境作業） |
 
 ---
 


### PR DESCRIPTION
## 概要

Issue #268 に対し、MSIX パッケージの静的検証・リリース添付・WACK 実行を GitHub Actions で自動化します。

- PR / main 向け CI で MSIX を生成し、マニフェスト・リソース・画像・Capabilities・SHA-256 を検証
- Release workflow で MSIX / msixupload を GitHub Release に添付
- WACK workflow で hosted runner 上のビルド・静的検証後、self-hosted Windows runner で WACK を実行
- WACK レポートを XML / HTML として artifact に保存
- MSIX 運用手順、CI と Store 認定の責務境界、runner 要件を文書化

## 背景

MSIX の Store 提出前に、マニフェストとパッケージ内容の不一致を CI で検出し、Windows App Certification Kit の結果を共有可能な artifact として残せるようにします。

WACK ジョブは対話セッションおよび管理者権限を必要とするため、self-hosted / windows / wack ラベルの runner を使用します。runner は Windows サービスではなく、対話セッションで起動する前提です。公開リポジトリの未信頼な PR から WACK runner を実行しないよう、WACK workflow のトリガーは手動実行とタグ push に限定しています。

## 検証

- `dotnet build CloudMigrator.slnx --no-restore --configuration Release`
- `dotnet test CloudMigrator.slnx --no-build --configuration Release`（1,034 件成功）
- `pwsh .\installer\msix\Build-MsixPackage.ps1 -Configuration Release -Version 0.7.1.0`
- `pwsh .\scripts\ValidateMsixPackage.ps1`（PASS）
- GitHub Actions YAML 構文確認
- PowerShell 構文確認
- `git diff --check`
- WACK 手動実行（exit=0、XML / HTML レポート生成済み）

Pages 有効化および self-hosted runner 登録は、リポジトリ外の環境設定として実施済みであり、この PR の変更対象には含めていません。

Closes #268