### PR TITLE
fix: reusable WACK workflow の artifact 判定を修正

### DIFF
--- a/.github/workflows/wack.yml
+++ b/.github/workflows/wack.yml
@@ -101,18 +101,18 @@ jobs:
   prepare_wack_input:
     name: WACK 入力 artifact の準備
     needs: build-msix
-    if: ${{ always() && (github.event_name == 'workflow_call' || needs.build-msix.result == 'success') }}
+    if: ${{ always() && (inputs.artifact_name != '' || needs.build-msix.result == 'success') }}
     runs-on: windows-latest
     steps:
       - name: リリースの MSIX artifact を取得
-        if: ${{ github.event_name == 'workflow_call' }}
+        if: ${{ inputs.artifact_name != '' }}
         uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifact_name }}
           path: wack-input
 
       - name: 手動実行の MSIX artifact を取得
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+        if: ${{ inputs.artifact_name == '' && needs.build-msix.result == 'success' }}
         uses: actions/download-artifact@v8
         with:
           name: msix-wack-input-${{ github.run_id }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@
   - 対象: ci.yml (upload×3, download×1)、release.yml (upload×1, download×1)
   - 外部 Renovate プリセット (`renovate-config`) の GitHub Actions 一括グループルールにより、将来 `upload-artifact@v8` がリリースされた際は同一 PR でペア更新される
 
+- **WACK reusable workflow の caller event 判定を修正**
+  - `workflow_call` で呼び出された場合も caller の `github.event_name` が見えるため、`artifact_name` input を基準にリリース artifact を選択するよう変更
+  - tag release で WACK と Microsoft Store 自動公開の job が skip される問題を解消
+
 ---
 
 ## [0.7.1] - 2026-05-04


### PR DESCRIPTION
## 概要

`v0.7.2` のリリース実行で、トップレベルの workflow は成功した一方、WACK と Microsoft Store 自動公開の job が skip されました。バージョン番号を進めず、同じ `v0.7.2` のリリース経路を修正します。

## 原因

再利用ワークフローでは caller workflow の `github.event_name` が見えるため、`wack.yml` が `workflow_call` を判定できず、リリース用 artifact の準備から後続 job まで skip されていました。

## 変更内容

- `.github/workflows/wack.yml` のリリース artifact 判定を `github.event_name` から `inputs.artifact_name` に変更
- 手動実行時の MSIX build / artifact 取得経路は維持
- `CHANGELOG.md` に `v0.7.2` の修正内容を追記
- アプリケーションのバージョン番号・manifest は変更なし

## 検証

- `dotnet restore CloudMigrator.slnx`
- `dotnet format CloudMigrator.slnx --verify-no-changes`
- `dotnet build CloudMigrator.slnx --no-restore --configuration Release`（警告 0、エラー 0）
- `dotnet test tests/unit/CloudMigrator.Tests.Unit.csproj --no-build --configuration Release`（1,034 件成功）
- `git diff --check`

## リリース手順

この PR のマージ後、既存の `v0.7.2` タグを修正後のマージコミットへ付け替えて release workflow を再実行します。タグの付け替えは別の明示確認を得てから実施します。

Related: #276