### PR TITLE
feat: タグ push 後の Microsoft Store 自動公開を追加 (#276)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# GitHub の対象とする Environment
+GITHUB_REPOSITORY=scottlz0310/cloud-migrator
+GITHUB_ENVIRONMENT=store-production
+
+# Microsoft Store の Product ID（公開識別子。シークレットではありません）
+STORE_PRODUCT_ID=9NG134LB022L
+
+# Partner Center / Microsoft Entra ID
+# 実値に置き換えてください。実値はコミット、Issue、ログへ貼り付けないでください。
+AZURE_AD_APPLICATION_CLIENT_ID=replace-with-entra-application-client-id
+AZURE_AD_APPLICATION_SECRET=replace-with-entra-client-secret
+AZURE_AD_TENANT_ID=replace-with-entra-tenant-id
+SELLER_ID=replace-with-partner-center-seller-id

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
 
 permissions:
   contents: write
+  actions: read
+
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
   publish:
@@ -149,6 +154,17 @@ jobs:
     steps:
       - name: リポジトリを checkout
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: tag commit が main 系列上にあることを確認
+        shell: pwsh
+        run: |
+          git fetch origin main --no-tags
+          & git merge-base --is-ancestor $env:GITHUB_SHA origin/main
+          if ($LASTEXITCODE -ne 0) {
+            throw "リリース tag の commit ($env:GITHUB_SHA) が origin/main の系列上にありません。"
+          }
 
       - name: .NET SDK セットアップ
         uses: actions/setup-dotnet@v6
@@ -188,6 +204,42 @@ jobs:
           pwsh -NoProfile -File .\scripts\ValidateMsixPackage.ps1 `
             -PackagePath ".\installer\msix\AppPackages\CloudMigrator_${{ steps.version.outputs.version }}_x64.msix"
 
+      - name: MSIX artifact の SHA-256 証跡を作成
+        shell: pwsh
+        run: |
+          $packageFiles = @(Get-ChildItem -Path "installer/msix/AppPackages/CloudMigrator_*_x64.msix" -File)
+          $uploadFiles = @(Get-ChildItem -Path "installer/msix/AppPackages/CloudMigrator_*_x64_bundle.msixupload" -File)
+          if ($packageFiles.Count -ne 1 -or $uploadFiles.Count -ne 1) {
+            throw "MSIX artifact は .msix と .msixupload を各 1 個だけ含む必要があります。msix=$($packageFiles.Count), msixupload=$($uploadFiles.Count)"
+          }
+
+          $package = $packageFiles[0]
+          $upload = $uploadFiles[0]
+          $evidence = [ordered]@{
+            schemaVersion = 1
+            tag = $env:GITHUB_REF_NAME
+            commit = $env:GITHUB_SHA
+            version = "${{ steps.version.outputs.version }}"
+            packageFile = $package.Name
+            packageSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $package.FullName).Hash.ToLowerInvariant()
+            uploadFile = $upload.Name
+            uploadSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $upload.FullName).Hash.ToLowerInvariant()
+            createdAtUtc = [DateTime]::UtcNow.ToString('O')
+          } | ConvertTo-Json -Depth 5
+
+          $artifactDirectory = Join-Path $env:GITHUB_WORKSPACE 'msix-artifact'
+          if (Test-Path -LiteralPath $artifactDirectory) {
+            Remove-Item -LiteralPath $artifactDirectory -Recurse -Force
+          }
+          New-Item -ItemType Directory -Path $artifactDirectory | Out-Null
+          Copy-Item -LiteralPath $package.FullName -Destination $artifactDirectory
+          Copy-Item -LiteralPath $upload.FullName -Destination $artifactDirectory
+          [IO.File]::WriteAllText(
+            (Join-Path $artifactDirectory 'msix-artifact-evidence.json'),
+            $evidence,
+            [Text.UTF8Encoding]::new($false))
+          Write-Host $evidence
+
       - name: MSIX をリリースにアップロード
         shell: pwsh
         run: |
@@ -202,11 +254,184 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: msix-release-${{ github.run_id }}
-          path: |
-            installer/msix/AppPackages/CloudMigrator_*_x64.msix
-            installer/msix/AppPackages/CloudMigrator_*_x64_bundle.msixupload
+          path: msix-artifact/*
           if-no-files-found: error
           retention-days: 30
+
+  wack:
+    name: WACK（同一 MSIX artifact）
+    needs: msix
+    uses: ./.github/workflows/wack.yml
+    with:
+      artifact_name: msix-release-${{ github.run_id }}
+
+  store:
+    name: Microsoft Store 自動公開
+    needs: [msix, wack]
+    if: ${{ needs.msix.result == 'success' && needs.wack.result == 'success' }}
+    runs-on: windows-latest
+    timeout-minutes: 360
+    environment:
+      name: store-production
+      url: https://partner.microsoft.com/dashboard/products/${{ vars.STORE_PRODUCT_ID }}
+    concurrency:
+      group: store-production
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      actions: read
+
+    steps:
+      - name: MSIX artifact を取得
+        uses: actions/download-artifact@v8
+        with:
+          name: msix-release-${{ github.run_id }}
+          path: store-input
+
+      - name: MSIX artifact と証跡を照合
+        shell: pwsh
+        run: |
+          $packages = @(Get-ChildItem -LiteralPath 'store-input' -File -Filter '*.msix')
+          $uploads = @(Get-ChildItem -LiteralPath 'store-input' -File -Filter '*.msixupload')
+          $evidencePath = Join-Path $env:GITHUB_WORKSPACE 'store-input/msix-artifact-evidence.json'
+          if ($packages.Count -ne 1 -or $uploads.Count -ne 1 -or -not (Test-Path -LiteralPath $evidencePath -PathType Leaf)) {
+            throw "Store 入力 artifact は .msix、.msixupload、証跡 JSON を各 1 個含む必要があります。msix=$($packages.Count), msixupload=$($uploads.Count)"
+          }
+
+          $evidence = Get-Content -LiteralPath $evidencePath -Raw | ConvertFrom-Json
+          $package = $packages[0]
+          $upload = $uploads[0]
+          $expectedPackage = "CloudMigrator_$($evidence.version)_x64.msix"
+          $expectedUpload = "CloudMigrator_$($evidence.version)_x64_bundle.msixupload"
+          if ($evidence.tag -ne $env:GITHUB_REF_NAME -or $evidence.commit -ne $env:GITHUB_SHA) {
+            throw "MSIX artifact の tag/commit 証跡が現在の release と一致しません。"
+          }
+          if ($package.Name -ne $expectedPackage -or $upload.Name -ne $expectedUpload) {
+            throw "MSIX artifact のファイル名が manifest Version と一致しません。"
+          }
+
+          $packageHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $package.FullName).Hash.ToLowerInvariant()
+          $uploadHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $upload.FullName).Hash.ToLowerInvariant()
+          if ($packageHash -ne $evidence.packageSha256 -or $uploadHash -ne $evidence.uploadSha256) {
+            throw "MSIX artifact の SHA-256 が生成時の証跡と一致しません。"
+          }
+
+          @(
+            '### Store 公開 artifact',
+            "- tag: $env:GITHUB_REF_NAME",
+            "- commit: $env:GITHUB_SHA",
+            "- package: $($package.Name) ($packageHash)",
+            "- upload: $($upload.Name) ($uploadHash)"
+          ) | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+
+      - name: Microsoft Store Developer CLI をセットアップ
+        id: msstore_cli
+        uses: microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0 # v1.4
+
+      - name: CLI telemetry を無効化
+        shell: pwsh
+        run: msstore settings --enableTelemetry false
+
+      - name: Partner Center credentials を設定
+        shell: pwsh
+        env:
+          AZURE_AD_APPLICATION_CLIENT_ID: ${{ secrets.AZURE_AD_APPLICATION_CLIENT_ID }}
+          AZURE_AD_APPLICATION_SECRET: ${{ secrets.AZURE_AD_APPLICATION_SECRET }}
+          AZURE_AD_TENANT_ID: ${{ secrets.AZURE_AD_TENANT_ID }}
+          SELLER_ID: ${{ secrets.SELLER_ID }}
+        run: |
+          $required = @{
+            AZURE_AD_APPLICATION_CLIENT_ID = $env:AZURE_AD_APPLICATION_CLIENT_ID
+            AZURE_AD_APPLICATION_SECRET = $env:AZURE_AD_APPLICATION_SECRET
+            AZURE_AD_TENANT_ID = $env:AZURE_AD_TENANT_ID
+            SELLER_ID = $env:SELLER_ID
+          }
+          foreach ($entry in $required.GetEnumerator()) {
+            if ([string]::IsNullOrWhiteSpace($entry.Value)) {
+              throw "GitHub Environment secret が未設定です: $($entry.Key)"
+            }
+          }
+          msstore reconfigure `
+            --tenantId $env:AZURE_AD_TENANT_ID `
+            --sellerId $env:SELLER_ID `
+            --clientId $env:AZURE_AD_APPLICATION_CLIENT_ID `
+            --clientSecret $env:AZURE_AD_APPLICATION_SECRET
+
+      - name: 既存 submission を確認し必要なら再開
+        id: submission
+        shell: pwsh
+        env:
+          STORE_PRODUCT_ID: ${{ vars.STORE_PRODUCT_ID }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:STORE_PRODUCT_ID)) {
+            throw 'GitHub Environment variable STORE_PRODUCT_ID が未設定です。Configure-StorePublishing.ps1 を実行してください。'
+          }
+          $packages = @(Get-ChildItem -LiteralPath 'store-input' -File -Filter '*.msix')
+          if ($packages.Count -ne 1) {
+            throw "Store 入力の MSIX は 1 個である必要があります。検出数: $($packages.Count)"
+          }
+          $expectedPackage = $packages[0].Name
+          $output = @(& msstore submission get $env:STORE_PRODUCT_ID 2>&1)
+          if ($LASTEXITCODE -ne 0) {
+            throw "既存 submission の取得に失敗しました。Product ID と Partner Center 権限を確認してください。"
+          }
+
+          $jsonLine = $output |
+            ForEach-Object { [regex]::Replace([string]$_, '\x1b\[[0-?]*[ -/]*[@-~]', '') } |
+            Where-Object { $_.TrimStart().StartsWith('{') } |
+            Select-Object -Last 1
+          if ([string]::IsNullOrWhiteSpace([string]$jsonLine)) {
+            throw '既存 submission の JSON を CLI 出力から取得できませんでした。'
+          }
+
+          $submission = $jsonLine | ConvertFrom-Json
+          $status = [string]$submission.Status
+          $packageNames = @($submission.ApplicationPackages | ForEach-Object { [string]$_.FileName })
+          $samePackage = $packageNames -contains $expectedPackage
+          "既存 submission status: $status" | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+          "既存 submission package 一致: $samePackage" | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+
+          'already_published=false' >> $env:GITHUB_OUTPUT
+          'polled_existing=false' >> $env:GITHUB_OUTPUT
+          if ($status -in @('CommitStarted', 'CommitFailed') -and -not $samePackage) {
+            throw "別 Version の submission が残っています。現在の submission を上書きせず停止します。"
+          }
+          if ($status -eq 'CommitStarted') {
+            & msstore submission poll $env:STORE_PRODUCT_ID
+            if ($LASTEXITCODE -ne 0) {
+              throw '既存 submission の poll に失敗しました。'
+            }
+            'polled_existing=true' >> $env:GITHUB_OUTPUT
+          } elseif ($status -eq 'Published' -and $samePackage) {
+            'already_published=true' >> $env:GITHUB_OUTPUT
+          }
+
+      - name: .msixupload を Store submission へ送信
+        if: steps.submission.outputs.already_published != 'true' && steps.submission.outputs.polled_existing != 'true'
+        shell: pwsh
+        env:
+          STORE_PRODUCT_ID: ${{ vars.STORE_PRODUCT_ID }}
+        run: |
+          $upload = Get-ChildItem -LiteralPath 'store-input' -File -Filter '*.msixupload' | Select-Object -First 1
+          & msstore publish $upload.FullName --appId $env:STORE_PRODUCT_ID
+          if ($LASTEXITCODE -ne 0) {
+            throw '.msixupload の Store submission に失敗しました。'
+          }
+
+      - name: submission status を最終確認
+        if: ${{ always() && steps.msstore_cli.outcome == 'success' }}
+        shell: pwsh
+        env:
+          STORE_PRODUCT_ID: ${{ vars.STORE_PRODUCT_ID }}
+        run: |
+          $output = @(& msstore submission status $env:STORE_PRODUCT_ID 2>&1)
+          $statusExit = $LASTEXITCODE
+          $output |
+            Where-Object { ([string]$_) -match '(?i)status' } |
+            Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+          if ($statusExit -ne 0) {
+            throw 'Store submission の最終 status 取得に失敗しました。'
+          }
 
   msi:
     name: MSI インストーラービルド

--- a/.github/workflows/wack.yml
+++ b/.github/workflows/wack.yml
@@ -7,16 +7,21 @@ on:
         description: "検証する manifest Version（省略時は対象 commit の manifest から取得）"
         required: false
         type: string
-  push:
-    tags:
-      - "v*"
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: "WACK に渡す MSIX artifact 名"
+        required: true
+        type: string
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   build-msix:
     name: MSIX build for WACK
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: windows-latest
     env:
       LEFTHOOK: 0
@@ -93,9 +98,38 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  prepare_wack_input:
+    name: WACK 入力 artifact の準備
+    needs: build-msix
+    if: ${{ always() && (github.event_name == 'workflow_call' || needs.build-msix.result == 'success') }}
+    runs-on: windows-latest
+    steps:
+      - name: リリースの MSIX artifact を取得
+        if: ${{ github.event_name == 'workflow_call' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: wack-input
+
+      - name: 手動実行の MSIX artifact を取得
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: msix-wack-input-${{ github.run_id }}
+          path: wack-input
+
+      - name: WACK 入力 artifact を再保存
+        uses: actions/upload-artifact@v7
+        with:
+          name: wack-input-${{ github.run_id }}
+          path: wack-input/*
+          if-no-files-found: error
+          retention-days: 7
+
   wack:
     name: WACK（self-hosted / Windows / wack）
-    needs: build-msix
+    needs: prepare_wack_input
+    if: ${{ needs.prepare_wack_input.result == 'success' }}
     runs-on: [self-hosted, windows, wack]
     env:
       LEFTHOOK: 0
@@ -107,7 +141,7 @@ jobs:
       - name: WACK 入力 package を取得
         uses: actions/download-artifact@v8
         with:
-          name: msix-wack-input-${{ github.run_id }}
+          name: wack-input-${{ github.run_id }}
           path: wack-input
 
       - name: runner の管理者権限・対話セッションを確認

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ node_modules/
 logs/
 .env
 .env.*
+!.env.example
 configs/config.json
 .playwright-mcp/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ### Added
 
+- **タグ push 後の Microsoft Store 自動公開を追加（#276 / #101-F）**
+  - `release.yml` が生成した同一 MSIX artifact を WACK と Store 公開へ渡し、tag、manifest Version、SHA-256 を照合
+  - WACK 成功後に `store-production` Environment から Microsoft Store Developer CLI を実行し、submission status を poll
+  - `.env.example`、`Configure-StorePublishing.ps1`、Environment の `v*` tag policy と `STORE_PRODUCT_ID` variable を追加し、`.gitignore` で記入済み `.env` を除外
 - **Partner Center Store Listing Data・提出アセット・プライバシーポリシーを整備（#266 / #101-C）**
   - `docs/assets/store/listingData.csv` を UTF-8 BOM / CRLF の相対パス形式で追加し、英語・日本語の説明文、機能一覧、検索語、スクリーンショット、Store logo を登録可能化
   - `docs/assets/store-source/README.md` にインポート手順、サポート URL、画像仕様、未参照プロモーション素材の扱いを記載

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,3 +99,23 @@ CloudMigrator.Cli
 - unit テストは XPlat Code Coverage で Cobertura XML を生成します。
 - pull request では `quality-gate` ジョブが `quality-metrics` と `security-scan` を実行します。
 - Codecov への送信は Ubuntu ジョブで一度だけ行い、生成済み Cobertura XML をそのまま利用します。
+
+## リリースフロー（MSIX / Microsoft Store）
+
+MSIX のリリースは `v*` tag push を入口とし、GitHub Release の生成、同一 MSIX artifact の WACK、Microsoft Store 自動公開を順に実行します。
+
+```text
+v* tag push
+  -> release.yml: CLI / Dashboard / MSI / MSIX を生成し GitHub Release へ添付
+  -> msix-release-<run_id>: .msix / .msixupload / SHA-256 証跡を保存
+  -> wack.yml (workflow_call): 同じ artifact の .msix を self-hosted WACK runner で検証
+  -> store-production: WACK 成功後だけ同じ artifact の .msixupload を Store へ提出・公開
+```
+
+- `release.yml` は tag と manifest Version、tag commit の main 系列、package の SHA-256 を確認します。
+- リリース経路の `wack.yml` は `workflow_call` で artifact を受け取り、tag 時に MSIX を再ビルドしません。`workflow_dispatch` による個別 WACK は別途維持します。
+- Store job は `store-production` Environment、`STORE_PRODUCT_ID` variable、Entra ID / Partner Center の Environment secrets を使用します。Environment の deployment policy は `v*` tag に限定し、Product 単位の concurrency で submission を直列化します。
+- Store job は既存 submission の status と package を確認し、同じ package の処理中 submission は poll して再利用します。別 Version の submission は上書きせず停止します。
+- GitHub Release の公開完了は Store 公開完了を意味しません。WACK と Store の job 結果、artifact 証跡、submission status を別々に確認します。
+
+Environment の初期設定と中断・再実行を含む詳細手順は、[MSIX パッケージング・WACK 検査・Microsoft Store 提出ガイド](msix-packaging-and-store-guide.md)の [Store 自動公開と初期設定](msix-packaging-and-store-guide.md#84-store-自動公開と初期設定-276) に集約します。

--- a/docs/msix-packaging-and-store-guide.md
+++ b/docs/msix-packaging-and-store-guide.md
@@ -1,8 +1,8 @@
 # MSIX パッケージング・WACK 検査・Microsoft Store 提出ガイド
 
-本書は、CloudMigrator の MSIX パッケージを生成し、Windows App Certification Kit (WACK) で検証し、Microsoft Partner Center で提出・公開するための手動ランブックです。Epic [#101](https://github.com/scottlz0310/cloud-migrator/issues/101) の #264〜#268 を横断する再開用の正本として扱います。
+本書は、CloudMigrator の MSIX パッケージを生成し、Windows App Certification Kit (WACK) で検証し、Microsoft Partner Center へ提出・公開するための準備・手動確認・自動公開運用ガイドです。Epic [#101](https://github.com/scottlz0310/cloud-migrator/issues/101) の #264〜#268 と #276 を横断する再開用の正本として扱います。
 
-本書で扱うのは、再現可能な準備・検証・提出画面の確認までです。Partner Center の「認定用に提出」および「Publish now」は外部状態を変更するため、実行者が内容を確認し、明示的に承認した後にだけ実行してください。GitHub Actions への MSIX/WACK 組み込みは [#268](https://github.com/scottlz0310/cloud-migrator/issues/268) の責務です。
+初回 listing の登録、手動確認、または自動公開が利用できない場合は本書の手動手順を使用します。通常の更新では `v*` tag push 後に、[8.4 Store 自動公開と初期設定](#84-store-自動公開と初期設定-276) の GitHub Actions が同一 artifact を WACK から Store まで搬送します。手動の「認定用に提出」および「Publish now」は、自動経路を使わない場合の明示的な回復手順として扱います。
 
 すべての相対パスはリポジトリルート（CloudMigrator）からのパスです。
 
@@ -320,13 +320,13 @@ Submission options で、次を確認します。
 - `runFullTrust` の用途とユーザー操作との関係を 2.5 のノートに沿って説明する。
 - 審査用テストアカウントが必要なら、実際に使用できるアカウントと安全な手順を、Partner Center が提供する審査向け欄へ入力する。公開リポジトリや通常の issue コメントへ資格情報を書かない。
 - Restricted capability の理由を要求された場合は、ローカルファイル・設定・ログを扱う Windows デスクトップ実行と、ユーザー指示の移行処理に限定して説明する。
-- 初回は公開を自動化せず、公開保留（`Don't publish this submission until I select Publish now` 相当）の設定を選択する。認定通過と公開操作を分離する。
+- 手動提出を行う場合だけ、公開保留（`Don't publish this submission until I select Publish now` 相当）の要否を選択する。#276 の自動経路では `store-production` job が submission status を poll し、認定後の公開まで実行する。
 
 ### 5.5 最終確認と提出
 
-概要ページで、package、listing、価格・市場、プライバシーポリシー、審査ノート、公開保留設定を確認します。次の停止点で提出操作を止め、実行者の明示的な承認を得ます。
+手動提出を行う場合は、概要ページで package、listing、価格・市場、プライバシーポリシー、審査ノート、公開保留設定を確認します。次の停止点で提出操作を止め、実行者の明示的な承認を得ます。#276 の自動経路では、この画面操作を通常手順にしません。
 
-> **停止点:** 本書の #267 作業だけでは「Submit for certification」または「Publish now」をクリックしない。画面の入力内容と証跡を共有し、提出・公開を実行する人の承認を得てから操作する。
+> **手動経路の停止点:** 本書の手動確認だけでは「Submit for certification」または「Publish now」をクリックしない。画面の入力内容と証跡を共有し、提出・公開を実行する人の承認を得てから操作する。自動経路では tag push と workflow の成功条件を使用する。
 
 承認後に認定へ提出した場合は、次を記録します。
 
@@ -343,9 +343,9 @@ Submission options で、次を確認します。
 | Required / Optional failure |  |
 | privacy URL の確認日時・HTTP 結果 |  |
 | 認定ステータス・差戻し内容 |  |
-| 公開保留を選択したか、Publish now の承認者 |  |
+| 公開経路（自動 workflow / 手動公開保留）と承認者 |  |
 
-認定を通過して公開保留中の場合も、公開ボタンを自動的に押しません。Store listing の公開確認と GitHub Release の公開は別の操作として記録します。
+手動経路で認定を通過して公開保留中の場合は、公開ボタンを自動的に押しません。自動経路では Store job が submission status を poll して公開完了を判定します。いずれの場合も Store の公開状態と GitHub Release の公開は別の操作として記録します。
 
 ---
 
@@ -357,9 +357,9 @@ Submission options で、次を確認します。
 2. manifest の Version は既存の Store package より大きくし、4 桁の値を package ファイル名の `-Version` と一致させる。
 3. 新しい `.msix` / `.msixupload` を生成し、ファイル名、package 内 manifest、SHA-256 を確認する。
 4. 新しい package で WACK を再実行し、Required/Optional の記録を更新する。
-5. Partner Center で新しい submission を作成し、Package、Store listing、Release notes、審査ノートを確認する。
-6. 初回と同様に公開保留を選択し、認定結果と公開操作を分離する。
-7. 公開後に Store listing、インストール、起動、ログイン、少量の転送、アンインストールを確認し、Submission ID と結果を記録する。
+5. `v<manifest Version>` の tag を push し、GitHub Actions の release workflow を開始する。
+6. workflow が同一 artifact の静的検査、WACK、`.msixupload` の Store submission と公開状態の poll を実行する。
+7. 公開後に Store listing、インストール、起動、ログイン、少量の転送、アンインストールを確認し、workflow の実行 URL と Submission ID を記録する。
 
 同じ submission の入力を上書きして証跡を失わないでください。修正して再提出する場合は、新しい package と新しい SHA-256 を記録します。
 
@@ -373,9 +373,9 @@ Submission options で、次を確認します。
 
 単なる再ビルドで同じ Version・同じ入力を再提出しません。Revision の 4 桁目だけを増やすか、主バージョンを進めるかは、変更内容と Partner Center の要求に応じてリリース準備時に決定します。4 桁目の増加をすべての差戻しに対する自動規則とはしません。
 
-### 6.3 GitHub Release との境界
+### 6.3 GitHub Release と Store 自動公開の境界
 
-現在の `.github/workflows/release.yml` は `v*` タグで GitHub Release と CLI/Dashboard、MSI、MSIX (`.msix` / `.msixupload`) のアセットを公開しますが、MSIX の WACK 完了や Partner Center の認定状態を確認するゲートではありません。したがって、Store の公開保留を GitHub Release の Draft と同一視しません。
+`.github/workflows/release.yml` は `v*` タグで GitHub Release と CLI/Dashboard、MSI、MSIX (`.msix` / `.msixupload`) のアセットを公開します。続いて同じ MSIX artifact を `wack.yml` の self-hosted WACK に渡し、WACK 成功後にだけ `store-production` Environment の Store 公開 job を開始します。GitHub Release の公開状態と Store の submission／公開状態は別の証跡として記録します。
 
 ---
 
@@ -437,9 +437,9 @@ runner は、GitHub Actions の self-hosted runner をログオン済みユー�
 `.github/workflows/wack.yml` は次の入口を持ちます。
 
 - `workflow_dispatch`: Actions 画面から対象 branch と manifest Version を選択して実行する
-- `v*` tag push: リリース候補として実行する。tag の Version（`v0.8.0` は `0.8.0.0` に正規化）と manifest Version が一致しない場合は開始前に失敗する
+- `workflow_call`: `release.yml` が生成した MSIX artifact を受け取り、tag push 時の再ビルドを行わずに実行する
 
-workflow は最初に `windows-latest` で同一 commit の MSIX を生成・静的検査し、その package を artifact 経由で `self-hosted / windows / wack` runner へ渡します。WACK runner は artifact 内の 1 個の `.msix` を `-PackagePath` で明示し、次の既存スクリプトを実行します。
+手動実行では `windows-latest` で MSIX を生成・静的検査してから artifact に保存します。リリース実行では `release.yml` が生成した artifact（`.msix`、`.msixupload`、SHA-256 証跡 JSON）をそのまま `self-hosted / windows / wack` runner へ渡します。WACK runner は artifact 内の 1 個の `.msix` を `-PackagePath` で明示し、次の既存スクリプトを実行します。
 
 ~~~powershell
 pwsh -NoProfile -File .\scripts\run-wack-test.ps1 `
@@ -451,9 +451,40 @@ pwsh -NoProfile -File .\scripts\run-wack-test.ps1 `
 
 WACK の UAC は通常の開発者実機でのみ使用します。CI の WACK runner は開始時点で管理者権限を持つため、UAC ダイアログの表示・自動操作には依存しません。runner の管理者権限または対話セッションが不足する場合は、WACK を開始せず失敗させます。
 
-### 8.4 CI と Store 提出の境界
+### 8.4 Store 自動公開と初期設定（#276）
 
-CI artifact と GitHub Release の MSIX asset は検証・受け渡し用であり、Partner Center へ自動提出しません。Store への `.msixupload` の提出、認定用送信、公開保留、`Publish now` は手動手順の停止点として残します。GitHub Pages のプライバシーポリシー URL の有効化も、この workflow の成功とは別に確認します。
+タグ push 後の Store 公開は、次の順序で実行します。
+
+1. `release.yml` が tag と manifest Version を照合し、MSIX／MSIXUPLOAD と SHA-256 証跡を作成する。
+2. GitHub Release に添付したものと同じ artifact を WACK runner へ渡す。
+3. WACK が成功した場合だけ `store-production` Environment の job を開始する。
+4. Microsoft Store Developer CLI で Entra ID の client credentials を設定し、`.msixupload` を Product ID `9NG134LB022L` へ送信する。
+5. 既存 submission の status と package 名を確認し、同じ package の処理中 submission は poll して再利用する。別 Version の submission が処理中なら上書きせず停止する。
+6. submission status が `PUBLISHED` になるまで poll し、失敗時は workflow を失敗させる。
+
+初回設定はリポジトリ root で行います。`.env` はローカルだけに置き、実値を Git、Issue、ログへ出力しません。
+
+~~~powershell
+Copy-Item .env.example .env
+# .env に Entra ID / Partner Center の値を記入
+pwsh -NoProfile -File .\scripts\Configure-StorePublishing.ps1 -WhatIf
+pwsh -NoProfile -File .\scripts\Configure-StorePublishing.ps1
+~~~
+
+設定スクリプトは `store-production` Environment を作成または更新し、`v*` tag の deployment policy、`STORE_PRODUCT_ID` variable、次の Environment secrets を設定します。
+
+- `AZURE_AD_APPLICATION_CLIENT_ID`
+- `AZURE_AD_APPLICATION_SECRET`
+- `AZURE_AD_TENANT_ID`
+- `SELLER_ID`
+
+Entra ID アプリには Microsoft Store Submission API を利用できる client credentials と、対象アプリを更新できる Partner Center 権限を付与します。Microsoft Store Developer CLI の GitHub Actions 更新は現行ドキュメント上、free product が前提です。Product ID は `.env` の `STORE_PRODUCT_ID` で確認しますが、secret にはしません。現在はユーザー判断により required reviewer を設定せず、`v*` tag 制限だけを Environment 保護ルールとして使います。承認を再導入する場合は GitHub Environment 側で追加設定します。
+
+Store 公開 job は Product 単位の concurrency で直列化します。GitHub Actions の timeout 後に再実行する場合は、新しい tag や手動再ビルドを作らず、同じ run の再実行で既存 submission の status を確認します。submission が別 Version の処理中または失敗状態で残っている場合も自動で上書きせず、Partner Center で状態を確認してから対応します。
+
+### 8.5 Listing Data との責務分離
+
+`docs/assets/store/listingData.csv` は listing の登録・更新用の入力であり、Store 公開 workflow の package artifact には含めません。Partner Center から export した CSV に含まれる一時的な絶対 asset URL や submission 識別子もリポジトリへコピーしません。listing の変更は別途確認してから package の新 Version と一緒に提出します。
 
 ---
 

--- a/scripts/Configure-StorePublishing.ps1
+++ b/scripts/Configure-StorePublishing.ps1
@@ -1,0 +1,209 @@
+[CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+param(
+    [string]$EnvFile,
+    [string]$Repository,
+    [string]$EnvironmentName,
+    [string]$ProductId
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Read-DotEnv {
+    param([Parameter(Mandatory)][string]$Path)
+
+    $values = @{}
+    foreach ($rawLine in Get-Content -LiteralPath $Path) {
+        $line = $rawLine.Trim()
+        if ([string]::IsNullOrWhiteSpace($line) -or $line.StartsWith('#')) {
+            continue
+        }
+
+        if ($line -notmatch '^(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?<value>.*)$') {
+            throw ".env の行を解釈できません: $rawLine"
+        }
+
+        $name = $Matches['name']
+        if ($values.ContainsKey($name)) {
+            throw ".env に同じキーが複数あります: $name"
+        }
+
+        $value = $Matches['value'].Trim()
+        if ($value.Length -ge 2 -and (($value.StartsWith('"') -and $value.EndsWith('"')) -or ($value.StartsWith("'") -and $value.EndsWith("'")))) {
+            $value = $value.Substring(1, $value.Length - 2)
+        } elseif ($value.StartsWith('"') -or $value.StartsWith("'")) {
+            throw ".env の引用符が閉じていません: $name"
+        }
+
+        $values[$name] = $value
+    }
+
+    return $values
+}
+
+function Get-RequiredValue {
+    param(
+        [Parameter(Mandatory)][hashtable]$Values,
+        [Parameter(Mandatory)][string]$Name
+    )
+
+    if (-not $Values.ContainsKey($Name) -or [string]::IsNullOrWhiteSpace([string]$Values[$Name])) {
+        throw ".env に必須値がありません: $Name"
+    }
+
+    return [string]$Values[$Name]
+}
+
+function Invoke-Gh {
+    param([Parameter(Mandatory)][string[]]$Arguments)
+
+    $output = @(& gh @Arguments 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        $detail = ($output | ForEach-Object { [string]$_ }) -join ' '
+        throw "gh コマンドに失敗しました: gh $($Arguments -join ' ') $detail"
+    }
+
+    return $output
+}
+
+function Invoke-GhJson {
+    param(
+        [Parameter(Mandatory)][string[]]$Arguments,
+        [Parameter(Mandatory)][string]$Json
+    )
+
+    $output = @($Json | & gh @Arguments 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        $detail = ($output | ForEach-Object { [string]$_ }) -join ' '
+        throw "gh API 呼び出しに失敗しました: $detail"
+    }
+
+    return $output
+}
+
+if ([string]::IsNullOrWhiteSpace($EnvFile)) {
+    $EnvFile = Join-Path $PSScriptRoot '..\.env'
+}
+
+$envFilePath = (Resolve-Path -LiteralPath $EnvFile -ErrorAction Stop).Path
+$values = Read-DotEnv -Path $envFilePath
+
+$secretNames = @(
+    'AZURE_AD_APPLICATION_CLIENT_ID',
+    'AZURE_AD_APPLICATION_SECRET',
+    'AZURE_AD_TENANT_ID',
+    'SELLER_ID'
+)
+
+foreach ($secretName in $secretNames) {
+    [void](Get-RequiredValue -Values $values -Name $secretName)
+}
+
+if ([string]::IsNullOrWhiteSpace($Repository)) {
+    if ($values.ContainsKey('GITHUB_REPOSITORY') -and -not [string]::IsNullOrWhiteSpace([string]$values['GITHUB_REPOSITORY'])) {
+        $Repository = [string]$values['GITHUB_REPOSITORY']
+    } else {
+        $Repository = [string](Invoke-Gh -Arguments @('repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner') | Select-Object -First 1)
+    }
+}
+
+if ($Repository -notmatch '^[^/]+/[^/]+$') {
+    throw "Repository は owner/name 形式で指定してください: $Repository"
+}
+
+if ([string]::IsNullOrWhiteSpace($EnvironmentName)) {
+    if ($values.ContainsKey('GITHUB_ENVIRONMENT') -and -not [string]::IsNullOrWhiteSpace([string]$values['GITHUB_ENVIRONMENT'])) {
+        $EnvironmentName = [string]$values['GITHUB_ENVIRONMENT']
+    } else {
+        $EnvironmentName = 'store-production'
+    }
+}
+
+if ($EnvironmentName -notmatch '^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$') {
+    throw "Environment 名に使用できない文字が含まれています: $EnvironmentName"
+}
+
+if ([string]::IsNullOrWhiteSpace($ProductId)) {
+    if ($values.ContainsKey('STORE_PRODUCT_ID') -and -not [string]::IsNullOrWhiteSpace([string]$values['STORE_PRODUCT_ID'])) {
+        $ProductId = [string]$values['STORE_PRODUCT_ID']
+    } else {
+        $ProductId = '9NG134LB022L'
+    }
+}
+
+if ($ProductId -notmatch '^[A-Za-z0-9-]+$') {
+    throw "Store Product ID が不正です: $ProductId"
+}
+
+[void](Invoke-Gh -Arguments @('auth', 'status'))
+[void](Invoke-Gh -Arguments @('repo', 'view', $Repository, '--json', 'nameWithOwner', '--jq', '.nameWithOwner'))
+
+$apiHeaders = @('--header', 'Accept: application/vnd.github+json', '--header', 'X-GitHub-Api-Version: 2026-03-10')
+$environmentEndpoint = "repos/$Repository/environments/$EnvironmentName"
+$environmentBody = [ordered]@{
+    deployment_branch_policy = [ordered]@{
+        protected_branches = $false
+        custom_branch_policies = $true
+    }
+} | ConvertTo-Json -Depth 5
+
+if ($PSCmdlet.ShouldProcess("GitHub Environment '$EnvironmentName'", '作成または更新')) {
+    [void](Invoke-GhJson -Arguments (@('api', $environmentEndpoint, '--method', 'PUT') + $apiHeaders + @('--input', '-')) -Json $environmentBody)
+}
+
+$policiesEndpoint = "$environmentEndpoint/deployment-branch-policies"
+if ($WhatIfPreference) {
+    Write-Host "WhatIf: Environment '$EnvironmentName' の既存 tag policy は確認せず、'v*' の追加予定を表示します。"
+} else {
+    $existingPolicies = @(Invoke-Gh -Arguments (@('api', $policiesEndpoint) + $apiHeaders + @('--jq', '.branch_policies[] | select(.name == "v*" and .type == "tag") | .name')))
+    if ($existingPolicies.Count -eq 0) {
+        $policyBody = [ordered]@{ name = 'v*'; type = 'tag' } | ConvertTo-Json -Depth 3
+        if ($PSCmdlet.ShouldProcess("GitHub Environment '$EnvironmentName'", "tag policy 'v*' を追加")) {
+            [void](Invoke-GhJson -Arguments (@('api', $policiesEndpoint, '--method', 'POST') + $apiHeaders + @('--input', '-')) -Json $policyBody)
+        }
+    } else {
+        Write-Host "tag policy 'v*' は設定済みです。"
+    }
+}
+
+if ($PSCmdlet.ShouldProcess("GitHub Environment '$EnvironmentName' の variable 'STORE_PRODUCT_ID'", '値を設定')) {
+    $output = @($ProductId | & gh variable set STORE_PRODUCT_ID --env $EnvironmentName --repo $Repository 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        $detail = ($output | ForEach-Object { [string]$_ }) -join ' '
+        throw "variable 'STORE_PRODUCT_ID' の設定に失敗しました: $detail"
+    }
+}
+
+foreach ($secretName in $secretNames) {
+    if ($PSCmdlet.ShouldProcess("GitHub Environment '$EnvironmentName' の secret '$secretName'", '値を設定')) {
+        $secretValue = [string]$values[$secretName]
+        $output = @($secretValue | & gh secret set $secretName --env $EnvironmentName --repo $Repository 2>&1)
+        if ($LASTEXITCODE -ne 0) {
+            $detail = ($output | ForEach-Object { [string]$_ }) -join ' '
+            throw "secret '$secretName' の設定に失敗しました: $detail"
+        }
+    }
+}
+
+if (-not $WhatIfPreference) {
+    $configuredProductId = [string](Invoke-Gh -Arguments @('variable', 'list', '--env', $EnvironmentName, '--repo', $Repository, '--json', 'name,value', '--jq', '.[] | select(.name == "STORE_PRODUCT_ID") | .value') | Select-Object -First 1)
+    if ($configuredProductId -ne $ProductId) {
+        throw "Environment '$EnvironmentName' の STORE_PRODUCT_ID が期待値と一致しません。"
+    }
+
+    $configuredSecretNames = @(Invoke-Gh -Arguments @('secret', 'list', '--env', $EnvironmentName, '--repo', $Repository, '--json', 'name', '--jq', '.[].name'))
+    $missingSecretNames = @($secretNames | Where-Object { $_ -notin $configuredSecretNames })
+    if ($missingSecretNames.Count -gt 0) {
+        throw "Environment '$EnvironmentName' に未設定の secret があります: $($missingSecretNames -join ', ')"
+    }
+    Write-Host "Store 自動公開用の GitHub Environment 設定を確認しました。"
+} else {
+    Write-Host "WhatIf: GitHub Environment と secret の設定予定を確認しました。外部変更はありません。"
+}
+
+Write-Host "Repository: $Repository"
+Write-Host "Environment: $EnvironmentName"
+Write-Host "Product ID: $ProductId"
+$summaryVerb = if ($WhatIfPreference) { '設定予定の' } else { '設定した' }
+Write-Host "$summaryVerb Environment variable: STORE_PRODUCT_ID"
+Write-Host "$summaryVerb secret: $($secretNames -join ', ')"

--- a/tasks.md
+++ b/tasks.md
@@ -139,9 +139,20 @@ MSI 配布 (#97) に続く次世代配布方式として MSIX パッケージン
 | [#266](https://github.com/scottlz0310/cloud-migrator/issues/266) | installer / doc | #101-C: Partner Center Store Listing Data・提出アセット・プライバシーポリシーの整備 | ✅ 完了（`docs/assets/store/listingData.csv`、`store/...` 相対パスのフォルダーインポート手順、提出アセット仕様、`docs/privacy-policy.html`） |
 | [#267](https://github.com/scottlz0310/cloud-migrator/issues/267) | doc / installer | #101-D: MSIX パッケージング・WACK 検査・Partner Center 提出マニュアルの作成 | ✅ 完了（MSIX/WACK/Partner Center の手動手順、提出前停止条件、更新・差戻し、インストールスコープ、#268 との CI 境界を `docs/msix-packaging-and-store-guide.md` に集約） |
 | [#268](https://github.com/scottlz0310/cloud-migrator/issues/268) | ci / installer | #101-E: GitHub Actions CI による MSIX ビルドおよびリリースアタッチの自動化 | ✅ 完了（PR/main の MSIX 静的検査、self-hosted WACK workflow、Required/Optional 判定、artifact 保存を追加。runner の登録・管理は環境作業） |
+| [#276](https://github.com/scottlz0310/cloud-migrator/issues/276) | ci / release | #101-F: Partner Center Submission API による Microsoft Store 提出・公開の自動化 | 🚧 実装中（tag push 後に同一 artifact を WACK → Store へ渡す workflow、Environment secret 設定スクリプト、`.env.example` を追加。実環境 secret 設定と初回 tag 実行は未実施） |
+
+### #276 の受け入れ条件
+
+- [x] tag と manifest/package Version、commit SHA、`.msix` / `.msixupload` の SHA-256 を照合する。
+- [x] `release.yml` の同一 artifact を WACK と Store 公開へ渡し、tag 時の再ビルドを行わない。
+- [x] WACK 成功後だけ Store 公開 job を開始し、`store-production` Environment の secret を使用する。
+- [x] `Configure-StorePublishing.ps1` と `.env.example` を用意し、`.env` を Git 管理対象外にする。
+- [x] `docs/architecture.md` と `docs/msix-packaging-and-store-guide.md` が tag → WACK → Store の現行フローを同じ手順として説明する。
+- [ ] Partner Center 用 Entra ID アプリ、Environment、secret を実環境へ設定する。
+- [ ] 新 Version の tag で WACK、Store submission、認定・公開完了までの E2E を実行し、証跡を記録する。
 
 ---
 
 ## 次の推奨着手
 
-[#207](https://github.com/scottlz0310/cloud-migrator/issues/207)（#196-A）から開始する。DashboardPage の `isDropbox` 分岐を RouteDescriptor 経由に置換。
+[#276](https://github.com/scottlz0310/cloud-migrator/issues/276) の実環境設定と初回 tag E2E を完了する。完了後は [#207](https://github.com/scottlz0310/cloud-migrator/issues/207)（#196-A）の DashboardPage 改修へ戻る。


### PR DESCRIPTION
## 概要

#276 / #101-F として、リリース tag push 後に同一 MSIX artifact を WACK から Microsoft Store 公開まで搬送する自動化を追加します。

## 変更内容

- `release.yml` で tag、manifest Version、commit 系列、MSIX / MSIXUPLOAD の SHA-256 を検証
- GitHub Release に添付するものと同じ artifact を reusable `wack.yml` と `store-production` job へ渡す構成に変更
- WACK 成功後のみ Microsoft Store Developer CLI を実行し、既存 submission の status / package を確認して poll・再利用
- `.env.example` と `scripts/Configure-StorePublishing.ps1` を追加
- `.gitignore` で記入済み `.env` を除外
- `docs/architecture.md` と MSIX 運用ガイドのリリース手順を現行フローへ統一
- `CHANGELOG.md` と `tasks.md` を更新

## 検証

- lefthook: dotnet build 成功（警告 0 / エラー 0）
- lefthook: dotnet format 成功
- lefthook: dotnet restore 成功
- lefthook: unit test 1,034件成功
- actionlint 成功（self-hosted label `wack` の既知警告は除外）
- `Configure-StorePublishing.ps1 -WhatIf` 成功（GitHub Environment / secret の外部変更なし）
- PowerShell 構文検査、`git diff --check` 成功

## マージ後に実施すること

- Partner Center / Microsoft Entra ID の実値をローカルの `.env` に記入
- `Configure-StorePublishing.ps1` で `store-production` Environment、variable、secret を設定
- 新 Version の tag で WACK → Store submission → 認定・公開完了までの E2E を実行し、証跡を記録
- 成功確認後にリリース運用へ移行

listingData の export CSV や secret の実値はこのPRへ含めていません。

Refs #276