### PR TITLE
fix: Microsoft Store submission の不正な Unicode escape を許容

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,19 @@ permissions:
   contents: read
 
 jobs:
+  store-submission-json:
+    name: Store submission JSON 解析検証
+    runs-on: windows-latest
+    env:
+      LEFTHOOK: 0
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: PowerShell 解析テスト
+        shell: pwsh
+        run: pwsh -NoProfile -File .\scripts\Test-StoreSubmissionJson.ps1
+
   build-test:
     name: Build & Test (${{ matrix.os }} / .NET ${{ matrix.dotnet }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,6 +282,9 @@ jobs:
       actions: read
 
     steps:
+      - name: リポジトリを checkout
+        uses: actions/checkout@v7
+
       - name: MSIX artifact を取得
         uses: actions/download-artifact@v8
         with:
@@ -385,7 +388,7 @@ jobs:
           $samePackage = $packageNames -contains $expectedPackage
           "既存 submission status: $status" | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
           "既存 submission package 一致: $samePackage" | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
-          "listing JSON の不正な Unicode escape 補正件数: $($submission.RepairedInvalidUnicodeEscapeCount)" | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+          "listing JSON の不正な escape 補正件数: $($submission.RepairedInvalidEscapeCount)" | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
 
           'already_published=false' >> $env:GITHUB_OUTPUT
           'polled_existing=false' >> $env:GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,26 +378,14 @@ jobs:
             throw "既存 submission の取得に失敗しました。Product ID と Partner Center 権限を確認してください。stderr: $errorPath"
           }
 
-          try {
-            $jsonText = Get-Content -LiteralPath $jsonPath -Raw -ErrorAction Stop
-          } catch {
-            throw "既存 submission の JSON 出力を読み込めませんでした。パス: $jsonPath。$($_.Exception.Message)"
-          }
-          $jsonText = [regex]::Replace([string]$jsonText, '\x1b\[[0-?]*[ -/]*[@-~]', '')
-          if ([string]::IsNullOrWhiteSpace($jsonText)) {
-            throw "既存 submission の JSON を CLI 出力から取得できませんでした。パス: $jsonPath"
-          }
-
-          try {
-            $submission = $jsonText | ConvertFrom-Json
-          } catch {
-            throw "既存 submission の複数行 JSON を解析できませんでした。CLI の出力形式を確認してください。$($_.Exception.Message)"
-          }
+          Import-Module (Join-Path $env:GITHUB_WORKSPACE 'scripts/StoreSubmissionJson.psm1') -Force
+          $submission = Read-StoreSubmissionMetadata -JsonPath $jsonPath
           $status = [string]$submission.Status
-          $packageNames = @($submission.ApplicationPackages | ForEach-Object { [string]$_.FileName })
+          $packageNames = @($submission.PackageNames)
           $samePackage = $packageNames -contains $expectedPackage
           "既存 submission status: $status" | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
           "既存 submission package 一致: $samePackage" | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+          "listing JSON の不正な Unicode escape 補正件数: $($submission.RepairedInvalidUnicodeEscapeCount)" | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
 
           'already_published=false' >> $env:GITHUB_OUTPUT
           'polled_existing=false' >> $env:GITHUB_OUTPUT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
 ### Fixed
 
 - **Microsoft Store submission の listing JSON 解析を堅牢化（#276 / #101-F）**
-  - Store listing の説明文に不正な `\u` 断片が含まれていても、正しい escape と package metadata を保持したまま既存 submission の status 確認を継続できるよう修正
-  - 合成 listing JSON を使った PowerShell 解析テストを CI に追加
+  - Store listing の説明文に JSON 仕様外の escape が含まれていても、正規の escape と package metadata を保持したまま既存 submission の status 確認を継続できるよう修正
+  - 合成 listing JSON を使った PowerShell 解析テストを CI に追加し、Store job が module を利用できるよう checkout を追加
 
 ## [0.7.2] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Microsoft Store submission の listing JSON 解析を堅牢化（#276 / #101-F）**
+  - Store listing の説明文に不正な `\u` 断片が含まれていても、正しい escape と package metadata を保持したまま既存 submission の status 確認を継続できるよう修正
+  - 合成 listing JSON を使った PowerShell 解析テストを CI に追加
+
 ## [0.7.2] - 2026-08-16
 
 ### Added

--- a/scripts/StoreSubmissionJson.psm1
+++ b/scripts/StoreSubmissionJson.psm1
@@ -3,14 +3,82 @@
     Microsoft Store submission JSON から公開判定に必要なメタデータを取得する。
 
 .DESCRIPTION
-    Store listing の説明文に不正な `\u` 断片が含まれる場合でも、JSON 全体を
-    解析できる形へ限定的に補正して Status と package 名を取得する。補正対象は
-    4 桁の hexadecimal ではない Unicode escape だけで、正しい escape と、
-    JSON 上の文字列としての `\\u` は変更しない。
+    Store listing の説明文に JSON 仕様外の escape が含まれる場合でも、JSON 全体を
+    解析できる形へ限定的に補正して Status と package 名を取得する。正規の JSON
+    escape と、JSON 上の文字列としての `\\u` は変更しない。
 #>
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+function Repair-InvalidJsonEscapes {
+    param(
+        [Parameter(Mandatory)]
+        [string]$JsonText
+    )
+
+    $builder = [System.Text.StringBuilder]::new($JsonText.Length)
+    $insideString = $false
+    $repairedInvalidEscapeCount = 0
+    $backslash = [char]0x5c
+
+    for ($index = 0; $index -lt $JsonText.Length; $index++) {
+        $current = $JsonText[$index]
+        if (-not $insideString) {
+            [void]$builder.Append($current)
+            if ($current -eq [char]0x22) {
+                $insideString = $true
+            }
+            continue
+        }
+
+        if ($current -eq [char]0x22) {
+            [void]$builder.Append($current)
+            $insideString = $false
+            continue
+        }
+
+        if ($current -ne $backslash) {
+            [void]$builder.Append($current)
+            continue
+        }
+
+        $nextIndex = $index + 1
+        if ($nextIndex -ge $JsonText.Length) {
+            [void]$builder.Append($backslash)
+            [void]$builder.Append($backslash)
+            $repairedInvalidEscapeCount++
+            continue
+        }
+
+        $next = $JsonText[$nextIndex]
+        if ([string]$next -in @('"', '\', '/', 'b', 'f', 'n', 'r', 't')) {
+            [void]$builder.Append($current)
+            [void]$builder.Append($next)
+            $index = $nextIndex
+            continue
+        }
+
+        if ($next -eq 'u' -and $nextIndex + 4 -lt $JsonText.Length) {
+            $unicodeDigits = $JsonText.Substring($nextIndex + 1, 4)
+            if ($unicodeDigits -match '^[0-9A-Fa-f]{4}$') {
+                [void]$builder.Append($current)
+                [void]$builder.Append($JsonText.Substring($nextIndex, 5))
+                $index = $nextIndex + 4
+                continue
+            }
+        }
+
+        [void]$builder.Append($backslash)
+        [void]$builder.Append($backslash)
+        $repairedInvalidEscapeCount++
+    }
+
+    return [pscustomobject]@{
+        JsonText                  = $builder.ToString()
+        RepairedInvalidEscapeCount = $repairedInvalidEscapeCount
+    }
+}
 
 function Read-StoreSubmissionMetadata {
     [CmdletBinding()]
@@ -34,11 +102,8 @@ function Read-StoreSubmissionMetadata {
         throw "既存 submission の JSON を CLI 出力から取得できませんでした。パス: $JsonPath"
     }
 
-    $invalidUnicodePattern = '(?<prefix>(?<!\\)(?:\\\\)*)\\u(?![0-9A-Fa-f]{4})'
-    $repairedInvalidUnicodeEscapeCount = [regex]::Matches($jsonText, $invalidUnicodePattern).Count
-    if ($repairedInvalidUnicodeEscapeCount -gt 0) {
-        $jsonText = [regex]::Replace($jsonText, $invalidUnicodePattern, '${prefix}\\u')
-    }
+    $repairedJson = Repair-InvalidJsonEscapes -JsonText $jsonText
+    $jsonText = $repairedJson.JsonText
 
     try {
         $submission = $jsonText | ConvertFrom-Json
@@ -70,7 +135,7 @@ function Read-StoreSubmissionMetadata {
     return [pscustomobject]@{
         Status                                  = [string]$statusProperty.Value
         PackageNames                            = $packageNames
-        RepairedInvalidUnicodeEscapeCount      = $repairedInvalidUnicodeEscapeCount
+        RepairedInvalidEscapeCount              = $repairedJson.RepairedInvalidEscapeCount
     }
 }
 

--- a/scripts/StoreSubmissionJson.psm1
+++ b/scripts/StoreSubmissionJson.psm1
@@ -1,0 +1,77 @@
+<#
+.SYNOPSIS
+    Microsoft Store submission JSON から公開判定に必要なメタデータを取得する。
+
+.DESCRIPTION
+    Store listing の説明文に不正な `\u` 断片が含まれる場合でも、JSON 全体を
+    解析できる形へ限定的に補正して Status と package 名を取得する。補正対象は
+    4 桁の hexadecimal ではない Unicode escape だけで、正しい escape と、
+    JSON 上の文字列としての `\\u` は変更しない。
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Read-StoreSubmissionMetadata {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$JsonPath
+    )
+
+    if (-not (Test-Path -LiteralPath $JsonPath -PathType Leaf)) {
+        throw "既存 submission の JSON 出力が見つかりません: $JsonPath"
+    }
+
+    try {
+        $jsonText = [System.IO.File]::ReadAllText((Resolve-Path -LiteralPath $JsonPath -ErrorAction Stop).Path)
+    } catch {
+        throw "既存 submission の JSON 出力を読み込めませんでした。パス: $JsonPath。$($_.Exception.Message)"
+    }
+
+    $jsonText = [regex]::Replace($jsonText, '\x1b\[[0-?]*[ -/]*[@-~]', '')
+    if ([string]::IsNullOrWhiteSpace($jsonText)) {
+        throw "既存 submission の JSON を CLI 出力から取得できませんでした。パス: $JsonPath"
+    }
+
+    $invalidUnicodePattern = '(?<prefix>(?<!\\)(?:\\\\)*)\\u(?![0-9A-Fa-f]{4})'
+    $repairedInvalidUnicodeEscapeCount = [regex]::Matches($jsonText, $invalidUnicodePattern).Count
+    if ($repairedInvalidUnicodeEscapeCount -gt 0) {
+        $jsonText = [regex]::Replace($jsonText, $invalidUnicodePattern, '${prefix}\\u')
+    }
+
+    try {
+        $submission = $jsonText | ConvertFrom-Json
+    } catch {
+        throw "既存 submission の JSON を解析できませんでした。パス: $JsonPath。$($_.Exception.Message)"
+    }
+
+    $statusProperty = $submission.PSObject.Properties['Status']
+    if ($null -eq $statusProperty -or [string]::IsNullOrWhiteSpace([string]$statusProperty.Value)) {
+        throw "既存 submission の JSON に Status がありません。パス: $JsonPath"
+    }
+
+    $packagesProperty = $submission.PSObject.Properties['ApplicationPackages']
+    if ($null -eq $packagesProperty) {
+        throw "既存 submission の JSON に ApplicationPackages がありません。パス: $JsonPath"
+    }
+
+    $packageNames = @(
+        $packagesProperty.Value |
+            Where-Object { $null -ne $_ } |
+            ForEach-Object {
+                $fileNameProperty = $_.PSObject.Properties['FileName']
+                if ($null -ne $fileNameProperty -and -not [string]::IsNullOrWhiteSpace([string]$fileNameProperty.Value)) {
+                    [string]$fileNameProperty.Value
+                }
+            }
+    )
+
+    return [pscustomobject]@{
+        Status                                  = [string]$statusProperty.Value
+        PackageNames                            = $packageNames
+        RepairedInvalidUnicodeEscapeCount      = $repairedInvalidUnicodeEscapeCount
+    }
+}
+
+Export-ModuleMember -Function Read-StoreSubmissionMetadata

--- a/scripts/Test-StoreSubmissionJson.ps1
+++ b/scripts/Test-StoreSubmissionJson.ps1
@@ -42,7 +42,7 @@ function Invoke-ParserTest {
         $metadata = Read-StoreSubmissionMetadata -JsonPath $temporaryFile.FullName
 
         Assert-Equal -Expected 'CommitStarted' -Actual $metadata.Status -Name "$Name / Status"
-        Assert-Equal -Expected $ExpectedRepairCount -Actual $metadata.RepairedInvalidUnicodeEscapeCount -Name "$Name / 補正件数"
+        Assert-Equal -Expected $ExpectedRepairCount -Actual $metadata.RepairedInvalidEscapeCount -Name "$Name / 補正件数"
         if ('CloudMigrator_0.7.2.0_x64.msix' -notin @($metadata.PackageNames)) {
             throw "テスト '$Name' が失敗しました。期待する package 名を取得できません。"
         }
@@ -92,6 +92,22 @@ Invoke-ParserTest -Name '正しい Unicode escape' -ExpectedRepairCount 0 -Json 
     "ja-jp": {
       "BaseListing": {
         "Description": "\u3042"
+      }
+    }
+  },
+  "ApplicationPackages": [
+    { "FileName": "CloudMigrator_0.7.2.0_x64.msix" }
+  ]
+}
+'@
+
+Invoke-ParserTest -Name 'その他の不正な escape' -ExpectedRepairCount 3 -Json @'
+{
+  "Status": "CommitStarted",
+  "Listings": {
+    "ja-jp": {
+      "BaseListing": {
+        "Description": "C:\store\app path\ file"
       }
     }
   },

--- a/scripts/Test-StoreSubmissionJson.ps1
+++ b/scripts/Test-StoreSubmissionJson.ps1
@@ -1,0 +1,104 @@
+<#
+.SYNOPSIS
+    Store submission JSON の許容的な解析を検証する。
+#>
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'StoreSubmissionJson.psm1') -Force
+
+function Assert-Equal {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Expected,
+        [Parameter(Mandatory)]
+        [object]$Actual,
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    if ($Expected -ne $Actual) {
+        throw "テスト '$Name' が失敗しました。期待値: '$Expected'、実際: '$Actual'"
+    }
+}
+
+function Invoke-ParserTest {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Json,
+        [Parameter(Mandatory)]
+        [int]$ExpectedRepairCount,
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    $temporaryFile = New-TemporaryFile
+    try {
+        Set-Content -LiteralPath $temporaryFile.FullName -Value $Json -Encoding utf8
+        $metadata = Read-StoreSubmissionMetadata -JsonPath $temporaryFile.FullName
+
+        Assert-Equal -Expected 'CommitStarted' -Actual $metadata.Status -Name "$Name / Status"
+        Assert-Equal -Expected $ExpectedRepairCount -Actual $metadata.RepairedInvalidUnicodeEscapeCount -Name "$Name / 補正件数"
+        if ('CloudMigrator_0.7.2.0_x64.msix' -notin @($metadata.PackageNames)) {
+            throw "テスト '$Name' が失敗しました。期待する package 名を取得できません。"
+        }
+    } finally {
+        if (Test-Path -LiteralPath $temporaryFile.FullName -PathType Leaf) {
+            Remove-Item -LiteralPath $temporaryFile.FullName -Force
+        }
+    }
+}
+
+Invoke-ParserTest -Name '不正な Unicode escape' -ExpectedRepairCount 1 -Json @'
+{
+  "Status": "CommitStarted",
+  "Listings": {
+    "ja-jp": {
+      "BaseListing": {
+        "Description": "literal \u 30"
+      }
+    }
+  },
+  "ApplicationPackages": [
+    { "FileName": "CloudMigrator_0.7.2.0_x64.msix" }
+  ]
+}
+'@
+
+Invoke-ParserTest -Name '文字列中の literal escape' -ExpectedRepairCount 0 -Json @'
+{
+  "Status": "CommitStarted",
+  "Listings": {
+    "ja-jp": {
+      "BaseListing": {
+        "Description": "literal \\u 30"
+      }
+    }
+  },
+  "ApplicationPackages": [
+    { "FileName": "CloudMigrator_0.7.2.0_x64.msix" }
+  ]
+}
+'@
+
+Invoke-ParserTest -Name '正しい Unicode escape' -ExpectedRepairCount 0 -Json @'
+{
+  "Status": "CommitStarted",
+  "Listings": {
+    "ja-jp": {
+      "BaseListing": {
+        "Description": "\u3042"
+      }
+    }
+  },
+  "ApplicationPackages": [
+    { "FileName": "CloudMigrator_0.7.2.0_x64.msix" }
+  ]
+}
+'@
+
+Write-Host 'Store submission JSON の解析テストが成功しました。'


### PR DESCRIPTION
## 概要

Microsoft Store 自動公開の既存 submission 確認で、listing description に含まれる不正な \u 断片を PowerShell の ConvertFrom-Json が解析できず workflow が停止する問題を修正します。

## 原因

リリース workflow 31942723548 で、msstore submission get は成功したものの、Listings.ja-jp.BaseListing.Description 内の不正な Unicode escape により submission 全体の JSON 解析が失敗しました。

## 変更内容

- Store submission JSON の読み込み・ANSI 除去・不正な Unicode escape の限定補正・metadata 抽出を module 化
- 正しい \u escape と JSON 文字列中の literal \\u は変更しない
- Status と ApplicationPackages.FileName を従来どおり検証
- 不正な escape の補正件数を workflow summary に記録
- 失敗形、literal escape、正しい Unicode escape の PowerShell 回帰テストを CI に追加
- CHANGELOG.md の Unreleased に記録

## 検証

- pwsh -NoProfile -File .\scripts\Test-StoreSubmissionJson.ps1
- git diff --cached --check
- commit hook 完了
- 既存の Store secrets / runner は変更しません

関連: #276