### PR TITLE
[#284] WACK gate を GitHub-hosted Windows runner へ移行

### DIFF
--- a/.github/workflows/wack.yml
+++ b/.github/workflows/wack.yml
@@ -127,10 +127,10 @@ jobs:
           retention-days: 7
 
   wack:
-    name: WACK（self-hosted / Windows / wack）
+    name: WACK（GitHub-hosted / Windows）
     needs: prepare_wack_input
     if: ${{ always() && needs.prepare_wack_input.result == 'success' }}
-    runs-on: [self-hosted, windows, wack]
+    runs-on: windows-latest
     env:
       LEFTHOOK: 0
 
@@ -144,7 +144,7 @@ jobs:
           name: wack-input-${{ github.run_id }}
           path: wack-input
 
-      - name: runner の管理者権限・対話セッションを確認
+      - name: GitHub-hosted runner の管理者権限・対話セッションを確認
         shell: pwsh
         run: |
           if ($env:OS -ne "Windows_NT") {
@@ -156,12 +156,26 @@ jobs:
           $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
           $principal = New-Object Security.Principal.WindowsPrincipal($identity)
           if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
-            throw "WACK runner は管理者権限で実行してください。GitHub-hosted runner の UAC 昇格には依存しません。"
+            throw "WACK runner は管理者権限で実行してください。GitHub-hosted runner の自動 UAC 昇格には依存しません。"
           }
-          $appCertPath = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\App Certification Kit\appcert.exe"
-          if (-not (Test-Path -LiteralPath $appCertPath -PathType Leaf)) {
-            throw "Windows App Certification Kit の appcert.exe が見つかりません: $appCertPath"
+          $appCertCandidates = @()
+          if (-not [string]::IsNullOrWhiteSpace(${env:ProgramFiles(x86)})) {
+            $appCertCandidates += Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\App Certification Kit\appcert.exe"
           }
+          if (-not [string]::IsNullOrWhiteSpace($env:ProgramFiles)) {
+            $appCertCandidates += Join-Path $env:ProgramFiles "Windows Kits\10\App Certification Kit\appcert.exe"
+          }
+          $appCertCommand = Get-Command appcert.exe -ErrorAction SilentlyContinue
+          if ($null -ne $appCertCommand -and -not [string]::IsNullOrWhiteSpace($appCertCommand.Source)) {
+            $appCertCandidates += $appCertCommand.Source
+          }
+          $appCertPath = $appCertCandidates |
+            Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } |
+            Select-Object -First 1
+          if ([string]::IsNullOrWhiteSpace($appCertPath)) {
+            throw "Windows App Certification Kit の appcert.exe が見つかりません。確認候補: $($appCertCandidates -join ', ')"
+          }
+          "AppCertKit: $appCertPath"
 
       - name: WACK を実行
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,14 @@
   - 成功済み `release.yml` の同一 MSIX artifact を取得し、tag、commit、ファイル名、SHA-256 を照合してから `windows-latest` で検証できるようにした
   - Hosted runner の OS、image、対話セッション、管理者権限、`appcert.exe` の状態と、WACK XML／HTML／TAEF／AppCertKit ログを証跡として保存する
   - AppCertKit 導入未検証、WACK 実行失敗、package 判定失敗を分離し、入力検証が早期失敗した場合も Spike 結果を保存する
-  - 本番の `release.yml`、`wack.yml`、Store 公開 gate は変更しない
+  - Spike 自体は本番の `release.yml`、`wack.yml`、Store 公開 gate を変更せず、移行判断に必要な証跡だけを保存する
+
+### Changed
+
+- **本番 WACK gate を GitHub-hosted Windows runner へ移行（#284 / #101-G）**
+  - `wack.yml` の同一 MSIX artifact 検証を `windows-latest` で実行し、AppCertKit、管理者権限、対話セッションの検査を維持する
+  - Hosted Spike #31950498930 の `hosted-candidate` 判定と、v0.7.2 artifact の SHA-256 一致を移行根拠として記録する
+  - self-hosted runner への暗黙 fallback は行わず、Hosted 環境の能力不足は WACK job の失敗として扱う
 
 ### Fixed
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,16 +108,16 @@ MSIX のリリースは `v*` tag push を入口とし、GitHub Release の生成
 v* tag push
   -> release.yml: CLI / Dashboard / MSI / MSIX を生成し GitHub Release へ添付
   -> msix-release-<run_id>: .msix / .msixupload / SHA-256 証跡を保存
-  -> wack.yml (workflow_call): 同じ artifact の .msix を self-hosted WACK runner で検証
+  -> wack.yml (workflow_call): 同じ artifact の .msix を GitHub-hosted Windows runner で検証
   -> store-production: WACK 成功後だけ同じ artifact の .msixupload を Store へ提出・公開
 ```
 
 - `release.yml` は tag と manifest Version、tag commit の main 系列、package の SHA-256 を確認します。
-- リリース経路の `wack.yml` は `workflow_call` で artifact を受け取り、tag 時に MSIX を再ビルドしません。`workflow_dispatch` による個別 WACK は別途維持します。
+- リリース経路の `wack.yml` は `workflow_call` で artifact を受け取り、tag 時に MSIX を再ビルドしません。WACK job は `windows-latest` 上で AppCertKit、管理者権限、対話セッションを確認してから実行します。`workflow_dispatch` による個別 WACK は別途維持します。
 - Store job は `store-production` Environment、`STORE_PRODUCT_ID` variable、Entra ID / Partner Center の Environment secrets を使用します。Environment の deployment policy は `v*` tag に限定し、Product 単位の concurrency で submission を直列化します。
 - Store job は既存 submission の status と package を確認し、同じ package の処理中 submission は poll して再利用します。別 Version の submission は上書きせず停止します。
 - GitHub Release の公開完了は Store 公開完了を意味しません。WACK と Store の job 結果、artifact 証跡、submission status を別々に確認します。
 
 Environment の初期設定と中断・再実行を含む詳細手順は、[MSIX パッケージング・WACK 検査・Microsoft Store 提出ガイド](msix-packaging-and-store-guide.md)の [Store 自動公開と初期設定](msix-packaging-and-store-guide.md#84-store-自動公開と初期設定-276) に集約します。
 
-self-hosted WACK runner を GitHub-hosted runner へ移行できるかは、本番 gate と分離した [GitHub-hosted WACK Spike 手順](wack-hosted-runner-spike.md)で検証します。Spike が成功するまで、リリースフローの WACK runner は self-hosted のままです。
+[GitHub-hosted WACK Spike 手順](wack-hosted-runner-spike.md)の実行（run #31950498930、`hosted-candidate`）により、現行の WACK は GitHub-hosted Windows runner で再現可能と確認済みです。本番の WACK gate も `windows-latest` を使用し、AppCertKit が利用できない場合や権限・対話セッションの検査に失敗した場合は自動的に self-hosted へ切り替えず、job を失敗させます。

--- a/docs/msix-packaging-and-store-guide.md
+++ b/docs/msix-packaging-and-store-guide.md
@@ -375,7 +375,7 @@ Submission options で、次を確認します。
 
 ### 6.3 GitHub Release と Store 自動公開の境界
 
-`.github/workflows/release.yml` は `v*` タグで GitHub Release と CLI/Dashboard、MSI、MSIX (`.msix` / `.msixupload`) のアセットを公開します。続いて同じ MSIX artifact を `wack.yml` の self-hosted WACK に渡し、WACK 成功後にだけ `store-production` Environment の Store 公開 job を開始します。GitHub Release の公開状態と Store の submission／公開状態は別の証跡として記録します。
+`.github/workflows/release.yml` は `v*` タグで GitHub Release と CLI/Dashboard、MSI、MSIX (`.msix` / `.msixupload`) のアセットを公開します。続いて同じ MSIX artifact を `wack.yml` の GitHub-hosted Windows WACK job に渡し、WACK 成功後にだけ `store-production` Environment の Store 公開 job を開始します。GitHub Release の公開状態と Store の submission／公開状態は別の証跡として記録します。
 
 ---
 
@@ -404,7 +404,7 @@ Add-AppxPackage -Path .\installer\msix\AppPackages\CloudMigrator_0.7.2.0_x64.msi
 
 ## 8. CI/CD との責務分離（#268）
 
-[#268](https://github.com/scottlz0310/cloud-migrator/issues/268) では、GitHub-hosted runner での静的検査と、WACK 導入済み self-hosted runner でのフル WACK を分離しています。GitHub-hosted runner の UAC ダイアログには依存しません。
+[#268](https://github.com/scottlz0310/cloud-migrator/issues/268) では、GitHub-hosted runner での静的検査と、WACK 導入済み self-hosted runner でのフル WACK を分離していました。#284 の Hosted Spike（run #31950498930）で `windows-latest` 上のフル WACK が成功したため、現在はフル WACK も GitHub-hosted runner で実行します。GitHub-hosted runner の UAC ダイアログには依存しません。
 
 ### 8.1 PR／main の MSIX 静的検査
 
@@ -417,20 +417,20 @@ Add-AppxPackage -Path .\installer\msix\AppPackages\CloudMigrator_0.7.2.0_x64.msi
 
 生成した `.msix` と `.msixupload` は `msix-ci-<run_id>` artifact に保存されます。MSIX は Windows SDK の `makeappx.exe` で展開して検査します。WACK はこの job では実行しません。
 
-### 8.2 self-hosted runner の準備
+### 8.2 GitHub-hosted WACK runner の前提
 
-WACK 用 runner は、リポジトリの **Settings > Actions > Runners** から追加し、次の条件を満たすラベルを付けます。
+WACK は `windows-latest` の GitHub-hosted runner で実行します。runner の登録、ラベル付け、Windows SDK の手動インストールは不要です。Hosted image の変更で AppCertKit が利用できなくなった場合に暗黙の self-hosted fallback を行わず、能力検査で job を失敗させます。
 
 | 条件 | 要件 |
 | --- | --- |
-| labels | `self-hosted`、`windows`、`wack` |
-| Windows | Windows 10/11 の対話ユーザーセッション |
-| 権限 | runner を起動するユーザーが Administrators グループに所属 |
-| セッション | `Environment.UserInteractive` が true になるアクティブセッション。Windows サービス／Session 0 では実行しない |
-| SDK | Windows SDK と Windows App Certification Kit (`appcert.exe`) |
+| runner | `windows-latest` |
+| Windows | Hosted image の Windows。Spike では `win25-vs2026` / Windows Server 2025 |
+| 権限 | workflow の開始時に Administrators 権限であることを検査 |
+| セッション | `Environment.UserInteractive` が true であることを検査。非対話 Session 0 では実行しない |
+| SDK | Hosted image に Windows App Certification Kit (`appcert.exe`) が存在することを検査 |
 | PowerShell | PowerShell 7 (`pwsh`) |
 
-runner は、GitHub Actions の self-hosted runner をログオン済みユーザーの対話プロセスとして起動します。管理者権限・アクティブセッション・WACK の存在は、WACK job の開始時にも再検査します。runner に保存した資格情報や OAuth token を workflow のログへ出力しません。
+Hosted runner の image、管理者権限、対話セッション、`appcert.exe` の存在は WACK job の開始時に再検査します。runner に資格情報を保存せず、OAuth token も workflow のログへ出力しません。既存 self-hosted runner の停止・登録解除は、移行後のリリース確認後に行う別の環境作業です。
 
 ### 8.3 Full WACK の実行
 
@@ -439,7 +439,7 @@ runner は、GitHub Actions の self-hosted runner をログオン済みユー�
 - `workflow_dispatch`: Actions 画面から対象 branch と manifest Version を選択して実行する
 - `workflow_call`: `release.yml` が生成した MSIX artifact を受け取り、tag push 時の再ビルドを行わずに実行する
 
-手動実行では `windows-latest` で MSIX を生成・静的検査してから artifact に保存します。リリース実行では `release.yml` が生成した artifact（`.msix`、`.msixupload`、SHA-256 証跡 JSON）をそのまま `self-hosted / windows / wack` runner へ渡します。WACK runner は artifact 内の 1 個の `.msix` を `-PackagePath` で明示し、次の既存スクリプトを実行します。
+手動実行では `windows-latest` で MSIX を生成・静的検査してから artifact に保存します。リリース実行では `release.yml` が生成した artifact（`.msix`、`.msixupload`、SHA-256 証跡 JSON）をそのまま `windows-latest` の WACK job へ渡します。WACK job は artifact 内の 1 個の `.msix` を `-PackagePath` で明示し、次の既存スクリプトを実行します。
 
 ~~~powershell
 pwsh -NoProfile -File .\scripts\run-wack-test.ps1 `
@@ -449,14 +449,14 @@ pwsh -NoProfile -File .\scripts\run-wack-test.ps1 `
 
 `run-wack-test.ps1` は WACK の XML/HTML を回収し、`AnalyzeWackReport.ps1 -FailOnRequiredFailure` で判定します。Required failure またはレポート異常は job failure、Optional failure のみの場合は job を成功とし、XML/HTML と WACK ログを `wack-reports-<run_id>` artifact に保存します。Optional failure の審査影響は artifact と [WACK 検証結果](wack-validation-results.md) に記録してください。
 
-WACK の UAC は通常の開発者実機でのみ使用します。CI の WACK runner は開始時点で管理者権限を持つため、UAC ダイアログの表示・自動操作には依存しません。runner の管理者権限または対話セッションが不足する場合は、WACK を開始せず失敗させます。
+WACK の UAC は通常の開発者実機でのみ使用します。CI の GitHub-hosted runner は開始時点で管理者権限を持つことを検査するため、UAC ダイアログの表示・自動操作には依存しません。runner の管理者権限、対話セッション、AppCertKit が不足する場合は、WACK を開始せず失敗させます。
 
 ### 8.4 Store 自動公開と初期設定（#276）
 
 タグ push 後の Store 公開は、次の順序で実行します。
 
 1. `release.yml` が tag と manifest Version を照合し、MSIX／MSIXUPLOAD と SHA-256 証跡を作成する。
-2. GitHub Release に添付したものと同じ artifact を WACK runner へ渡す。
+2. GitHub Release に添付したものと同じ artifact を `windows-latest` の WACK job へ渡す。
 3. WACK が成功した場合だけ `store-production` Environment の job を開始する。
 4. Microsoft Store Developer CLI で Entra ID の client credentials を設定し、`.msixupload` を Product ID `9NG134LB022L` へ送信する。
 5. 既存 submission の status と package 名を確認し、同じ package の処理中 submission は poll して再利用する。別 Version の submission が処理中なら上書きせず停止する。

--- a/docs/wack-hosted-runner-spike.md
+++ b/docs/wack-hosted-runner-spike.md
@@ -6,6 +6,19 @@
 
 本番の `release.yml`、`wack.yml`、`scripts/run-wack-test.ps1` の gate は変更しません。Microsoft Store への提出も行いません。
 
+## 実行結果
+
+2026-08-16 に [WACK Hosted Runner Spike #31950498930](https://github.com/scottlz0310/cloud-migrator/actions/runs/31950498930) を実行しました。
+
+- source release: run #31944768934、tag `v0.7.2`、commit `1c724bcbbd54a75ca0d1d3f99737959423baa953`
+- Hosted image: `win25-vs2026`（Windows Server 2025）
+- AppCertKit: `appcert.exe` を検出し、導入不要。version `10.0.26100.8249`
+- artifact integrity: `.msix` と `.msixupload` のファイル名・SHA-256 が source artifact と一致
+- WACK: XML／HTML レポート生成、Required failure なし、解析 exit code 0
+- classification: `hosted-candidate`
+
+この結果に基づき、本番 `wack.yml` の WACK job を別の移行PRで `windows-latest` へ変更します。既存の self-hosted runner の停止・登録解除は、移行後のリリース成功確認を終えてから行う環境作業です。
+
 ## 実行手順
 
 1. GitHub Actions の **WACK Hosted Runner Spike** を開く。
@@ -20,7 +33,7 @@
 
 | workflow 結果 | 判定 |
 |---|---|
-| 成功（`hosted-candidate`） | Hosted 移行候補。別 PR で本番 workflow と運用手順を変更する |
+| 成功（`hosted-candidate`） | Hosted 移行可。本番 workflow と運用手順を別 PR で変更する |
 | 失敗・`appcert-setup-unverified` | Hosted runner に Kit がなく、再現可能な導入を試していないため判定保留 |
 | 失敗・`capability-recording-failed` | Hosted runner の能力記録に失敗したため判定保留 |
 | 失敗・`package-failure` | WACK レポート生成後の package 判定失敗。Hosted runner 能力不足とは分離して package を調査 |

--- a/tasks.md
+++ b/tasks.md
@@ -2,7 +2,7 @@
 
 前フェーズ履歴: [docs/archive/tasks-archive-20260501.md](docs/archive/tasks-archive-20260501.md)
 
-## 現在の状態: v0.7.2 リリース済み / #284 Hosted WACK Spike 実装中
+## 現在の状態: v0.7.2 リリース済み / #284 Hosted WACK 移行PR 作成中
 
 - 確認日: 2026-08-16
 - 対象リポジトリ: `scottlz0310/cloud-migrator`
@@ -20,7 +20,7 @@
 | [#204](https://github.com/scottlz0310/cloud-migrator/pull/204) | [#191](https://github.com/scottlz0310/cloud-migrator/issues/191) | DashboardPage タブバーを MudTabs に戻す・UI 改善 | 2026-05-03 |
 | [#205](https://github.com/scottlz0310/cloud-migrator/pull/205) | [#195](https://github.com/scottlz0310/cloud-migrator/issues/195) | CloudMigrator.Routes プロジェクト新規作成・RouteDescriptor 定義 | 2026-05-04 |
 
-> 次の推奨着手: **[#284](https://github.com/scottlz0310/cloud-migrator/issues/284)** (#101-G) — GitHub-hosted runner 上で同一 MSIX artifact の WACK 実行可否を検証
+> 次の推奨着手: **[#284](https://github.com/scottlz0310/cloud-migrator/issues/284)** (#101-G) — Spike 結果に基づく GitHub-hosted WACK gate への移行
 
 ---
 
@@ -32,7 +32,7 @@
 | 2 | [#208](https://github.com/scottlz0310/cloud-migrator/issues/208) | refactor | #196-B: SettingsPage のセクション表示・バリデーション判定を RouteDescriptor.SettingsSections 経由に置換 | #207 の後。IsSharePointRoute/IsDropboxRoute 30箇所以上の置換。中程度の変更量。 |
 | 3 | [#209](https://github.com/scottlz0310/cloud-migrator/issues/209) | refactor | #196-C: App.xaml.cs の移行パイプライン実行ロジックをルート対応ファクトリに切り出す | #207・#208 の後。最大変更。IMigrationPipelineFactory 新設が含まれる。 |
 | 4 | [#15](https://github.com/scottlz0310/cloud-migrator/issues/15) | maintenance | Dependency Dashboard | 機能修正後に CI が安定した状態で依存関係更新を確認する。Renovate 管理のため通常実装とは別レーン。 |
-| 5 | [#284](https://github.com/scottlz0310/cloud-migrator/issues/284) | spike / ci | #101-G: GitHub-hosted runner で WACK を実行し self-hosted runner を廃止できるか検証 | #101 のリリース経路を変更せず、同一 MSIX artifact と Hosted runner の能力を手動検証する。 |
+| 5 | [#284](https://github.com/scottlz0310/cloud-migrator/issues/284) | ci / migration | #101-G: GitHub-hosted runner で WACK を実行し self-hosted runner を廃止できるか検証 | Spike 成功を受け、同一 MSIX artifact を GitHub-hosted WACK gate へ移行する。 |
 
 ---
 
@@ -128,7 +128,7 @@ MSI 配布 (#97) に続く次世代配布方式として MSIX パッケージン
 ### 前提・状態
 
 - #101 の MSIX パッケージング、WACK、提出アセット、CI、Store 自動公開は完了し、`v0.7.2` のリリースで実環境 E2E を確認済み。
-- #101 はクローズ済み。self-hosted WACK runner の廃止可否は後続の #284 Spike で、本番 gate と分離して検証する。
+- #101 はクローズ済み。#284 の Spike で Hosted runner 上の WACK 成功を確認し、本番 gate の Hosted 移行を進める。
 
 ### サブ ISSUE（中断再開性の確保）
 
@@ -140,7 +140,7 @@ MSI 配布 (#97) に続く次世代配布方式として MSIX パッケージン
 | [#267](https://github.com/scottlz0310/cloud-migrator/issues/267) | doc / installer | #101-D: MSIX パッケージング・WACK 検査・Partner Center 提出マニュアルの作成 | ✅ 完了（MSIX/WACK/Partner Center の手動手順、提出前停止条件、更新・差戻し、インストールスコープ、#268 との CI 境界を `docs/msix-packaging-and-store-guide.md` に集約） |
 | [#268](https://github.com/scottlz0310/cloud-migrator/issues/268) | ci / installer | #101-E: GitHub Actions CI による MSIX ビルドおよびリリースアタッチの自動化 | ✅ 完了（PR/main の MSIX 静的検査、self-hosted WACK workflow、Required/Optional 判定、artifact 保存を追加。runner の登録・管理は環境作業） |
 | [#276](https://github.com/scottlz0310/cloud-migrator/issues/276) | ci / release | #101-F: Partner Center Submission API による Microsoft Store 提出・公開の自動化 | ✅ 完了（`v0.7.2` で同一 artifact の WACK → Store submission → 認定・公開完了を確認） |
-| [#284](https://github.com/scottlz0310/cloud-migrator/issues/284) | ci / spike | #101-G: GitHub-hosted runner で WACK を実行し self-hosted runner を廃止できるか検証 | 🚧 実装中（本番 gate と分離した手動 workflow、同一 artifact の SHA-256 照合、Hosted capability と WACK 証跡を追加） |
+| [#284](https://github.com/scottlz0310/cloud-migrator/issues/284) | ci / migration | #101-G: GitHub-hosted runner で WACK を実行し self-hosted runner を廃止できるか検証 | 🚧 移行PR作成中（Spike #31950498930 の `hosted-candidate` を受け、`wack.yml` と運用手順を Hosted 前提へ更新） |
 
 ### #276 の受け入れ条件
 
@@ -159,10 +159,10 @@ MSI 配布 (#97) に続く次世代配布方式として MSIX パッケージン
 - [x] Hosted runner の OS、image、`UserInteractive`、管理者権限、`appcert.exe` の状態を記録する。
 - [x] WACK XML／HTML／TAEF／AppCertKit ログと Required/Optional 判定を artifact として保存する。
 - [x] AppCertKit 導入未検証、WACK 実行失敗、package 判定失敗を別分類し、入力検証の早期失敗でも結果証跡を保存する。
-- [ ] 実行結果に基づき、Hosted 移行または self-hosted 継続を決定する。
+- [x] 実行結果（run #31950498930、`hosted-candidate`）に基づき、Hosted 移行を決定する。
 
 ---
 
 ## 次の推奨着手
 
-[#284](https://github.com/scottlz0310/cloud-migrator/issues/284) を手動実行し、Hosted runner 上の WACK 可否を判定する。移行可否の結論後は [#286](https://github.com/scottlz0310/cloud-migrator/issues/286)（MSI 廃止検討）または [#207](https://github.com/scottlz0310/cloud-migrator/issues/207)（#196-A）の優先度を再評価する。
+[#284](https://github.com/scottlz0310/cloud-migrator/issues/284) の Hosted 移行PRをレビュー・マージし、リリース経路での WACK 成功を確認する。確認後は既存 self-hosted runner の停止・登録解除を手動で行い、[#286](https://github.com/scottlz0310/cloud-migrator/issues/286)（MSI 廃止検討）または [#207](https://github.com/scottlz0310/cloud-migrator/issues/207)（#196-A）の優先度を再評価する。


### PR DESCRIPTION
## 概要

#284 の Hosted WACK Spike 成功を受け、本番の WACK gate を self-hosted runner から GitHub-hosted Windows runner へ移行します。

## 変更内容

- `.github/workflows/wack.yml` の WACK job を `windows-latest` へ変更
- 同一 MSIX artifact の搬送、AppCertKit・管理者権限・対話セッションの検査、既存の Required/Optional 判定を維持
- AppCertKit の x86／x64 既定パスと `PATH` を検査対象にして Hosted image の差異に対応
- リリースフロー、WACK Spike の実行結果、MSIX 運用ガイド、tasks、CHANGELOG を現行フローへ更新

## 移行根拠

[Hosted WACK Spike #31950498930](https://github.com/scottlz0310/cloud-migrator/actions/runs/31950498930) で、source release run #31944768934 の `v0.7.2` artifact を `windows-latest` 上で検証しました。

- AppCertKit 導入不要
- WACK XML／HTML レポート生成
- Required failure なし
- MSIX／`.msixupload` の SHA-256 が source artifact と一致
- classification: `hosted-candidate`

## 検証

- PowerShell 4本の構文解析: 成功
- `git diff --check`: 成功
- pre-commit: `dotnet-build`、`dotnet-format`、`dotnet-restore`、unit test 1034件が成功

## 運用境界

- `release.yml` は引き続き同じ MSIX artifact を WACK へ渡し、tag 時の再ビルドは行いません。
- Hosted 環境の能力不足時に self-hosted へ暗黙 fallback は行わず、WACK job を失敗させます。
- 既存 self-hosted runner の停止・登録解除は、移行後のリリース成功確認後に行う別の環境作業です。
- #284 は移行後のリリース経路確認まで自動クローズしないよう、PR本文では close キーワードを使用していません。

関連: #284