### PR TITLE
[#284] GitHub-hosted runner WACK Spike を追加

### DIFF
--- a/.github/workflows/wack-hosted-spike.yml
+++ b/.github/workflows/wack-hosted-spike.yml
@@ -192,6 +192,19 @@ jobs:
           if ($null -ne $appCertPath) {
             $appCertVersion = (Get-Item -LiteralPath $appCertPath).VersionInfo.FileVersion
           }
+          $appCertSetup = if ($null -eq $appCertPath) {
+            [ordered]@{
+              attempted = $false
+              status = "not-attempted"
+              reason = "再現可能な Windows SDK/AppCertKit 導入手順をこの Spike では試していないため、self-hosted 判定を保留します。"
+            }
+          } else {
+            [ordered]@{
+              attempted = $false
+              status = "not-required"
+              reason = "Hosted image 上の appcert.exe を検出しました。"
+            }
+          }
           $status = if ($null -eq $appCertPath) {
             "appcert-missing"
           } elseif (-not $isInteractive) {
@@ -218,6 +231,7 @@ jobs:
             appCertCandidates = @($candidates | Select-Object -Unique)
             appCertPath = $appCertPath
             appCertVersion = $appCertVersion
+            appCertSetup = $appCertSetup
             status = $status
             recordedAtUtc = [DateTime]::UtcNow.ToString("O")
           }
@@ -228,6 +242,7 @@ jobs:
 
           $appCertFound = ($null -ne $appCertPath).ToString().ToLowerInvariant()
           "appcert_found=$appCertFound" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "appcert_setup_status=$($appCertSetup.status)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           if ($null -ne $appCertPath) {
             "appcert_path=$appCertPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           }
@@ -270,7 +285,20 @@ jobs:
           CAPABILITY_OUTCOME: ${{ steps.capability.outcome }}
           WACK_OUTCOME: ${{ steps.wack.outcome }}
           APPCERT_FOUND: ${{ steps.capability.outputs.appcert_found }}
+          APPCERT_SETUP_STATUS: ${{ steps.capability.outputs.appcert_setup_status }}
         run: |
+          $evidenceDirectory = Join-Path $env:GITHUB_WORKSPACE "spike-evidence"
+          New-Item -ItemType Directory -Force -Path $evidenceDirectory | Out-Null
+          $wackResultPath = Join-Path $evidenceDirectory "wack-reports/hosted-wack-result.json"
+          $wackResult = $null
+          if (Test-Path -LiteralPath $wackResultPath -PathType Leaf) {
+            try {
+              $wackResult = Get-Content -LiteralPath $wackResultPath -Raw | ConvertFrom-Json
+            } catch {
+              $wackResult = $null
+            }
+          }
+
           if ($env:SOURCE_OUTCOME -ne "success" -or $env:INTEGRITY_OUTCOME -ne "success") {
             $classification = "source-artifact-verification-failed"
             $reason = "対象 release run または同一 artifact の検証に失敗しました。"
@@ -278,14 +306,20 @@ jobs:
             $classification = "capability-recording-failed"
             $reason = "Hosted runner の OS、権限、または App Certification Kit の能力記録に失敗しました。"
           } elseif ($env:APPCERT_FOUND -ne "true") {
-            $classification = "self-hosted-required"
-            $reason = "Hosted runner に appcert.exe がありません。"
+            $classification = "appcert-setup-unverified"
+            $reason = "Hosted runner に appcert.exe がなく、再現可能な AppCertKit 導入を試していないため判定を保留します。"
           } elseif ($env:WACK_OUTCOME -eq "success") {
             $classification = "hosted-candidate"
             $reason = "同一 MSIX artifact の WACK と Required failure 判定が Hosted runner で完了しました。"
+          } elseif ($null -ne $wackResult -and $wackResult.classification -eq "package-failure") {
+            $classification = "package-failure"
+            $reason = "WACK レポート生成後の Required/Optional 判定で package failure が検出されました。Hosted runner 能力不足とは分類しません。"
+          } elseif ($null -ne $wackResult -and $wackResult.classification -eq "wack-execution-failed") {
+            $classification = "wack-execution-failed"
+            $reason = "appcert.exe は検出されましたが、WACK またはレポート生成が完了しませんでした。"
           } else {
-            $classification = "self-hosted-required"
-            $reason = "appcert.exe は検出されましたが、Hosted runner 上の WACK が完了しませんでした。"
+            $classification = "wack-result-unavailable"
+            $reason = "Hosted WACK wrapper の構造化された実行結果を取得できませんでした。"
           }
 
           $result = [ordered]@{
@@ -297,10 +331,13 @@ jobs:
             capabilityOutcome = $env:CAPABILITY_OUTCOME
             wackOutcome = $env:WACK_OUTCOME
             appCertFound = $env:APPCERT_FOUND -eq "true"
+            appCertSetupStatus = $env:APPCERT_SETUP_STATUS
+            wackResultClassification = if ($null -eq $wackResult) { $null } else { [string]$wackResult.classification }
+            wackFailureStage = if ($null -eq $wackResult) { $null } else { [string]$wackResult.wackStage }
             recordedAtUtc = [DateTime]::UtcNow.ToString("O")
           }
           [IO.File]::WriteAllText(
-            (Join-Path $env:GITHUB_WORKSPACE "spike-evidence/spike-result.json"),
+            (Join-Path $evidenceDirectory "spike-result.json"),
             ($result | ConvertTo-Json -Depth 6),
             [Text.UTF8Encoding]::new($false))
 

--- a/.github/workflows/wack-hosted-spike.yml
+++ b/.github/workflows/wack-hosted-spike.yml
@@ -1,0 +1,328 @@
+name: WACK Hosted Runner Spike
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_run_id:
+        description: "MSIX artifact を生成した release workflow の run ID"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: wack-hosted-spike-${{ inputs.release_run_id }}
+  cancel-in-progress: false
+
+jobs:
+  hosted-wack-spike:
+    name: WACK（GitHub-hosted / Windows）Spike
+    runs-on: windows-latest
+    env:
+      LEFTHOOK: 0
+
+    steps:
+      - name: リポジトリを checkout
+        uses: actions/checkout@v7
+
+      - name: release run と artifact の対象を検証
+        id: source
+        shell: pwsh
+        env:
+          RELEASE_RUN_ID: ${{ inputs.release_run_id }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $releaseRunId = $env:RELEASE_RUN_ID.Trim()
+          if ($releaseRunId -notmatch '^\d+$') {
+            throw "release run ID は数字で指定してください: $releaseRunId"
+          }
+
+          $runJson = gh api "repos/$env:GITHUB_REPOSITORY/actions/runs/$releaseRunId"
+          if ($LASTEXITCODE -ne 0) {
+            throw "release run のメタデータ取得に失敗しました: $releaseRunId"
+          }
+          $run = $runJson | ConvertFrom-Json
+
+          if ($run.status -ne "completed" -or $run.conclusion -ne "success") {
+            throw "対象 release run は成功済みである必要があります。status=$($run.status), conclusion=$($run.conclusion)"
+          }
+          if ($run.path -notmatch "(^|/)release\.yml$") {
+            throw "対象 run は release.yml である必要があります: $($run.path)"
+          }
+          if ($run.event -ne "push") {
+            throw "対象 release run は tag push である必要があります: event=$($run.event)"
+          }
+          if ([string]::IsNullOrWhiteSpace($run.head_sha) -or
+              [string]::IsNullOrWhiteSpace($run.head_branch) -or
+              $run.head_branch -notmatch '^v\d+\.\d+\.\d+(?:\.\d+)?(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$') {
+            throw "対象 run は v* tag push である必要があります。ref=$($run.head_branch), sha=$($run.head_sha)"
+          }
+
+          $artifactName = "msix-release-$releaseRunId"
+          $metadata = [ordered]@{
+            schemaVersion = 1
+            sourceRunId = [int64]$releaseRunId
+            workflowPath = $run.path
+            status = $run.status
+            conclusion = $run.conclusion
+            event = $run.event
+            tag = $run.head_branch
+            commit = $run.head_sha
+            artifactName = $artifactName
+            recordedAtUtc = [DateTime]::UtcNow.ToString("O")
+          }
+          New-Item -ItemType Directory -Force -Path "spike-evidence" | Out-Null
+          [IO.File]::WriteAllText(
+            (Join-Path $env:GITHUB_WORKSPACE "spike-evidence/source-run.json"),
+            ($metadata | ConvertTo-Json -Depth 6),
+            [Text.UTF8Encoding]::new($false))
+
+          "artifact_name=$artifactName" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "source_head_sha=$($run.head_sha)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "source_tag=$($run.head_branch)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: release artifact を取得
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ steps.source.outputs.artifact_name }}
+          path: wack-input
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.release_run_id }}
+
+      - name: MSIX artifact の SHA-256 と証跡を照合
+        id: integrity
+        shell: pwsh
+        env:
+          RELEASE_RUN_ID: ${{ inputs.release_run_id }}
+          SOURCE_HEAD_SHA: ${{ steps.source.outputs.source_head_sha }}
+          SOURCE_TAG: ${{ steps.source.outputs.source_tag }}
+        run: |
+          $inputDirectory = Join-Path $env:GITHUB_WORKSPACE "wack-input"
+          $packages = @(Get-ChildItem -LiteralPath $inputDirectory -File -Filter "*.msix")
+          $uploads = @(Get-ChildItem -LiteralPath $inputDirectory -File -Filter "*.msixupload")
+          $evidencePath = Join-Path $inputDirectory "msix-artifact-evidence.json"
+
+          if ($packages.Count -ne 1 -or $uploads.Count -ne 1) {
+            throw "release artifact は .msix と .msixupload を各 1 個含む必要があります。msix=$($packages.Count), msixupload=$($uploads.Count)"
+          }
+          if (-not (Test-Path -LiteralPath $evidencePath -PathType Leaf)) {
+            throw "MSIX artifact の SHA-256 証跡が見つかりません: $evidencePath"
+          }
+
+          $evidence = Get-Content -LiteralPath $evidencePath -Raw | ConvertFrom-Json
+          $packageHash = (Get-FileHash -LiteralPath $packages[0].FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+          $uploadHash = (Get-FileHash -LiteralPath $uploads[0].FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+          $expectedPackageFile = [string]$evidence.packageFile
+          $expectedUploadFile = [string]$evidence.uploadFile
+          $expectedPackageHash = ([string]$evidence.packageSha256).ToLowerInvariant()
+          $expectedUploadHash = ([string]$evidence.uploadSha256).ToLowerInvariant()
+
+          $checks = [ordered]@{
+            schemaVersion = 1
+            sourceRunId = [int64]$env:RELEASE_RUN_ID
+            sourceTag = $env:SOURCE_TAG
+            sourceCommit = $env:SOURCE_HEAD_SHA
+            evidenceTag = [string]$evidence.tag
+            evidenceCommit = [string]$evidence.commit
+            packageFile = $packages[0].Name
+            evidencePackageFile = $expectedPackageFile
+            packageSha256 = $packageHash
+            evidencePackageSha256 = $expectedPackageHash
+            uploadFile = $uploads[0].Name
+            evidenceUploadFile = $expectedUploadFile
+            uploadSha256 = $uploadHash
+            evidenceUploadSha256 = $expectedUploadHash
+            verifiedAtUtc = [DateTime]::UtcNow.ToString("O")
+          }
+
+          if ([string]$evidence.tag -ne $env:SOURCE_TAG -or
+              [string]$evidence.commit -ne $env:SOURCE_HEAD_SHA -or
+              $packages[0].Name -ne $expectedPackageFile -or
+              $uploads[0].Name -ne $expectedUploadFile -or
+              $packageHash -ne $expectedPackageHash -or
+              $uploadHash -ne $expectedUploadHash) {
+            [IO.File]::WriteAllText(
+              (Join-Path $env:GITHUB_WORKSPACE "spike-evidence/artifact-integrity.json"),
+              ($checks | ConvertTo-Json -Depth 6),
+              [Text.UTF8Encoding]::new($false))
+            throw "release artifact の tag、commit、または SHA-256 が証跡と一致しません。"
+          }
+
+          [IO.File]::WriteAllText(
+            (Join-Path $env:GITHUB_WORKSPACE "spike-evidence/artifact-integrity.json"),
+            ($checks | ConvertTo-Json -Depth 6),
+            [Text.UTF8Encoding]::new($false))
+          "package_name=$($packages[0].Name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Hosted runner の能力を記録
+        id: capability
+        shell: pwsh
+        run: |
+          $os = Get-CimInstance Win32_OperatingSystem |
+            Select-Object Caption, Version, BuildNumber, OSArchitecture, LastBootUpTime
+          $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+          $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+          $isAdministrator = $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+          $isInteractive = [Environment]::UserInteractive
+
+          $candidates = @()
+          if (-not [string]::IsNullOrWhiteSpace(${env:ProgramFiles(x86)})) {
+            $candidates += Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\App Certification Kit\appcert.exe"
+          }
+          if (-not [string]::IsNullOrWhiteSpace($env:ProgramFiles)) {
+            $candidates += Join-Path $env:ProgramFiles "Windows Kits\10\App Certification Kit\appcert.exe"
+          }
+          $command = Get-Command appcert.exe -ErrorAction SilentlyContinue
+          if ($null -ne $command -and -not [string]::IsNullOrWhiteSpace($command.Source)) {
+            $candidates += $command.Source
+          }
+
+          $appCertPath = $null
+          foreach ($candidate in ($candidates | Select-Object -Unique)) {
+            if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+              $appCertPath = (Resolve-Path -LiteralPath $candidate).Path
+              break
+            }
+          }
+
+          $appCertVersion = $null
+          if ($null -ne $appCertPath) {
+            $appCertVersion = (Get-Item -LiteralPath $appCertPath).VersionInfo.FileVersion
+          }
+          $status = if ($null -eq $appCertPath) {
+            "appcert-missing"
+          } elseif (-not $isInteractive) {
+            "non-interactive"
+          } elseif (-not $isAdministrator) {
+            "not-administrator"
+          } else {
+            "ready-for-direct-test"
+          }
+
+          $capability = [ordered]@{
+            schemaVersion = 1
+            runner = [ordered]@{
+              os = $env:RUNNER_OS
+              arch = $env:RUNNER_ARCH
+              imageOS = $env:ImageOS
+              imageVersion = $env:ImageVersion
+              imageRelease = $env:ImageRelease
+            }
+            operatingSystem = $os
+            identity = $identity.Name
+            userInteractive = $isInteractive
+            isAdministrator = $isAdministrator
+            appCertCandidates = @($candidates | Select-Object -Unique)
+            appCertPath = $appCertPath
+            appCertVersion = $appCertVersion
+            status = $status
+            recordedAtUtc = [DateTime]::UtcNow.ToString("O")
+          }
+          [IO.File]::WriteAllText(
+            (Join-Path $env:GITHUB_WORKSPACE "spike-evidence/hosted-capability.json"),
+            ($capability | ConvertTo-Json -Depth 8),
+            [Text.UTF8Encoding]::new($false))
+
+          $appCertFound = ($null -ne $appCertPath).ToString().ToLowerInvariant()
+          "appcert_found=$appCertFound" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          if ($null -ne $appCertPath) {
+            "appcert_path=$appCertPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          }
+
+          @(
+            "### Hosted runner capability"
+            "- OS: $($os.Caption) $($os.Version) (build $($os.BuildNumber))"
+            "- Image: $($env:ImageOS) / $($env:ImageVersion)"
+            "- UserInteractive: $isInteractive"
+            "- Administrator: $isAdministrator"
+            "- appcert.exe: $status"
+          ) | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+
+      - name: WACK を直接実行（Spike 専用 wrapper）
+        id: wack
+        if: ${{ steps.capability.outputs.appcert_found == 'true' }}
+        shell: pwsh
+        env:
+          APPCERT_PATH: ${{ steps.capability.outputs.appcert_path }}
+          PACKAGE_NAME: ${{ steps.integrity.outputs.package_name }}
+        run: |
+          $packagePath = Join-Path $env:GITHUB_WORKSPACE "wack-input\$env:PACKAGE_NAME"
+          $reportDirectory = Join-Path $env:GITHUB_WORKSPACE "spike-evidence\wack-reports"
+          $workDirectory = Join-Path $env:GITHUB_WORKSPACE "spike-evidence\wack-work"
+          & pwsh -NoProfile -ExecutionPolicy Bypass -File .\scripts\run-wack-hosted-spike.ps1 `
+            -PackagePath $packagePath `
+            -AppCertPath $env:APPCERT_PATH `
+            -ReportDirectory $reportDirectory `
+            -WorkDirectory $workDirectory
+          if ($LASTEXITCODE -ne 0) {
+            throw "Hosted runner 上の WACK 実行に失敗しました（exit=$LASTEXITCODE）。"
+          }
+
+      - name: Spike の判定を記録
+        if: always()
+        shell: pwsh
+        env:
+          SOURCE_OUTCOME: ${{ steps.source.outcome }}
+          INTEGRITY_OUTCOME: ${{ steps.integrity.outcome }}
+          CAPABILITY_OUTCOME: ${{ steps.capability.outcome }}
+          WACK_OUTCOME: ${{ steps.wack.outcome }}
+          APPCERT_FOUND: ${{ steps.capability.outputs.appcert_found }}
+        run: |
+          if ($env:SOURCE_OUTCOME -ne "success" -or $env:INTEGRITY_OUTCOME -ne "success") {
+            $classification = "source-artifact-verification-failed"
+            $reason = "対象 release run または同一 artifact の検証に失敗しました。"
+          } elseif ($env:CAPABILITY_OUTCOME -ne "success") {
+            $classification = "capability-recording-failed"
+            $reason = "Hosted runner の OS、権限、または App Certification Kit の能力記録に失敗しました。"
+          } elseif ($env:APPCERT_FOUND -ne "true") {
+            $classification = "self-hosted-required"
+            $reason = "Hosted runner に appcert.exe がありません。"
+          } elseif ($env:WACK_OUTCOME -eq "success") {
+            $classification = "hosted-candidate"
+            $reason = "同一 MSIX artifact の WACK と Required failure 判定が Hosted runner で完了しました。"
+          } else {
+            $classification = "self-hosted-required"
+            $reason = "appcert.exe は検出されましたが、Hosted runner 上の WACK が完了しませんでした。"
+          }
+
+          $result = [ordered]@{
+            schemaVersion = 1
+            classification = $classification
+            reason = $reason
+            sourceOutcome = $env:SOURCE_OUTCOME
+            integrityOutcome = $env:INTEGRITY_OUTCOME
+            capabilityOutcome = $env:CAPABILITY_OUTCOME
+            wackOutcome = $env:WACK_OUTCOME
+            appCertFound = $env:APPCERT_FOUND -eq "true"
+            recordedAtUtc = [DateTime]::UtcNow.ToString("O")
+          }
+          [IO.File]::WriteAllText(
+            (Join-Path $env:GITHUB_WORKSPACE "spike-evidence/spike-result.json"),
+            ($result | ConvertTo-Json -Depth 6),
+            [Text.UTF8Encoding]::new($false))
+
+          @(
+            "### Spike result"
+            "- 判定: **$classification**"
+            "- 理由: $reason"
+            "- release artifact integrity: $($env:INTEGRITY_OUTCOME)"
+            "- WACK execution: $($env:WACK_OUTCOME)"
+          ) | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+
+          if ($classification -ne "hosted-candidate") {
+            throw "WACK Hosted Runner Spike の判定: $classification。$reason"
+          }
+
+      - name: Spike 証跡を artifact に保存
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: wack-hosted-spike-${{ github.run_id }}
+          path: |
+            spike-evidence/
+            wack-input/
+          if-no-files-found: warn
+          retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **GitHub-hosted runner 上の WACK 実行可否を検証する手動 Spike を追加（#284 / #101-G）**
   - 成功済み `release.yml` の同一 MSIX artifact を取得し、tag、commit、ファイル名、SHA-256 を照合してから `windows-latest` で検証できるようにした
   - Hosted runner の OS、image、対話セッション、管理者権限、`appcert.exe` の状態と、WACK XML／HTML／TAEF／AppCertKit ログを証跡として保存する
+  - AppCertKit 導入未検証、WACK 実行失敗、package 判定失敗を分離し、入力検証が早期失敗した場合も Spike 結果を保存する
   - 本番の `release.yml`、`wack.yml`、Store 公開 gate は変更しない
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- **GitHub-hosted runner 上の WACK 実行可否を検証する手動 Spike を追加（#284 / #101-G）**
+  - 成功済み `release.yml` の同一 MSIX artifact を取得し、tag、commit、ファイル名、SHA-256 を照合してから `windows-latest` で検証できるようにした
+  - Hosted runner の OS、image、対話セッション、管理者権限、`appcert.exe` の状態と、WACK XML／HTML／TAEF／AppCertKit ログを証跡として保存する
+  - 本番の `release.yml`、`wack.yml`、Store 公開 gate は変更しない
+
 ### Fixed
 
 - **Microsoft Store submission の listing JSON 解析を堅牢化（#276 / #101-F）**

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,3 +119,5 @@ v* tag push
 - GitHub Release の公開完了は Store 公開完了を意味しません。WACK と Store の job 結果、artifact 証跡、submission status を別々に確認します。
 
 Environment の初期設定と中断・再実行を含む詳細手順は、[MSIX パッケージング・WACK 検査・Microsoft Store 提出ガイド](msix-packaging-and-store-guide.md)の [Store 自動公開と初期設定](msix-packaging-and-store-guide.md#84-store-自動公開と初期設定-276) に集約します。
+
+self-hosted WACK runner を GitHub-hosted runner へ移行できるかは、本番 gate と分離した [GitHub-hosted WACK Spike 手順](wack-hosted-runner-spike.md)で検証します。Spike が成功するまで、リリースフローの WACK runner は self-hosted のままです。

--- a/docs/wack-hosted-runner-spike.md
+++ b/docs/wack-hosted-runner-spike.md
@@ -14,16 +14,18 @@
 3. workflow が `msix-release-<run_id>` artifact を別 run から取得する。
 4. Hosted runner の OS／image、対話セッション、管理者権限、`appcert.exe` の有無とバージョンを記録する。
 5. `.msix`、`.msixupload`、SHA-256 証跡 JSON の tag／commit／ハッシュを照合する。
-6. `appcert.exe` が見つかった場合だけ、Spike 専用 wrapper で WACK と `AnalyzeWackReport.ps1 -FailOnRequiredFailure` を実行する。
+6. `appcert.exe` が見つかった場合だけ、Spike 専用 wrapper で WACK と `AnalyzeWackReport.ps1 -FailOnRequiredFailure` を実行する。見つからない場合は AppCertKit の導入を試さず、導入可否未検証として判定を保留する。
 
 ## 判定
 
 | workflow 結果 | 判定 |
 |---|---|
 | 成功（`hosted-candidate`） | Hosted 移行候補。別 PR で本番 workflow と運用手順を変更する |
-| 失敗・`self-hosted-required`（能力 status が `appcert-missing`） | Hosted runner に Kit がなく、self-hosted 継続 |
+| 失敗・`appcert-setup-unverified` | Hosted runner に Kit がなく、再現可能な導入を試していないため判定保留 |
 | 失敗・`capability-recording-failed` | Hosted runner の能力記録に失敗したため判定保留 |
-| 失敗・WACK 実行エラー | OS、セッション、権限、Kit、package 結果を確認し、self-hosted 継続または追加検証 |
+| 失敗・`package-failure` | WACK レポート生成後の package 判定失敗。Hosted runner 能力不足とは分離して package を調査 |
+| 失敗・`wack-execution-failed` | WACK またはレポート生成が未完了。OS、セッション、権限、Kit を調査 |
+| 失敗・`wack-result-unavailable` | wrapper の構造化結果がないため判定保留 |
 | artifact 検証失敗 | 同一 artifact の条件を満たさないため判定保留 |
 
 成功しても、WACK の実行成功は Microsoft Store の認定・公開成功とは別の状態です。
@@ -34,9 +36,9 @@
 
 - `source-run.json`: 対象 release run と tag／commit
 - `artifact-integrity.json`: `.msix` / `.msixupload` の SHA-256 照合結果
-- `hosted-capability.json`: Hosted runner の OS、image、対話セッション、管理者権限、`appcert.exe`
+- `hosted-capability.json`: Hosted runner の OS、image、対話セッション、管理者権限、`appcert.exe`、AppCertKit 導入試行状態
 - `spike-result.json`: Spike の判定
-- `wack-reports/`: WACK XML／HTML／コマンド出力
+- `wack-reports/`: WACK XML／HTML／コマンド出力／wrapper の構造化結果
 - `wack-work/`: 隔離した TAEF／AppCertKit ログ
 
 ## スコープ境界

--- a/docs/wack-hosted-runner-spike.md
+++ b/docs/wack-hosted-runner-spike.md
@@ -1,0 +1,46 @@
+# GitHub-hosted WACK Spike（#284）
+
+## 目的
+
+現行の release gate は、`self-hosted / windows / wack` runner 上で Windows App Certification Kit（WACK）を実行しています。本 Spike は、同じ release MSIX artifact を `windows-latest` で WACK に渡せるかを検証し、self-hosted runner 廃止の可否を判断するためのものです。
+
+本番の `release.yml`、`wack.yml`、`scripts/run-wack-test.ps1` の gate は変更しません。Microsoft Store への提出も行いません。
+
+## 実行手順
+
+1. GitHub Actions の **WACK Hosted Runner Spike** を開く。
+2. **Run workflow** で `release_run_id` に、検証対象の成功済み `release.yml` run ID を指定する。
+   - 例: `31944768934`
+3. workflow が `msix-release-<run_id>` artifact を別 run から取得する。
+4. Hosted runner の OS／image、対話セッション、管理者権限、`appcert.exe` の有無とバージョンを記録する。
+5. `.msix`、`.msixupload`、SHA-256 証跡 JSON の tag／commit／ハッシュを照合する。
+6. `appcert.exe` が見つかった場合だけ、Spike 専用 wrapper で WACK と `AnalyzeWackReport.ps1 -FailOnRequiredFailure` を実行する。
+
+## 判定
+
+| workflow 結果 | 判定 |
+|---|---|
+| 成功（`hosted-candidate`） | Hosted 移行候補。別 PR で本番 workflow と運用手順を変更する |
+| 失敗・`self-hosted-required`（能力 status が `appcert-missing`） | Hosted runner に Kit がなく、self-hosted 継続 |
+| 失敗・`capability-recording-failed` | Hosted runner の能力記録に失敗したため判定保留 |
+| 失敗・WACK 実行エラー | OS、セッション、権限、Kit、package 結果を確認し、self-hosted 継続または追加検証 |
+| artifact 検証失敗 | 同一 artifact の条件を満たさないため判定保留 |
+
+成功しても、WACK の実行成功は Microsoft Store の認定・公開成功とは別の状態です。
+
+## 証跡
+
+`wack-hosted-spike-<run_id>` artifact に次を保存します。
+
+- `source-run.json`: 対象 release run と tag／commit
+- `artifact-integrity.json`: `.msix` / `.msixupload` の SHA-256 照合結果
+- `hosted-capability.json`: Hosted runner の OS、image、対話セッション、管理者権限、`appcert.exe`
+- `spike-result.json`: Spike の判定
+- `wack-reports/`: WACK XML／HTML／コマンド出力
+- `wack-work/`: 隔離した TAEF／AppCertKit ログ
+
+## スコープ境界
+
+- 本番 WACK gate の runner 変更は別 PR で行う。
+- `UserInteractive`、管理者権限、WACK script の guard は本番スクリプトから削除しない。
+- Store submission、認定、公開完了の検証は対象外とする。

--- a/scripts/run-wack-hosted-spike.ps1
+++ b/scripts/run-wack-hosted-spike.ps1
@@ -1,0 +1,318 @@
+<#
+.SYNOPSIS
+    GitHub-hosted runner 上で WACK 本体の実行可否を検証する Spike 専用 wrapper。
+
+.DESCRIPTION
+    本番用 run-wack-test.ps1 の UserInteractive / 管理者権限ガードや UAC 昇格を
+    変更せず、appcert.exe の直接実行と既存の AnalyzeWackReport.ps1 による判定だけを
+    検証する。実験用の環境変数と AppCertKit 作業領域は指定した WorkDirectory に隔離する。
+
+    本番の release.yml / wack.yml からは呼び出さない。Microsoft Store への提出も行わない。
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$PackagePath,
+    [Parameter(Mandatory)]
+    [string]$AppCertPath,
+    [Parameter(Mandatory)]
+    [string]$ReportDirectory,
+    [Parameter(Mandatory)]
+    [string]$WorkDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$environmentNames = @(
+    "TEMP",
+    "TMP",
+    "USERPROFILE",
+    "LOCALAPPDATA",
+    "APPDATA",
+    "HOMEDRIVE",
+    "HOMEPATH",
+    "TAEF_LOG_DIR",
+    "TAEF_LOG_ROOT",
+    "TAEF_LOG_PATH"
+)
+$originalEnvironment = @{}
+$environmentIsolationApplied = $false
+
+function Resolve-InputPath {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return [System.IO.Path]::GetFullPath($Path)
+    }
+
+    return [System.IO.Path]::GetFullPath((Join-Path $repositoryRoot $Path))
+}
+
+function Resolve-ExistingFile {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [Parameter(Mandatory)]
+        [string]$Description
+    )
+
+    $resolvedPath = Resolve-InputPath $Path
+    if (-not (Test-Path -LiteralPath $resolvedPath -PathType Leaf)) {
+        throw "$Description が見つかりません: $resolvedPath"
+    }
+
+    return (Resolve-Path -LiteralPath $resolvedPath).Path
+}
+
+function Get-PwshExecutable {
+    $currentPwsh = Join-Path $PSHOME "pwsh.exe"
+    if (Test-Path -LiteralPath $currentPwsh -PathType Leaf) {
+        return (Resolve-Path -LiteralPath $currentPwsh).Path
+    }
+
+    $pwshCommand = Get-Command pwsh.exe -ErrorAction SilentlyContinue
+    if ($null -ne $pwshCommand -and -not [string]::IsNullOrWhiteSpace($pwshCommand.Source)) {
+        return (Resolve-Path -LiteralPath $pwshCommand.Source).Path
+    }
+
+    throw "WACK のレポート解析に使用する pwsh.exe が見つかりません。"
+}
+
+function Set-IsolatedEnvironment {
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]$Values,
+        [Parameter(Mandatory)]
+        [string[]]$Directories
+    )
+
+    foreach ($directory in $Directories) {
+        New-Item -ItemType Directory -Force -Path $directory | Out-Null
+    }
+
+    foreach ($name in $environmentNames) {
+        $originalEnvironment[$name] = [Environment]::GetEnvironmentVariable(
+            $name,
+            [EnvironmentVariableTarget]::Process
+        )
+        [Environment]::SetEnvironmentVariable(
+            $name,
+            [string]$Values[$name],
+            [EnvironmentVariableTarget]::Process
+        )
+    }
+
+    $script:environmentIsolationApplied = $true
+}
+
+function Restore-Environment {
+    if (-not $script:environmentIsolationApplied) {
+        return
+    }
+
+    foreach ($name in $environmentNames) {
+        [Environment]::SetEnvironmentVariable(
+            $name,
+            $originalEnvironment[$name],
+            [EnvironmentVariableTarget]::Process
+        )
+    }
+
+    $script:environmentIsolationApplied = $false
+}
+
+function Invoke-AppCert {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$Arguments
+    )
+
+    $output = @(& $appCertFullPath @Arguments 2>&1)
+    [pscustomobject]@{
+        ExitCode = $LASTEXITCODE
+        Output = @($output | ForEach-Object { $_.ToString() })
+    }
+}
+
+function Write-CommandLog {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name,
+        [Parameter(Mandatory)]
+        [int]$ExitCode,
+        [Parameter(Mandatory)]
+        [string[]]$Output
+    )
+
+    $lines = @(
+        "[$([DateTime]::UtcNow.ToString('O'))] $Name exit=$ExitCode"
+    ) + $Output
+    Add-Content -LiteralPath $commandLogPath -Value $lines
+}
+
+$packageFullPath = Resolve-ExistingFile $PackagePath "検証対象パッケージ"
+$appCertFullPath = Resolve-ExistingFile $AppCertPath "appcert.exe"
+$reportDirectoryFullPath = Resolve-InputPath $ReportDirectory
+$workDirectoryFullPath = Resolve-InputPath $WorkDirectory
+
+if ([System.IO.Path]::GetExtension($packageFullPath).ToLowerInvariant() -ne ".msix") {
+    throw "Hosted runner Spike の検証対象は .msix である必要があります: $packageFullPath"
+}
+
+New-Item -ItemType Directory -Force -Path $reportDirectoryFullPath | Out-Null
+New-Item -ItemType Directory -Force -Path $workDirectoryFullPath | Out-Null
+$commandLogPath = Join-Path $reportDirectoryFullPath "appcert-command-output.log"
+$packageName = [System.IO.Path]::GetFileNameWithoutExtension($packageFullPath)
+$timestamp = (Get-Date).ToUniversalTime().ToString("yyyyMMdd-HHmmssfff")
+$reportPath = Join-Path $reportDirectoryFullPath "$packageName-$timestamp.xml"
+$reportBaseName = [System.IO.Path]::GetFileNameWithoutExtension($reportPath)
+$packageHash = (Get-FileHash -LiteralPath $packageFullPath -Algorithm SHA256).Hash.ToLowerInvariant()
+
+$wackProfile = Join-Path $workDirectoryFullPath "profile"
+$wackLocalAppData = Join-Path $wackProfile "AppData\Local"
+$wackRoamingAppData = Join-Path $wackProfile "AppData\Roaming"
+$wackTemp = Join-Path $wackLocalAppData "Temp"
+$wackLogs = Join-Path $workDirectoryFullPath "logs"
+$wackAppCertDirectory = Join-Path $wackLocalAppData "Microsoft\AppCertKit"
+$appVerifierLogs = Join-Path $wackLocalAppData "AppVerifierLogs"
+
+$wackEnvironment = @{
+    TEMP = $wackTemp
+    TMP = $wackTemp
+    USERPROFILE = $wackProfile
+    LOCALAPPDATA = $wackLocalAppData
+    APPDATA = $wackRoamingAppData
+    HOMEDRIVE = Split-Path $wackProfile -Qualifier
+    HOMEPATH = $wackProfile.Substring((Split-Path $wackProfile -Qualifier).Length)
+    TAEF_LOG_DIR = $wackLogs
+    TAEF_LOG_ROOT = $wackLogs
+    TAEF_LOG_PATH = $wackLogs
+}
+
+$resultPath = Join-Path $reportDirectoryFullPath "hosted-wack-result.json"
+$startedAt = Get-Date
+try {
+    Set-IsolatedEnvironment -Values $wackEnvironment -Directories @(
+        $wackTemp,
+        $wackLogs,
+        $wackLocalAppData,
+        $wackRoamingAppData,
+        $appVerifierLogs
+    )
+
+    $reset = Invoke-AppCert -Arguments @("reset")
+    Write-CommandLog -Name "appcert reset" -ExitCode $reset.ExitCode -Output $reset.Output
+    if ($reset.ExitCode -ne 0) {
+        throw "WACK の reset に失敗しました（exit=$($reset.ExitCode)）。"
+    }
+
+    $test = Invoke-AppCert -Arguments @(
+        "test",
+        "-appxpackagepath",
+        $packageFullPath,
+        "-reportoutputpath",
+        $reportPath
+    )
+    Write-CommandLog -Name "appcert test" -ExitCode $test.ExitCode -Output $test.Output
+
+    if ($test.ExitCode -eq 1) {
+        if (-not (Test-Path -LiteralPath $reportPath -PathType Leaf)) {
+            throw "WACK が終了コード 1 を返しましたが、最終化対象の XML レポートがありません。"
+        }
+
+        $finalize = Invoke-AppCert -Arguments @(
+            "finalizereport",
+            "-reportfilepath",
+            $reportPath
+        )
+        Write-CommandLog -Name "appcert finalizereport" -ExitCode $finalize.ExitCode -Output $finalize.Output
+        if ($finalize.ExitCode -ne 0) {
+            throw "WACK レポートの最終化に失敗しました（exit=$($finalize.ExitCode)）。"
+        }
+    } elseif ($test.ExitCode -ne 0) {
+        throw "WACK の実行に失敗しました（exit=$($test.ExitCode)）。"
+    }
+
+    if (-not (Test-Path -LiteralPath $reportPath -PathType Leaf)) {
+        throw "WACK の XML レポートが生成されませんでした: $reportPath"
+    }
+
+    $htmlCandidates = @()
+    if (Test-Path -LiteralPath $wackAppCertDirectory -PathType Container) {
+        $htmlCandidates = @(
+            Get-ChildItem -LiteralPath $wackAppCertDirectory -File -Recurse |
+                Where-Object {
+                    @(".htm", ".html") -contains $_.Extension.ToLowerInvariant() -and
+                    ($_.BaseName -eq $reportBaseName -or $_.LastWriteTime -ge $startedAt)
+                }
+        )
+    }
+    $htmlSource = $htmlCandidates |
+        Where-Object { $_.BaseName -eq $reportBaseName } |
+        Select-Object -First 1
+    if ($null -eq $htmlSource) {
+        $htmlSource = $htmlCandidates | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    }
+    if ($null -eq $htmlSource) {
+        throw "WACK XML は生成されましたが、HTML/HTM レポートが見つかりません: $wackAppCertDirectory"
+    }
+
+    $htmlReportPath = Join-Path $reportDirectoryFullPath "$reportBaseName$($htmlSource.Extension)"
+    Copy-Item -LiteralPath $htmlSource.FullName -Destination $htmlReportPath -Force
+
+    $analyzerPath = Join-Path $PSScriptRoot "AnalyzeWackReport.ps1"
+    $pwshPath = Get-PwshExecutable
+    $analysisOutput = @(
+        & $pwshPath -NoProfile -ExecutionPolicy Bypass -File $analyzerPath `
+            -ReportPath $reportPath `
+            -FailOnRequiredFailure `
+            2>&1
+    )
+    $analysisExitCode = $LASTEXITCODE
+    $analysisText = @($analysisOutput | ForEach-Object { $_.ToString() })
+    $analysisLogLines = @(
+        "[$([DateTime]::UtcNow.ToString('O'))] AnalyzeWackReport exit=$analysisExitCode"
+    ) + $analysisText
+    Add-Content -LiteralPath $commandLogPath -Value $analysisLogLines
+    $analysisText | ForEach-Object { Write-Host $_ }
+    if ($analysisExitCode -ne 0) {
+        throw "WACK XML の判定で Required failure またはレポート異常が検出されました（exit=$analysisExitCode）。"
+    }
+
+    $result = [ordered]@{
+        schemaVersion = 1
+        classification = "hosted-candidate"
+        package = $packageName
+        packageSha256 = $packageHash
+        xmlReport = [System.IO.Path]::GetFileName($reportPath)
+        htmlReport = [System.IO.Path]::GetFileName($htmlReportPath)
+        analyzerExitCode = $analysisExitCode
+        completedAtUtc = [DateTime]::UtcNow.ToString("O")
+    }
+    [IO.File]::WriteAllText(
+        $resultPath,
+        ($result | ConvertTo-Json -Depth 6),
+        [Text.UTF8Encoding]::new($false))
+    Write-Host "Hosted runner 上の WACK と Required failure 判定が完了しました。" -ForegroundColor Green
+} catch {
+    $failure = [ordered]@{
+        schemaVersion = 1
+        classification = "wack-failed"
+        package = $packageName
+        packageSha256 = $packageHash
+        error = $_.Exception.Message
+        failedAtUtc = [DateTime]::UtcNow.ToString("O")
+    }
+    [IO.File]::WriteAllText(
+        $resultPath,
+        ($failure | ConvertTo-Json -Depth 6),
+        [Text.UTF8Encoding]::new($false))
+    throw
+} finally {
+    Restore-Environment
+}

--- a/scripts/run-wack-hosted-spike.ps1
+++ b/scripts/run-wack-hosted-spike.ps1
@@ -145,8 +145,8 @@ function Write-CommandLog {
         [string]$Name,
         [Parameter(Mandatory)]
         [int]$ExitCode,
-        [Parameter(Mandatory)]
-        [string[]]$Output
+        [AllowEmptyCollection()]
+        [string[]]$Output = @()
     )
 
     $lines = @(
@@ -196,7 +196,12 @@ $wackEnvironment = @{
 
 $resultPath = Join-Path $reportDirectoryFullPath "hosted-wack-result.json"
 $startedAt = Get-Date
+$wackStage = "not-started"
+$reportGenerated = $false
+$analysisAttempted = $false
+$analysisExitCode = $null
 try {
+    $wackStage = "environment-isolation"
     Set-IsolatedEnvironment -Values $wackEnvironment -Directories @(
         $wackTemp,
         $wackLogs,
@@ -205,12 +210,14 @@ try {
         $appVerifierLogs
     )
 
+    $wackStage = "reset"
     $reset = Invoke-AppCert -Arguments @("reset")
     Write-CommandLog -Name "appcert reset" -ExitCode $reset.ExitCode -Output $reset.Output
     if ($reset.ExitCode -ne 0) {
         throw "WACK の reset に失敗しました（exit=$($reset.ExitCode)）。"
     }
 
+    $wackStage = "test"
     $test = Invoke-AppCert -Arguments @(
         "test",
         "-appxpackagepath",
@@ -241,7 +248,9 @@ try {
     if (-not (Test-Path -LiteralPath $reportPath -PathType Leaf)) {
         throw "WACK の XML レポートが生成されませんでした: $reportPath"
     }
+    $reportGenerated = $true
 
+    $wackStage = "html-report"
     $htmlCandidates = @()
     if (Test-Path -LiteralPath $wackAppCertDirectory -PathType Container) {
         $htmlCandidates = @(
@@ -265,8 +274,10 @@ try {
     $htmlReportPath = Join-Path $reportDirectoryFullPath "$reportBaseName$($htmlSource.Extension)"
     Copy-Item -LiteralPath $htmlSource.FullName -Destination $htmlReportPath -Force
 
+    $wackStage = "analyze"
     $analyzerPath = Join-Path $PSScriptRoot "AnalyzeWackReport.ps1"
     $pwshPath = Get-PwshExecutable
+    $analysisAttempted = $true
     $analysisOutput = @(
         & $pwshPath -NoProfile -ExecutionPolicy Bypass -File $analyzerPath `
             -ReportPath $reportPath `
@@ -292,6 +303,7 @@ try {
         xmlReport = [System.IO.Path]::GetFileName($reportPath)
         htmlReport = [System.IO.Path]::GetFileName($htmlReportPath)
         analyzerExitCode = $analysisExitCode
+        analysisAttempted = $analysisAttempted
         completedAtUtc = [DateTime]::UtcNow.ToString("O")
     }
     [IO.File]::WriteAllText(
@@ -300,11 +312,21 @@ try {
         [Text.UTF8Encoding]::new($false))
     Write-Host "Hosted runner 上の WACK と Required failure 判定が完了しました。" -ForegroundColor Green
 } catch {
+    $reportExists = $reportGenerated -or (Test-Path -LiteralPath $reportPath -PathType Leaf)
+    $failureClassification = if ($analysisAttempted -and $reportExists) {
+        "package-failure"
+    } else {
+        "wack-execution-failed"
+    }
     $failure = [ordered]@{
         schemaVersion = 1
-        classification = "wack-failed"
+        classification = $failureClassification
         package = $packageName
         packageSha256 = $packageHash
+        wackStage = $wackStage
+        reportGenerated = $reportExists
+        analysisAttempted = $analysisAttempted
+        analyzerExitCode = $analysisExitCode
         error = $_.Exception.Message
         failedAtUtc = [DateTime]::UtcNow.ToString("O")
     }

--- a/tasks.md
+++ b/tasks.md
@@ -158,6 +158,7 @@ MSI 配布 (#97) に続く次世代配布方式として MSIX パッケージン
 - [x] 成功済み `release.yml` の同一 `.msix` / `.msixupload` artifact、tag、commit、SHA-256 を照合する。
 - [x] Hosted runner の OS、image、`UserInteractive`、管理者権限、`appcert.exe` の状態を記録する。
 - [x] WACK XML／HTML／TAEF／AppCertKit ログと Required/Optional 判定を artifact として保存する。
+- [x] AppCertKit 導入未検証、WACK 実行失敗、package 判定失敗を別分類し、入力検証の早期失敗でも結果証跡を保存する。
 - [ ] 実行結果に基づき、Hosted 移行または self-hosted 継続を決定する。
 
 ---

--- a/tasks.md
+++ b/tasks.md
@@ -2,12 +2,12 @@
 
 前フェーズ履歴: [docs/archive/tasks-archive-20260501.md](docs/archive/tasks-archive-20260501.md)
 
-## 現在の状態: v0.7.0 リリース準備中
+## 現在の状態: v0.7.2 リリース済み / #284 Hosted WACK Spike 実装中
 
-- 確認日: 2026-05-04
+- 確認日: 2026-08-16
 - 対象リポジトリ: `scottlz0310/cloud-migrator`
 - 確認方法: `gh issue list --state open --limit 200`
-- open issue 数: 7 件（#196 サブISSUE x3 追加）
+- 最新リリース: `v0.7.2`（MSIX/WACK 後の Microsoft Store 自動公開まで成功）
 
 ### 最近の完了（main マージ済み）
 
@@ -20,7 +20,7 @@
 | [#204](https://github.com/scottlz0310/cloud-migrator/pull/204) | [#191](https://github.com/scottlz0310/cloud-migrator/issues/191) | DashboardPage タブバーを MudTabs に戻す・UI 改善 | 2026-05-03 |
 | [#205](https://github.com/scottlz0310/cloud-migrator/pull/205) | [#195](https://github.com/scottlz0310/cloud-migrator/issues/195) | CloudMigrator.Routes プロジェクト新規作成・RouteDescriptor 定義 | 2026-05-04 |
 
-> 次の推奨着手: **[#207](https://github.com/scottlz0310/cloud-migrator/issues/207)** (#196-A) — DashboardPage のフェーズ判定・表示分岐を RouteDescriptor 経由に置換（最小スコープ）
+> 次の推奨着手: **[#284](https://github.com/scottlz0310/cloud-migrator/issues/284)** (#101-G) — GitHub-hosted runner 上で同一 MSIX artifact の WACK 実行可否を検証
 
 ---
 
@@ -32,7 +32,7 @@
 | 2 | [#208](https://github.com/scottlz0310/cloud-migrator/issues/208) | refactor | #196-B: SettingsPage のセクション表示・バリデーション判定を RouteDescriptor.SettingsSections 経由に置換 | #207 の後。IsSharePointRoute/IsDropboxRoute 30箇所以上の置換。中程度の変更量。 |
 | 3 | [#209](https://github.com/scottlz0310/cloud-migrator/issues/209) | refactor | #196-C: App.xaml.cs の移行パイプライン実行ロジックをルート対応ファクトリに切り出す | #207・#208 の後。最大変更。IMigrationPipelineFactory 新設が含まれる。 |
 | 4 | [#15](https://github.com/scottlz0310/cloud-migrator/issues/15) | maintenance | Dependency Dashboard | 機能修正後に CI が安定した状態で依存関係更新を確認する。Renovate 管理のため通常実装とは別レーン。 |
-| 5 | [#101](https://github.com/scottlz0310/cloud-migrator/issues/101) | epic / installer | MSIX パッケージング・Microsoft Store 公開 | サブ ISSUE #264〜#268 起票・再開済み。WACK/ListingData/マニュアル準備と合わせて段階的実行可能。 |
+| 5 | [#284](https://github.com/scottlz0310/cloud-migrator/issues/284) | spike / ci | #101-G: GitHub-hosted runner で WACK を実行し self-hosted runner を廃止できるか検証 | #101 のリリース経路を変更せず、同一 MSIX artifact と Hosted runner の能力を手動検証する。 |
 
 ---
 
@@ -127,8 +127,8 @@ MSI 配布 (#97) に続く次世代配布方式として MSIX パッケージン
 
 ### 前提・状態
 
-- サブ ISSUE 群（#264〜#268）起票・再開済み。
-- MSI 配布 (#97) の運用実績確認と並行して、WACK 検査スクリプト・Listing Data・マニュアルドキュメントの準備を進める。
+- #101 の MSIX パッケージング、WACK、提出アセット、CI、Store 自動公開は完了し、`v0.7.2` のリリースで実環境 E2E を確認済み。
+- #101 はクローズ済み。self-hosted WACK runner の廃止可否は後続の #284 Spike で、本番 gate と分離して検証する。
 
 ### サブ ISSUE（中断再開性の確保）
 
@@ -139,7 +139,8 @@ MSI 配布 (#97) に続く次世代配布方式として MSIX パッケージン
 | [#266](https://github.com/scottlz0310/cloud-migrator/issues/266) | installer / doc | #101-C: Partner Center Store Listing Data・提出アセット・プライバシーポリシーの整備 | ✅ 完了（`docs/assets/store/listingData.csv`、`store/...` 相対パスのフォルダーインポート手順、提出アセット仕様、`docs/privacy-policy.html`） |
 | [#267](https://github.com/scottlz0310/cloud-migrator/issues/267) | doc / installer | #101-D: MSIX パッケージング・WACK 検査・Partner Center 提出マニュアルの作成 | ✅ 完了（MSIX/WACK/Partner Center の手動手順、提出前停止条件、更新・差戻し、インストールスコープ、#268 との CI 境界を `docs/msix-packaging-and-store-guide.md` に集約） |
 | [#268](https://github.com/scottlz0310/cloud-migrator/issues/268) | ci / installer | #101-E: GitHub Actions CI による MSIX ビルドおよびリリースアタッチの自動化 | ✅ 完了（PR/main の MSIX 静的検査、self-hosted WACK workflow、Required/Optional 判定、artifact 保存を追加。runner の登録・管理は環境作業） |
-| [#276](https://github.com/scottlz0310/cloud-migrator/issues/276) | ci / release | #101-F: Partner Center Submission API による Microsoft Store 提出・公開の自動化 | 🚧 実装中（tag push 後に同一 artifact を WACK → Store へ渡す workflow、Environment secret 設定スクリプト、`.env.example` を追加。実環境 secret 設定と初回 tag 実行は未実施） |
+| [#276](https://github.com/scottlz0310/cloud-migrator/issues/276) | ci / release | #101-F: Partner Center Submission API による Microsoft Store 提出・公開の自動化 | ✅ 完了（`v0.7.2` で同一 artifact の WACK → Store submission → 認定・公開完了を確認） |
+| [#284](https://github.com/scottlz0310/cloud-migrator/issues/284) | ci / spike | #101-G: GitHub-hosted runner で WACK を実行し self-hosted runner を廃止できるか検証 | 🚧 実装中（本番 gate と分離した手動 workflow、同一 artifact の SHA-256 照合、Hosted capability と WACK 証跡を追加） |
 
 ### #276 の受け入れ条件
 
@@ -148,11 +149,19 @@ MSI 配布 (#97) に続く次世代配布方式として MSIX パッケージン
 - [x] WACK 成功後だけ Store 公開 job を開始し、`store-production` Environment の secret を使用する。
 - [x] `Configure-StorePublishing.ps1` と `.env.example` を用意し、`.env` を Git 管理対象外にする。
 - [x] `docs/architecture.md` と `docs/msix-packaging-and-store-guide.md` が tag → WACK → Store の現行フローを同じ手順として説明する。
-- [ ] Partner Center 用 Entra ID アプリ、Environment、secret を実環境へ設定する。
-- [ ] 新 Version の tag で WACK、Store submission、認定・公開完了までの E2E を実行し、証跡を記録する。
+- [x] Partner Center 用 Entra ID アプリ、Environment、secret を実環境へ設定する。
+- [x] `v0.7.2` の tag で WACK、Store submission、認定・公開完了までの E2E を実行し、証跡を記録する。
+
+### #284 の受け入れ条件
+
+- [x] 本番の `release.yml`、`wack.yml`、`scripts/run-wack-test.ps1` を変更せず、手動 Spike として分離する。
+- [x] 成功済み `release.yml` の同一 `.msix` / `.msixupload` artifact、tag、commit、SHA-256 を照合する。
+- [x] Hosted runner の OS、image、`UserInteractive`、管理者権限、`appcert.exe` の状態を記録する。
+- [x] WACK XML／HTML／TAEF／AppCertKit ログと Required/Optional 判定を artifact として保存する。
+- [ ] 実行結果に基づき、Hosted 移行または self-hosted 継続を決定する。
 
 ---
 
 ## 次の推奨着手
 
-[#276](https://github.com/scottlz0310/cloud-migrator/issues/276) の実環境設定と初回 tag E2E を完了する。完了後は [#207](https://github.com/scottlz0310/cloud-migrator/issues/207)（#196-A）の DashboardPage 改修へ戻る。
+[#284](https://github.com/scottlz0310/cloud-migrator/issues/284) を手動実行し、Hosted runner 上の WACK 可否を判定する。移行可否の結論後は [#286](https://github.com/scottlz0310/cloud-migrator/issues/286)（MSI 廃止検討）または [#207](https://github.com/scottlz0310/cloud-migrator/issues/207)（#196-A）の優先度を再評価する。


### PR DESCRIPTION
## 概要

Refs #284

GitHub-hosted `windows-latest` 上で、既存のリリース MSIX artifact に対して WACK を実行できるか検証する手動 Spike を追加します。self-hosted runner 廃止の可否を判断するための証跡を収集します。

## 変更内容

- `.github/workflows/wack-hosted-spike.yml` を追加
  - 成功済み `release.yml` run の `msix-release-<run_id>` artifact を取得
  - `.msix` / `.msixupload` の tag、commit、ファイル名、SHA-256 を照合
  - Hosted runner の OS、image、`UserInteractive`、管理者権限、`appcert.exe` の状態を記録
  - Spike 専用 wrapper で WACK、XML/HTML 生成、Required/Optional 判定、証跡保存
- `scripts/run-wack-hosted-spike.ps1` を追加
  - 本番 `run-wack-test.ps1` の guard や UAC 昇格を変更せず、Hosted capability 切り分け用に直接実行
  - TAEF/AppCertKit の作業領域を隔離
- `docs/wack-hosted-runner-spike.md` を追加
- `tasks.md`、`CHANGELOG.md`、`docs/architecture.md` を現行の #284 と整合

## 本番影響

`release.yml`、`wack.yml`、`scripts/run-wack-test.ps1`、Microsoft Store 公開 gate は変更していません。Hosted Spike が成功するまで、現行の self-hosted WACK runner を維持します。

## 検証

- pre-commit: dotnet build / format / restore 成功
- unit tests: 1034 passed
- PowerShell 構文チェック成功
- CRLF、差分境界チェック成功
- `v0.7.2` release run #31944768934 の source 条件確認成功

## 未実施

この PR の workflow 自体は、マージ後に Actions の **WACK Hosted Runner Spike** を `release_run_id=31944768934` で手動実行して確認します。実際の GitHub-hosted runner 上での WACK 実行結果に基づき、#284 を close するか、self-hosted 継続または移行 PR を判断します。