### PR TITLE
chore: v0.7.2 バージョンバンプ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-08-16
+
 ### Added
 
 - **タグ push 後の Microsoft Store 自動公開を追加（#276 / #101-F）**
@@ -999,7 +1001,8 @@
 - `task.md` - フェーズ別タスク管理
 - `README.md` - プロジェクト概要・構成・開発手順
 
-[Unreleased]: https://github.com/scottlz0310/cloud-migrator/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/scottlz0310/cloud-migrator/compare/v0.7.2...HEAD
+[0.7.2]: https://github.com/scottlz0310/cloud-migrator/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/scottlz0310/cloud-migrator/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/scottlz0310/cloud-migrator/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/scottlz0310/cloud-migrator/compare/v0.4.0...v0.6.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
       デフォルトバージョン（開発ビルド用）。
       リリースビルドは GitHub Actions でタグから -p:Version=x.y.z を渡して上書きする。
     -->
-    <Version>0.7.1</Version>
+    <Version>0.7.2</Version>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/docs/msix-packaging-and-store-guide.md
+++ b/docs/msix-packaging-and-store-guide.md
@@ -35,7 +35,7 @@ WACK は切断された RDP セッションや、UAC を表示できない非対
 | Identity Name | `scottlz0310.CloudMigrator` |
 | Publisher | `CN=39FB3D39-1F1A-4B82-B081-47469FD12CA6` |
 | PublisherDisplayName | `scottlz0310` |
-| 開発用 Version | `Directory.Build.props` が `0.7.1`、manifest が `0.7.1.0` |
+| 開発用 Version | `Directory.Build.props` が `0.7.2`、manifest が `0.7.2.0` |
 | アーキテクチャ | Windows Desktop / x64 |
 | 対象 OS | MinVersion `10.0.19041.0`、MaxVersionTested `10.0.22621.0` |
 | 言語 | `ja-JP` / `en-US`、既定言語 `ja-JP` |
@@ -68,13 +68,13 @@ Test-Path .\installer\msix\Package.appxmanifest
 リポジトリルートから次を実行します。
 
 ~~~powershell
-.\installer\msix\Build-MsixPackage.ps1 -Configuration Release -Version 0.7.1.0
+.\installer\msix\Build-MsixPackage.ps1 -Configuration Release -Version 0.7.2.0
 ~~~
 
 生成先は `installer/msix/AppPackages/` です。
 
-- `CloudMigrator_0.7.1.0_x64.msix`: WACK・ローカル検査用の MSIX
-- `CloudMigrator_0.7.1.0_x64_bundle.msixupload`: Partner Center のアップロード用ファイル
+- `CloudMigrator_0.7.2.0_x64.msix`: WACK・ローカル検査用の MSIX
+- `CloudMigrator_0.7.2.0_x64_bundle.msixupload`: Partner Center のアップロード用ファイル
 
 ビルドスクリプトは、`Package.appxmanifest` の `PublisherDisplayName`、`Resources/Resource@Language`、manifest が参照する 4 つの画像を検証した後、Windows SDK の `makepri.exe` で `resources.pri` を生成して MSIX に含めます。`Resources` の先頭にある `ja-JP` が既定言語です。`csproj` の `DefaultLanguage` / `Languages` だけでは、手動 `makeappx` 経路の manifest へ自動反映されません。`makepri.exe` の生成方式は Microsoft の [MakePRI による PRI ファイル生成手順](https://learn.microsoft.com/en-us/windows/msix/desktop/desktop-to-uwp-manual-conversion#generate-a-package-resource-index-pri-file-using-makepri) に準拠します。
 
@@ -89,7 +89,7 @@ Partner Center で「画像が見つからない」「PublisherDisplayName が�
 生成直後に、対象ファイルと SHA-256 を固定します。
 
 ~~~powershell
-$version = "0.7.1.0"
+$version = "0.7.2.0"
 $packageDirectory = ".\installer\msix\AppPackages"
 $package = Get-Item (Join-Path $packageDirectory ("CloudMigrator_" + $version + "_x64.msix"))
 $upload = Get-Item (Join-Path $packageDirectory ("CloudMigrator_" + $version + "_x64_bundle.msixupload"))
@@ -152,7 +152,7 @@ Windows SDK の [Windows App Certification Kit](https://learn.microsoft.com/en-u
 リリース記録では自動選択を使わず、検査対象を明示します。
 
 ~~~powershell
-$packagePath = ".\installer\msix\AppPackages\CloudMigrator_0.7.1.0_x64.msix"
+$packagePath = ".\installer\msix\AppPackages\CloudMigrator_0.7.2.0_x64.msix"
 .\scripts\run-wack-test.ps1 -PackagePath $packagePath
 ~~~
 
@@ -395,7 +395,7 @@ MSIX の登録スコープは、既存の MSI のインストール先選択と�
 現在の手動ビルドは未署名なので、次の per-user 例がそのまま成功するとは限りません。
 
 ~~~powershell
-Add-AppxPackage -Path .\installer\msix\AppPackages\CloudMigrator_0.7.1.0_x64.msix
+Add-AppxPackage -Path .\installer\msix\AppPackages\CloudMigrator_0.7.2.0_x64.msix
 ~~~
 
 このコマンドが失敗しても、WACK の Required failure 0 と矛盾するとは限りません。信頼された証明書で署名したテスト package、または Store から取得した package でインストール・起動を確認します。プロビジョニングは管理者向けの企業展開であり、Microsoft Store の通常配布に「per-machine」を追加する manifest スイッチではありません。

--- a/installer/msix/Build-MsixPackage.ps1
+++ b/installer/msix/Build-MsixPackage.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param (
     [string]$Configuration = "Release",
-    [string]$Version = "0.7.1.0",
+    [string]$Version = "0.7.2.0",
     [string]$OutputDirectory = "installer/msix/AppPackages"
 )
 

--- a/installer/msix/Package.appxmanifest
+++ b/installer/msix/Package.appxmanifest
@@ -8,7 +8,7 @@
   <Identity
     Name="scottlz0310.CloudMigrator"
     Publisher="CN=39FB3D39-1F1A-4B82-B081-47469FD12CA6"
-    Version="0.7.1.0"
+    Version="0.7.2.0"
     ProcessorArchitecture="x64" />
 
   <Properties>

--- a/src/CloudMigrator.Dashboard/Package.appxmanifest
+++ b/src/CloudMigrator.Dashboard/Package.appxmanifest
@@ -8,7 +8,7 @@
   <Identity
     Name="scottlz0310.CloudMigrator"
     Publisher="CN=39FB3D39-1F1A-4B82-B081-47469FD12CA6"
-    Version="0.7.1.0"
+    Version="0.7.2.0"
     ProcessorArchitecture="x64" />
 
   <Properties>


### PR DESCRIPTION
## 概要

v0.7.2 リリースに向けて、アプリケーション版数と MSIX 版数を整合させます。

## 変更内容

- `Directory.Build.props` の開発用 Version を `0.7.2` に更新
- 2つの `Package.appxmanifest` を `0.7.2.0` に更新
- `Build-MsixPackage.ps1` の既定 Version を `0.7.2.0` に更新
- Store 提出ガイドの現行版数・コマンド例を更新
- `CHANGELOG.md` に v0.7.2 セクションと比較リンクを追加

これにより、マージ後に `v0.7.2` を push した際、`release.yml` の tag/manifest Version 検証を通過できます。

## 検証

- manifest / `Directory.Build.props` の版数整合性チェック
- `Build-MsixPackage.ps1` PowerShell 構文チェック
- `dotnet build --configuration Release --no-restore`
- `dotnet test --configuration Release --no-restore --no-build`（1,036件成功）
- pre-commit hooks（build / format / restore / unit test 1,034件）成功

## リリース手順

このPRのマージ後、`main` のマージ済みコミットに対して `v0.7.2` タグを push します。タグ push 後は既存のリリースフローにより、同一 MSIX artifact の生成、WACK、Microsoft Store 提出・公開が実行されます。初回 Store E2E の実行結果と証跡は別途確認します。

関連: #276