### PR TITLE
fix: Microsoft Store submission の複数行 JSON 解析を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -371,20 +371,24 @@ jobs:
             throw "Store 入力の MSIX は 1 個である必要があります。検出数: $($packages.Count)"
           }
           $expectedPackage = $packages[0].Name
-          $output = @(& msstore submission get $env:STORE_PRODUCT_ID 2>&1)
+          $jsonPath = Join-Path $env:RUNNER_TEMP "store-submission-$env:GITHUB_RUN_ID.json"
+          $errorPath = Join-Path $env:RUNNER_TEMP "store-submission-$env:GITHUB_RUN_ID.err"
+          & msstore submission get $env:STORE_PRODUCT_ID 1> $jsonPath 2> $errorPath
           if ($LASTEXITCODE -ne 0) {
             throw "既存 submission の取得に失敗しました。Product ID と Partner Center 権限を確認してください。"
           }
 
-          $jsonLine = $output |
-            ForEach-Object { [regex]::Replace([string]$_, '\x1b\[[0-?]*[ -/]*[@-~]', '') } |
-            Where-Object { $_.TrimStart().StartsWith('{') } |
-            Select-Object -Last 1
-          if ([string]::IsNullOrWhiteSpace([string]$jsonLine)) {
+          $jsonText = Get-Content -LiteralPath $jsonPath -Raw
+          $jsonText = [regex]::Replace([string]$jsonText, '\x1b\[[0-?]*[ -/]*[@-~]', '')
+          if ([string]::IsNullOrWhiteSpace($jsonText)) {
             throw '既存 submission の JSON を CLI 出力から取得できませんでした。'
           }
 
-          $submission = $jsonLine | ConvertFrom-Json
+          try {
+            $submission = $jsonText | ConvertFrom-Json
+          } catch {
+            throw '既存 submission の複数行 JSON を解析できませんでした。CLI の出力形式を確認してください。'
+          }
           $status = [string]$submission.Status
           $packageNames = @($submission.ApplicationPackages | ForEach-Object { [string]$_.FileName })
           $samePackage = $packageNames -contains $expectedPackage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -375,19 +375,23 @@ jobs:
           $errorPath = Join-Path $env:RUNNER_TEMP "store-submission-$env:GITHUB_RUN_ID.err"
           & msstore submission get $env:STORE_PRODUCT_ID 1> $jsonPath 2> $errorPath
           if ($LASTEXITCODE -ne 0) {
-            throw "既存 submission の取得に失敗しました。Product ID と Partner Center 権限を確認してください。"
+            throw "既存 submission の取得に失敗しました。Product ID と Partner Center 権限を確認してください。stderr: $errorPath"
           }
 
-          $jsonText = Get-Content -LiteralPath $jsonPath -Raw
+          try {
+            $jsonText = Get-Content -LiteralPath $jsonPath -Raw -ErrorAction Stop
+          } catch {
+            throw "既存 submission の JSON 出力を読み込めませんでした。パス: $jsonPath。$($_.Exception.Message)"
+          }
           $jsonText = [regex]::Replace([string]$jsonText, '\x1b\[[0-?]*[ -/]*[@-~]', '')
           if ([string]::IsNullOrWhiteSpace($jsonText)) {
-            throw '既存 submission の JSON を CLI 出力から取得できませんでした。'
+            throw "既存 submission の JSON を CLI 出力から取得できませんでした。パス: $jsonPath"
           }
 
           try {
             $submission = $jsonText | ConvertFrom-Json
           } catch {
-            throw '既存 submission の複数行 JSON を解析できませんでした。CLI の出力形式を確認してください。'
+            throw "既存 submission の複数行 JSON を解析できませんでした。CLI の出力形式を確認してください。$($_.Exception.Message)"
           }
           $status = [string]$submission.Status
           $packageNames = @($submission.ApplicationPackages | ForEach-Object { [string]$_.FileName })

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,9 @@
   - reusable workflow の上流 job が skip されても WACK 本体を暗黙に skip しないようにし、self-hosted WACK の完了を Store 公開の前提にする
   - 初回 runner でも Partner Center credentials の設定後に CLI telemetry を無効化するよう手順を修正
 
+- **Microsoft Store の既存 submission JSON 解析を修正（#276 / #101-F）**
+  - `msstore submission get` が返す複数行 JSON 全体を解析し、先頭の `{` 行だけを渡して失敗する問題を解消
+
 ---
 
 ## [0.7.1] - 2026-05-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 
 - **Microsoft Store の既存 submission JSON 解析を修正（#276 / #101-F）**
   - `msstore submission get` が返す複数行 JSON 全体を解析し、先頭の `{` 行だけを渡して失敗する問題を解消
+  - submission 取得・JSON 出力読み込み・解析の失敗時に、stderr／一時ファイルのパスや元の例外メッセージを示して診断性を改善
 
 ---
 


### PR DESCRIPTION
## 概要

Release run #31940437948（https://github.com/scottlz0310/cloud-migrator/actions/runs/31940437948）の Microsoft Store 自動公開 job が、Store submission 送信前の既存 submission 解析で失敗した問題を修正します。

## 原因

Microsoft Store Developer CLI の msstore submission get は整形済みの複数行 JSON を返しますが、workflow は JSON の先頭 { 行だけを抽出して ConvertFrom-Json に渡していました。そのため、JSON が { だけの不完全な文字列になり、Unexpected end when reading JSON で停止していました。

WACK、MSIX artifact の取得・SHA-256 照合、Partner Center credentials の設定は同じ run で成功しており、.msixupload の Store 送信前に停止しています。

## 変更内容

- msstore submission get の stdout と stderr を分離
- stdout を runner 一時領域へ保存し、Get-Content -Raw で複数行 JSON 全体を解析
- JSON が空、または形式不正の場合は原因が分かるエラーで停止
- CHANGELOG.md の修正履歴を更新

## 検証

- git diff --check
- 埋め込み PowerShell の構文解析
- 複数行 submission JSON の再現 parse
- lefthook pre-commit hook 完了（commit: 865516d）

## リリース影響

- バージョン番号は変更しません
- WACK／self-hosted runner の構成は変更しません
- この PR のマージ後、同じ v0.7.2 tag を修正済み main commit へ付け替えて release workflow を再実行します
- Store submission が成功するまで Issue #276 はクローズしません

Related to #276