### PR TITLE
fix: WACK と Store 公開の実行 gate を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,10 +328,6 @@ jobs:
         id: msstore_cli
         uses: microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0 # v1.4
 
-      - name: CLI telemetry を無効化
-        shell: pwsh
-        run: msstore settings --enableTelemetry false
-
       - name: Partner Center credentials を設定
         shell: pwsh
         env:
@@ -356,6 +352,10 @@ jobs:
             --sellerId $env:SELLER_ID `
             --clientId $env:AZURE_AD_APPLICATION_CLIENT_ID `
             --clientSecret $env:AZURE_AD_APPLICATION_SECRET
+
+      - name: CLI telemetry を無効化
+        shell: pwsh
+        run: msstore settings --enableTelemetry false
 
       - name: 既存 submission を確認し必要なら再開
         id: submission

--- a/.github/workflows/wack.yml
+++ b/.github/workflows/wack.yml
@@ -129,7 +129,7 @@ jobs:
   wack:
     name: WACK（self-hosted / Windows / wack）
     needs: prepare_wack_input
-    if: ${{ needs.prepare_wack_input.result == 'success' }}
+    if: ${{ always() && needs.prepare_wack_input.result == 'success' }}
     runs-on: [self-hosted, windows, wack]
     env:
       LEFTHOOK: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@
   - `workflow_call` で呼び出された場合も caller の `github.event_name` が見えるため、`artifact_name` input を基準にリリース artifact を選択するよう変更
   - tag release で WACK と Microsoft Store 自動公開の job が skip される問題を解消
 
+- **WACK 実行と Microsoft Store CLI 初期化の release gate を修正**
+  - reusable workflow の上流 job が skip されても WACK 本体を暗黙に skip しないようにし、self-hosted WACK の完了を Store 公開の前提にする
+  - 初回 runner でも Partner Center credentials の設定後に CLI telemetry を無効化するよう手順を修正
+
 ---
 
 ## [0.7.1] - 2026-05-04


### PR DESCRIPTION
## 概要

`v0.7.2` の修正版 release run で、MSIX artifact の準備までは成功しましたが、WACK 本体が skip 扱いとなり、Microsoft Store 自動公開が誤って実行されました。また、初回の Microsoft Store Developer CLI 初期化で `SellerId is not set` が発生しました。

## 変更内容

- `wack.yml` の self-hosted WACK job に `always()` を付け、workflow_call 側で skip された `build-msix` の影響を後続 WACK jobへ暗黙伝播させない
- self-hosted WACK が offline / 未実行の場合に、Store 公開を成功扱いで通過させない
- Partner Center credentials の `msstore reconfigure` を CLI telemetry 設定より先に実行
- `CHANGELOG.md` に `v0.7.2` の修正内容を追記
- アプリケーションのバージョン番号・manifest は変更なし

## 根拠

対象 run: https://github.com/scottlz0310/cloud-migrator/actions/runs/31937969083

- MSIX build / artifact 準備: 成功
- WACK self-hosted job: skipped（登録 runner は offline）
- Store job: 実行されたが `SellerId is not set` で失敗
- Store job が WACK skip を成功扱いにしない fail-closed 経路を修正

## 検証

- pre-commit: restore / format / build / unit test 成功
- Release build: 警告 0、エラー 0
- Unit test: 1,034 件成功
- `git diff --check`

## リリース手順

この PR も `v0.7.2` の修正として扱います。マージ後は、WACK self-hosted runner を online にした状態で既存の `v0.7.2` タグを再度マージコミットへ付け替えて release workflow を再実行します。

このPRのマージ・タグ付け替えは、#282に対する許可とは別の確認を必要とします。

Related: #276